### PR TITLE
Fix TDT beam search timestamp alignment

### DIFF
--- a/nemo/collections/asr/parts/submodules/rnnt_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_decoding.py
@@ -1106,7 +1106,7 @@ class AbstractRNNTDecoding(ConfidenceMixin):
 
         Returns:
             List[Dict[str, Union[str, int]]]: A list of dictionaries, where each dictionary contains:
-                - "char": List[str] - The character/subword token
+                - "char": List[int] - The character/subword token ID
                 - "start_offset": int - The start time index of the token
                 - "end_offset": int - The end time index of the token
 
@@ -1127,32 +1127,78 @@ class AbstractRNNTDecoding(ConfidenceMixin):
     @staticmethod
     def _compute_offsets_tdt(hypothesis: Hypothesis, blank_id: int, *args) -> List[Dict[str, Union[str, int]]]:
         """
-        Utility method that calculates the indidual time indices where a token starts and ends.
+        Utility method that calculates the individual time indices where a token starts and ends for TDT models.
+
+        This method handles both START and END timestamp semantics. Beam search in TDT stores END timestamps
+        (timesteps + duration), while greedy decoding stores START timestamps. The method uses an explicit
+        _timestamp_semantics flag or a fallback heuristic to determine the correct interpretation.
 
         Args:
-            hypothesis: A Hypothesis object that contains `text` field that holds the character / subword token
-                emitted at a specific time step considering predicted durations of the previous tokens.
+            hypothesis: A Hypothesis object that contains `timestamp` and `token_duration` fields.
+            blank_id: The index representing the blank token in the vocabulary.
+            *args: Additional arguments (unused, for compatibility).
 
         Returns:
             List[Dict[str, Union[str, int]]]: A list of dictionaries, where each dictionary contains:
-                - "char": List[str] - The character/subword token
+                - "char": List[int] - The character/subword token ID
                 - "start_offset": int - The start time index of the token
                 - "end_offset": int - The end time index of the token
 
         **Note**: Blank tokens are not included in the offsets.
         """
-        if isinstance(hypothesis.timestamp, torch.Tensor):
-            hypothesis.token_duration = hypothesis.token_duration.cpu().tolist()
+        # Handle missing token_duration (compute from timestamp diffs)
+        if hypothesis.token_duration is None:
+            if hypothesis.timestamp is None or len(hypothesis.timestamp) == 0:
+                return []
+            if isinstance(hypothesis.timestamp, torch.Tensor):
+                timestamps = hypothesis.timestamp.cpu().tolist()
+            else:
+                timestamps = list(hypothesis.timestamp)
+            durations = []
+            prev = 0
+            for curr in timestamps:
+                durations.append(max(0, curr - prev))
+                prev = curr
+            hypothesis.token_duration = durations
 
+        # Convert to lists
         if isinstance(hypothesis.timestamp, torch.Tensor):
             hypothesis.timestamp = hypothesis.timestamp.cpu().tolist()
+        if isinstance(hypothesis.token_duration, torch.Tensor):
+            hypothesis.token_duration = hypothesis.token_duration.cpu().tolist()
 
-        # Merge the results per token into a list of dictionaries
-        offsets = [
-            {"char": [t], "start_offset": s, "end_offset": s + d}
-            for t, s, d in zip(hypothesis.y_sequence, hypothesis.timestamp, hypothesis.token_duration)
-            if t != blank_id
-        ]
+        # Determine timestamp semantics
+        semantics_flag = getattr(hypothesis, "_timestamp_semantics", None)
+        if semantics_flag == "end":
+            timestamps_are_ends = True
+        elif semantics_flag == "start":
+            timestamps_are_ends = False
+        else:
+            # Fallback heuristic: END timestamps never precede cumulative duration
+            timestamps_are_ends = False
+            if len(hypothesis.timestamp) > 0 and len(hypothesis.token_duration) > 0:
+                cumulative = 0
+                matches_end_semantics = True
+                for ts, dur in zip(hypothesis.timestamp, hypothesis.token_duration):
+                    cumulative += dur
+                    if ts + 1 < cumulative:  # 1-frame slack
+                        matches_end_semantics = False
+                        break
+                if matches_end_semantics and hypothesis.timestamp[0] >= hypothesis.token_duration[0]:
+                    timestamps_are_ends = True
+
+        # Compute offsets
+        offsets = []
+        for t, ts, d in zip(hypothesis.y_sequence, hypothesis.timestamp, hypothesis.token_duration):
+            if t == blank_id:
+                continue
+            if timestamps_are_ends:
+                start_offset = ts - d
+                end_offset = ts
+            else:
+                start_offset = ts
+                end_offset = ts + d
+            offsets.append({"char": [t], "start_offset": start_offset, "end_offset": end_offset})
         return offsets
 
     @staticmethod

--- a/nemo/collections/asr/parts/utils/batched_beam_decoding_utils.py
+++ b/nemo/collections/asr/parts/utils/batched_beam_decoding_utils.py
@@ -171,6 +171,13 @@ class BatchedBeamHyps:
             self.next_timestamp = torch.zeros((batch_size, self.beam_size), device=device, dtype=torch.long)
             self.last_timestamp_lasts = torch.zeros((batch_size, self.beam_size), device=device, dtype=torch.long)
 
+            # For TDT models, also store token durations to enable correct timestamp offset computation
+            # Beam search stores END timestamps (timesteps + duration), but offset computation expects START
+            if self.model_type == ASRModelTypeEnum.TDT:
+                self.token_durations = torch.zeros(
+                    (batch_size, self.beam_size, self._max_length), device=device, dtype=torch.long
+                )
+
     def clear_(self):
         """
         Clears and resets the internal state of the object.
@@ -199,6 +206,9 @@ class BatchedBeamHyps:
             self.next_timestamp.fill_(0)
             self.last_timestamp_lasts.fill_(0)
 
+        if self.model_type == ASRModelTypeEnum.TDT:
+            self.token_durations.fill_(0)
+
     def _allocate_more(self):
         """
         Dynamically allocates more memory for the internal buffers.
@@ -215,6 +225,11 @@ class BatchedBeamHyps:
             self.timestamps = self._create_timestamps_tensor(2 * self._max_length)
         else:
             self.timestamps = torch.cat((self.timestamps, torch.zeros_like(self.timestamps)), dim=-1)
+
+        if self.model_type == ASRModelTypeEnum.TDT:
+            self.token_durations = torch.cat(
+                (self.token_durations, torch.zeros_like(self.token_durations)), dim=-1
+            )
 
         self._max_length *= 2
 
@@ -300,6 +315,13 @@ class BatchedBeamHyps:
                 dim=-1,
                 index=self.current_lengths_wb.unsqueeze(-1),
                 src=(timesteps + next_label_durations).unsqueeze(-1),
+            )
+            # Also store token durations for TDT (needed for correct offset computation)
+            durations_to_store = torch.where(is_extended, next_label_durations, 0)
+            self.token_durations.scatter_(
+                dim=-1,
+                index=self.current_lengths_wb.unsqueeze(-1),
+                src=durations_to_store.unsqueeze(-1),
             )
             torch.where(is_extended, timesteps + next_label_durations, timesteps, out=self.next_timestamp)
             torch.where(
@@ -474,19 +496,28 @@ class BatchedBeamHyps:
         max_idx = self.current_lengths_wb.max() - 1
         timestamps = self.timestamps[..., 0, : max_idx + 1]
         transcripts = self.transcript_wb[..., 0, : max_idx + 1]
-        hypotheses = [
-            Hypothesis(
+
+        if self.model_type == ASRModelTypeEnum.TDT:
+            token_durations = self.token_durations[..., 0, : max_idx + 1]
+
+        hypotheses = []
+        for batch_idx in range(self.batch_size):
+            mask = self._create_transcripts_mask(transcripts[batch_idx])
+            hyp = Hypothesis(
                 score=scores[batch_idx],
-                y_sequence=transcripts[batch_idx][mask := self._create_transcripts_mask(transcripts[batch_idx])]
-                .cpu()
-                .detach()
-                .numpy(),
+                y_sequence=transcripts[batch_idx][mask].cpu().detach().numpy(),
                 timestamp=timestamps[batch_idx][mask].cpu().detach().numpy(),
                 alignments=None,
                 dec_state=None,
             )
-            for batch_idx in range(self.batch_size)
-        ]
+
+            # Populate token_duration and mark semantics for TDT
+            if self.model_type == ASRModelTypeEnum.TDT:
+                hyp.token_duration = token_durations[batch_idx][mask].cpu().detach().numpy().tolist()
+                hyp._timestamp_semantics = "end"  # Explicit marker
+
+            hypotheses.append(hyp)
+
         return hypotheses
 
     def to_nbest_hyps_list(self, score_norm: bool = True) -> list[NBestHypotheses]:
@@ -506,27 +537,33 @@ class BatchedBeamHyps:
         max_idx = self.current_lengths_wb.max() - 1
         transcripts = self.transcript_wb[..., : max_idx + 1]
         timestamps = self.timestamps[..., : max_idx + 1]
-        hypotheses = [
-            NBestHypotheses(
-                [
-                    Hypothesis(
+
+        if self.model_type == ASRModelTypeEnum.TDT:
+            token_durations = self.token_durations[..., : max_idx + 1]
+
+        hypotheses = []
+        for batch_idx in range(self.batch_size):
+            batch_hyps = []
+            for beam_idx in range(self.beam_size):
+                if scores[batch_idx][beam_idx] > INACTIVE_SCORE:
+                    mask = self._create_transcripts_mask(transcripts[batch_idx][beam_idx])
+                    hyp = Hypothesis(
                         score=scores[batch_idx][beam_idx],
-                        y_sequence=transcripts[batch_idx][beam_idx][
-                            mask := self._create_transcripts_mask(transcripts[batch_idx][beam_idx])
-                        ]
-                        .cpu()
-                        .detach()
-                        .numpy(),
+                        y_sequence=transcripts[batch_idx][beam_idx][mask].cpu().detach().numpy(),
                         timestamp=timestamps[batch_idx][beam_idx][mask].cpu().detach().numpy(),
                         alignments=None,
                         dec_state=None,
                     )
-                    for beam_idx in range(self.beam_size)
-                    if scores[batch_idx][beam_idx] > INACTIVE_SCORE
-                ]
-            )
-            for batch_idx in range(self.batch_size)
-        ]
+
+                    # Populate token_duration and mark semantics for TDT
+                    if self.model_type == ASRModelTypeEnum.TDT:
+                        hyp.token_duration = token_durations[batch_idx][beam_idx][mask].cpu().detach().numpy().tolist()
+                        hyp._timestamp_semantics = "end"  # Explicit marker
+
+                    batch_hyps.append(hyp)
+
+            hypotheses.append(NBestHypotheses(batch_hyps))
+
         return hypotheses
 
     def flatten_sort_(self, score_norm: bool = True):
@@ -551,6 +588,17 @@ class BatchedBeamHyps:
 
         max_idx = self.current_lengths_wb.max() - 1
         ptrs = indices
+
+        # Sort token_durations BEFORE updating ptrs to avoid misalignment
+        if self.model_type == ASRModelTypeEnum.TDT:
+            token_durations_sorted = torch.zeros_like(self.token_durations)
+            temp_ptrs = indices
+            for idx in range(max_idx, -1, -1):
+                token_durations_sorted[..., idx].copy_(
+                    self.token_durations[self.batch_indices.unsqueeze(-1), temp_ptrs, idx]
+                )
+                temp_ptrs = self.transcript_wb_prev_ptr[self.batch_indices.unsqueeze(-1), temp_ptrs, idx]
+            self.token_durations.copy_(token_durations_sorted)
 
         for idx in range(max_idx, -1, -1):
             self.transcript_wb[..., idx].copy_(self.transcript_wb[self.batch_indices.unsqueeze(-1), ptrs, idx])

--- a/nemo/collections/asr/parts/utils/batched_beam_decoding_utils.py
+++ b/nemo/collections/asr/parts/utils/batched_beam_decoding_utils.py
@@ -227,9 +227,7 @@ class BatchedBeamHyps:
             self.timestamps = torch.cat((self.timestamps, torch.zeros_like(self.timestamps)), dim=-1)
 
         if self.model_type == ASRModelTypeEnum.TDT:
-            self.token_durations = torch.cat(
-                (self.token_durations, torch.zeros_like(self.token_durations)), dim=-1
-            )
+            self.token_durations = torch.cat((self.token_durations, torch.zeros_like(self.token_durations)), dim=-1)
 
         self._max_length *= 2
 


### PR DESCRIPTION
# What does this PR do ?

Fixes two TDT beam search timestamp issues:
1. **Crash** when using beam search with `timestamps=True` (NoneType iteration error)
2. **~160ms offset** in timestamps between beam search and greedy decoding

**Collection**: ASR

# Changelog

- Store `token_durations` in `BatchedBeamHyps` for TDT models during beam search
- Mark timestamp semantics with `_timestamp_semantics` flag on `Hypothesis` objects
- Update `_compute_offsets_tdt` to handle both START and END timestamp semantics
- Add backward compatibility for computing durations from timestamp differences
- Fix docstring: corrected `"char"` field documentation from `List[str]` to `List[int]` (pre-existing bug: `y_sequence` contains integer token IDs, not strings)

# Problem

## Issue 1: Crash with beam search + timestamps

When using TDT beam search with `timestamps=True`, the code crashes with:
```
TypeError: 'NoneType' object is not iterable
  at nemo/collections/asr/parts/submodules/rnnt_decoding.py:1153 in _compute_offsets_tdt
```

**Root cause:** Beam search (`BatchedBeamHyps`) doesn't populate the `token_duration` field that `_compute_offsets_tdt` requires.

## Issue 2: ~160ms timestamp offset

After fixing the crash (by computing durations from timestamp diffs), beam search timestamps are still ~160ms late compared to greedy. This occurs because:
1. Beam search stores **END timestamps**: `timestamp = timesteps + duration`
2. Greedy stores **START timestamps**: `timestamp = timesteps`
3. `_compute_offsets_tdt` assumed all timestamps were START times
4. Result: beam search offsets included leading blank frames (~160ms = 4 frames @ 40ms/frame)

# Solution

**Three-part approach:**
1. **Store token durations** in `BatchedBeamHyps` (already receiving them during beam search, now stored)
2. **Mark timestamp semantics** with `_timestamp_semantics` attribute on `Hypothesis` objects
   - Beam search: `"end"` (timestamps are END times)
   - Greedy: `"start"` (timestamps are START times)
3. **Compute correct offsets** in `_compute_offsets_tdt` based on semantics:
   - END semantics: `start_offset = timestamp - duration, end_offset = timestamp`
   - START semantics: `start_offset = timestamp, end_offset = timestamp + duration`
   - Fallback heuristic when flag missing (backward compatibility)

# Usage

No API changes. The fix is transparent to users:

```python
import nemo.collections.asr as nemo_asr
from omegaconf import OmegaConf

# Load TDT model
model = nemo_asr.models.ASRModel.from_pretrained("nvidia/parakeet-tdt-0.6b-v3")

# Configure beam search (e.g., for GPU phrase boosting)
decoding_cfg = OmegaConf.to_container(model.cfg.decoding, resolve=True)
decoding_cfg["strategy"] = "beam"
decoding_cfg["beam"]["beam_size"] = 4
decoding_cfg["beam"]["return_best_hypothesis"] = True
model.change_decoding_strategy(OmegaConf.create(decoding_cfg))

# Timestamps now work correctly with beam search (no crash, no 160ms offset)
result = model.transcribe(["audio.wav"], timestamps=True)
```

# Impact

- **Enables GPU phrase boosting with timestamps** (Issue 1: previously crashed)
- **Eliminates ~160ms timestamp offset** (Issue 2: beam search word-level timestamps now align with greedy)
- **Zero performance penalty** (durations computed during beam search anyway)
- **Backward compatible** (computes durations from diffs if missing)

# GitHub Actions CI

Ready for CI. Please add "Run CICD" label.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests? (Can add if requested by reviewers)
- [x] Did you add or update any necessary documentation? (Updated docstrings)
- [x] Does the PR affect components that are optional to install? No

**PR Type**:

- [x] Bugfix

## Who can review?
@andrusenkoau 
Per [contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md), requesting review from ASR team:
- @titu1994
- @redoctopus
- @jbalam-nv
- @okuchaiev