### PR TITLE
enable streaming input of multiple audio streams in cacheawarestreamingaudiobuffer

### DIFF
--- a/nemo/collections/asr/parts/utils/streaming_utils.py
+++ b/nemo/collections/asr/parts/utils/streaming_utils.py
@@ -1592,11 +1592,164 @@ class CacheAwareStreamingAudioBuffer:
         else:
             self.sampling_frames = None
 
-    def __iter__(self):
-        while True:
-            if self.buffer_idx >= self.buffer.size(-1):
-                return
+    def get_next_chunk(self):
+        """
+        Get the next audio chunk for streaming processing.
 
+        This method can be called repeatedly after appending audio via append_audio()
+        to process the audio in a streaming fashion.
+
+        Returns:
+            tuple: (audio_chunk, chunk_lengths) if there's data to process, None if buffer is exhausted
+                - audio_chunk: tensor containing the audio chunk with pre-encode cache prepended
+                - chunk_lengths: tensor containing the valid lengths for each stream in the batch
+        """
+        if self.buffer is None or self.buffer_idx >= self.buffer.size(-1):
+            return None
+
+        # Determine chunk size based on position (first chunk may be different)
+        if self.buffer_idx == 0 and isinstance(self.streaming_cfg.chunk_size, list):
+            if self.pad_and_drop_preencoded:
+                chunk_size = self.streaming_cfg.chunk_size[1]
+            else:
+                chunk_size = self.streaming_cfg.chunk_size[0]
+        else:
+            chunk_size = (
+                self.streaming_cfg.chunk_size[1]
+                if isinstance(self.streaming_cfg.chunk_size, list)
+                else self.streaming_cfg.chunk_size
+            )
+
+        # Determine shift size based on position (first chunk may be different)
+        if self.buffer_idx == 0 and isinstance(self.streaming_cfg.shift_size, list):
+            if self.pad_and_drop_preencoded:
+                shift_size = self.streaming_cfg.shift_size[1]
+            else:
+                shift_size = self.streaming_cfg.shift_size[0]
+        else:
+            shift_size = (
+                self.streaming_cfg.shift_size[1]
+                if isinstance(self.streaming_cfg.shift_size, list)
+                else self.streaming_cfg.shift_size
+            )
+
+        # Extract the current audio chunk
+        audio_chunk = self.buffer[:, :, self.buffer_idx : self.buffer_idx + chunk_size]
+
+        # For single-stream streaming: wait if not enough data accumulated yet
+        # For multi-stream batches: rely on chunk_lengths to mask invalid streams
+        if len(self.streams_length) == 1:
+            available_valid_frames = self.streams_length[0] - self.buffer_idx
+            if available_valid_frames < chunk_size:
+                # Not enough data accumulated yet, wait for more audio
+                return None
+
+        # Check if we have enough frames for downsampling (if applicable)
+        if self.sampling_frames is not None:
+            if self.buffer_idx == 0 and isinstance(self.sampling_frames, list):
+                cur_sampling_frames = self.sampling_frames[0]
+            else:
+                cur_sampling_frames = (
+                    self.sampling_frames[1] if isinstance(self.sampling_frames, list) else self.sampling_frames
+                )
+            if audio_chunk.size(-1) < cur_sampling_frames:
+                return None
+
+        # Add the pre-encode cache to the chunk
+        zeros_pads = None
+        if self.buffer_idx == 0 and isinstance(self.streaming_cfg.pre_encode_cache_size, list):
+            if self.pad_and_drop_preencoded:
+                cache_pre_encode_num_frames = self.streaming_cfg.pre_encode_cache_size[1]
+            else:
+                cache_pre_encode_num_frames = self.streaming_cfg.pre_encode_cache_size[0]
+            cache_pre_encode = torch.zeros(
+                (audio_chunk.size(0), self.input_features, cache_pre_encode_num_frames),
+                device=audio_chunk.device,
+                dtype=audio_chunk.dtype,
+            )
+        else:
+            if isinstance(self.streaming_cfg.pre_encode_cache_size, list):
+                pre_encode_cache_size = self.streaming_cfg.pre_encode_cache_size[1]
+            else:
+                pre_encode_cache_size = self.streaming_cfg.pre_encode_cache_size
+
+            start_pre_encode_cache = self.buffer_idx - pre_encode_cache_size
+            if start_pre_encode_cache < 0:
+                start_pre_encode_cache = 0
+            cache_pre_encode = self.buffer[:, :, start_pre_encode_cache : self.buffer_idx]
+            if cache_pre_encode.size(-1) < pre_encode_cache_size:
+                zeros_pads = torch.zeros(
+                    (
+                        audio_chunk.size(0),
+                        audio_chunk.size(-2),
+                        pre_encode_cache_size - cache_pre_encode.size(-1),
+                    ),
+                    device=audio_chunk.device,
+                    dtype=audio_chunk.dtype,
+                )
+
+        added_len = cache_pre_encode.size(-1)
+        audio_chunk = torch.cat((cache_pre_encode, audio_chunk), dim=-1)
+
+        # Apply online normalization if enabled
+        if self.online_normalization:
+            audio_chunk, x_mean, x_std = normalize_batch(
+                x=audio_chunk,
+                seq_len=torch.tensor([audio_chunk.size(-1)] * audio_chunk.size(0)),
+                normalize_type=self.model_normalize_type,
+            )
+
+        # Add zero padding if needed
+        if zeros_pads is not None:
+            audio_chunk = torch.cat((zeros_pads, audio_chunk), dim=-1)
+            added_len += zeros_pads.size(-1)
+
+        # Calculate valid chunk lengths for each stream
+        max_chunk_lengths = self.streams_length - self.buffer_idx
+        max_chunk_lengths = max_chunk_lengths + added_len
+        chunk_lengths = torch.clamp(max_chunk_lengths, min=0, max=audio_chunk.size(-1))
+
+        # Update buffer position and step counter
+        self.buffer_idx += shift_size
+        self.step += 1
+
+        return audio_chunk, chunk_lengths
+
+    def __iter__(self):
+        """
+        Iterator interface for batch processing.
+        Yields chunks by repeatedly calling get_next_chunk().
+        """
+        while True:
+            result = self.get_next_chunk()
+            if result is None:
+                return
+            yield result
+
+    def is_buffer_empty(self):
+        if self.buffer_idx >= self.buffer.size(-1):
+            return True
+        else:
+            return False
+
+    def has_next_chunk(self):
+        """
+        Check if there are more chunks available to process.
+
+        Returns:
+            bool: True if get_next_chunk() will return data, False otherwise
+        """
+        if self.buffer is None or self.streams_length is None:
+            return False
+
+        # Check if we've processed past the buffer
+        if self.buffer_idx >= self.buffer.size(-1):
+            return False
+
+        # For single-stream: check if enough data accumulated
+        # For multi-stream batches: always return True and let chunk_lengths handle validity
+        if len(self.streams_length) == 1:
+            # Determine the required chunk size for the next chunk
             if self.buffer_idx == 0 and isinstance(self.streaming_cfg.chunk_size, list):
                 if self.pad_and_drop_preencoded:
                     chunk_size = self.streaming_cfg.chunk_size[1]
@@ -1609,94 +1762,12 @@ class CacheAwareStreamingAudioBuffer:
                     else self.streaming_cfg.chunk_size
                 )
 
-            if self.buffer_idx == 0 and isinstance(self.streaming_cfg.shift_size, list):
-                if self.pad_and_drop_preencoded:
-                    shift_size = self.streaming_cfg.shift_size[1]
-                else:
-                    shift_size = self.streaming_cfg.shift_size[0]
-            else:
-                shift_size = (
-                    self.streaming_cfg.shift_size[1]
-                    if isinstance(self.streaming_cfg.shift_size, list)
-                    else self.streaming_cfg.shift_size
-                )
-
-            audio_chunk = self.buffer[:, :, self.buffer_idx : self.buffer_idx + chunk_size]
-
-            if self.sampling_frames is not None:
-                # checking to make sure the audio chunk has enough frames to produce at least one output after
-                # downsampling
-                if self.buffer_idx == 0 and isinstance(self.sampling_frames, list):
-                    cur_sampling_frames = self.sampling_frames[0]
-                else:
-                    cur_sampling_frames = (
-                        self.sampling_frames[1] if isinstance(self.sampling_frames, list) else self.sampling_frames
-                    )
-                if audio_chunk.size(-1) < cur_sampling_frames:
-                    return
-
-            # Adding the cache needed for the pre-encoder part of the model to the chunk
-            # if there is not enough frames to be used as the pre-encoding cache, zeros would be added
-            zeros_pads = None
-            if self.buffer_idx == 0 and isinstance(self.streaming_cfg.pre_encode_cache_size, list):
-                if self.pad_and_drop_preencoded:
-                    cache_pre_encode_num_frames = self.streaming_cfg.pre_encode_cache_size[1]
-                else:
-                    cache_pre_encode_num_frames = self.streaming_cfg.pre_encode_cache_size[0]
-                cache_pre_encode = torch.zeros(
-                    (audio_chunk.size(0), self.input_features, cache_pre_encode_num_frames),
-                    device=audio_chunk.device,
-                    dtype=audio_chunk.dtype,
-                )
-            else:
-                if isinstance(self.streaming_cfg.pre_encode_cache_size, list):
-                    pre_encode_cache_size = self.streaming_cfg.pre_encode_cache_size[1]
-                else:
-                    pre_encode_cache_size = self.streaming_cfg.pre_encode_cache_size
-
-                start_pre_encode_cache = self.buffer_idx - pre_encode_cache_size
-                if start_pre_encode_cache < 0:
-                    start_pre_encode_cache = 0
-                cache_pre_encode = self.buffer[:, :, start_pre_encode_cache : self.buffer_idx]
-                if cache_pre_encode.size(-1) < pre_encode_cache_size:
-                    zeros_pads = torch.zeros(
-                        (
-                            audio_chunk.size(0),
-                            audio_chunk.size(-2),
-                            pre_encode_cache_size - cache_pre_encode.size(-1),
-                        ),
-                        device=audio_chunk.device,
-                        dtype=audio_chunk.dtype,
-                    )
-
-            added_len = cache_pre_encode.size(-1)
-            audio_chunk = torch.cat((cache_pre_encode, audio_chunk), dim=-1)
-
-            if self.online_normalization:
-                audio_chunk, x_mean, x_std = normalize_batch(
-                    x=audio_chunk,
-                    seq_len=torch.tensor([audio_chunk.size(-1)] * audio_chunk.size(0)),
-                    normalize_type=self.model_normalize_type,
-                )
-
-            if zeros_pads is not None:
-                # TODO: check here when zero_pads is not None and added_len is already non-zero
-                audio_chunk = torch.cat((zeros_pads, audio_chunk), dim=-1)
-                added_len += zeros_pads.size(-1)
-
-            max_chunk_lengths = self.streams_length - self.buffer_idx
-            max_chunk_lengths = max_chunk_lengths + added_len
-            chunk_lengths = torch.clamp(max_chunk_lengths, min=0, max=audio_chunk.size(-1))
-
-            self.buffer_idx += shift_size
-            self.step += 1
-            yield audio_chunk, chunk_lengths
-
-    def is_buffer_empty(self):
-        if self.buffer_idx >= self.buffer.size(-1):
-            return True
+            # Check if we have enough valid data available
+            available_valid_frames = self.streams_length[0] - self.buffer_idx
+            return available_valid_frames >= chunk_size
         else:
-            return False
+            # Multi-stream batch: return True if buffer not exhausted
+            return True
 
     def __len__(self):
         return len(self.buffer)


### PR DESCRIPTION
# What does this PR do ?

Enables `CacheAwareStreamingAudioBuffer` to handle streaming input by calling `append_audio` directly and calling `get_next_chunk`.

**Collection**: [Note which collection this PR will affect]

ASR

# Changelog

- Add specific line by line info of high level changes in this PR.

Call `append_audio` with a chunk of audio bytes to append the preprocessed feature buffer.
Call `[get_next_chunk](https://github.com/modal-projects/NeMo/blob/shababo/add-streaming-input-to-cacheawarestreamingaudiobuffer/nemo/collections/asr/parts/utils/streaming_utils.py#L1595-L1596)` to get the next full sized feature chunk.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
async def transcribe(self, audio_data, step_num, stream_id = -1) -> str:

    print(f"transcribing audio data: {len(audio_data)} bytes")

    drop_extra_pre_encoded = (
        0
        if step_num == 0 and not self.cfg.pad_and_drop_preencoded
        else self.asr_model.encoder.streaming_cfg.drop_extra_pre_encoded
    )
    # convert to numpy
    audio_data = int2float(np.frombuffer(audio_data, dtype=np.int16))
    processed_signal, processed_signal_length, stream_id = self.streaming_buffer.append_audio(audio_data, stream_id=stream_id)
    
    result = self.streaming_buffer.get_next_chunk()
    if result is not None:
        audio_chunk, chunk_lengths = result
    else:
        return None, stream_id

    with torch.inference_mode():
        with torch.amp.autocast(self.diar_model.device.type, enabled=True):
            with torch.no_grad():
                result = self.multispk_asr_streamer.perform_parallel_streaming_stt_spk(
                    step_num=step_num,
                    chunk_audio=audio_chunk,
                    chunk_lengths=chunk_lengths,
                    is_buffer_empty=False,
                    drop_extra_pre_encoded=drop_extra_pre_encoded,
                )
    if result:
        return result[0], stream_id
    return None, stream_id
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
