### PR TITLE
[ASR] Replace print() with NeMo logging in utility modules

### DIFF
--- a/nemo/collections/asr/parts/utils/streaming_utils.py
+++ b/nemo/collections/asr/parts/utils/streaming_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import copy
-import logging
+from nemo.utils import logging
 import math
 import os
 from dataclasses import dataclass
@@ -55,11 +55,8 @@ def print_alignment(alignment):
     if m > 0:
         n = len(alignment[0])
         for i in range(m):
-            for j in range(n):
-                if j == 0:
-                    print(f"{i:4d} |", end=" ")
-                print(f"{alignment[i][j]}", end=" ")
-            print()
+            row = f"{i:4d} | " + " ".join(str(alignment[i][j]) for j in range(n))
+            logging.debug(row)
 
 
 def write_lcs_alignment_to_pickle(alignment, filepath, extras=None):
@@ -292,7 +289,7 @@ def longest_common_subsequence_merge(X, Y, filepath=None):
             "slice_idx": result_idx,
         }
         write_lcs_alignment_to_pickle(LCSuff, filepath=filepath, extras=extras)
-        print("Wrote alignemnt to :", filepath)
+        logging.debug("Wrote alignemnt to : " + filepath)
 
     return result_idx, LCSuff
 
@@ -1066,7 +1063,7 @@ class BatchedFrameASRRNNT(FrameBatchASR):
         except Exception:
             self.eos_id = -1
 
-        print("Performing Stateful decoding :", self.stateful_decoding)
+        logging.info(f"Performing Stateful decoding : {self.stateful_decoding}")
 
         if self.target_lang_id is not None:
             logging.info("Using target language ID")
@@ -1962,7 +1959,7 @@ class FrameBatchMultiTaskAED(FrameBatchASR):
         if not keep_logits:
             return hypothesis
 
-        print("keep_logits=True is not supported for MultiTaskAEDFrameBatchInfer. Returning empty logits.")
+        logging.warning("keep_logits=True is not supported for MultiTaskAEDFrameBatchInfer. Returning empty logits.")
         return hypothesis, []
 
     def _join_hypotheses(self, hypotheses, timestamps=False):
@@ -2102,7 +2099,7 @@ class FrameBatchChunkedRNNT(FrameBatchASR):
         if not keep_logits:
             return hypothesis
 
-        print("keep_logits=True is not supported for FrameBatchChunkedRNNT. Returning empty logits.")
+        logging.warning("keep_logits=True is not supported for FrameBatchChunkedRNNT. Returning empty logits.")
         return hypothesis, []
 
 
@@ -2159,7 +2156,7 @@ class FrameBatchChunkedCTC(FrameBatchASR):
         if not keep_logits:
             return hypothesis
 
-        print("keep_logits=True is not supported for FrameBatchChunkedCTC. Returning empty logits.")
+        logging.warning("keep_logits=True is not supported for FrameBatchChunkedCTC. Returning empty logits.")
         return hypothesis, []
 
 

--- a/nemo/collections/asr/parts/utils/transcribe_utils.py
+++ b/nemo/collections/asr/parts/utils/transcribe_utils.py
@@ -127,7 +127,7 @@ def get_buffered_pred_feat_rnnt(
     if manifest:
         filepaths = []
         with open(manifest, "r", encoding='utf_8') as mfst_f:
-            print("Parsing manifest files...")
+            logging.info("Parsing manifest files...")
             for L in mfst_f:
                 L = L.strip()
                 if not L:
@@ -202,13 +202,13 @@ def get_buffered_pred_feat_rnnt(
 
     if os.environ.get('DEBUG', '0') in ('1', 'y', 't'):
         if len(refs) == 0:
-            print("ground-truth text does not present!")
+            logging.warning("ground-truth text does not present!")
             for hyp in hyps:
-                print("hyp:", hyp)
+                logging.debug("hyp: " + str(hyp))
         else:
             for hyp, ref in zip(hyps, refs):
-                print("hyp:", hyp)
-                print("ref:", ref)
+                logging.debug("hyp: " + str(hyp))
+                logging.debug("ref: " + str(ref))
 
     wrapped_hyps = wrap_transcription(hyps)
     return wrapped_hyps

--- a/nemo/collections/asr/parts/utils/vad_utils.py
+++ b/nemo/collections/asr/parts/utils/vad_utils.py
@@ -954,12 +954,12 @@ def vad_tune_threshold_on_dev(
                 best_threshold = param
                 optimal_scores = all_perf[str(param)]
                 min_score = score
-            print("Current best", best_threshold, optimal_scores)
+            logging.info(f"Current best {best_threshold} {optimal_scores}")
 
         except RuntimeError as e:
-            print(f"Pass {param}, with error {e}")
+            logging.warning(f"Pass {param}, with error {e}")
         except pd.errors.EmptyDataError as e1:
-            print(f"Pass {param}, with error {e1}")
+            logging.warning(f"Pass {param}, with error {e1}")
 
     return best_threshold, optimal_scores
 


### PR DESCRIPTION
# What does this PR do?
Replaces 15 bare `print()` calls with the NeMo logger across three ASR utility modules, as required by CONTRIBUTING.md rule #11: "Loggers are preferred to print."
 
**Collection**: ASR
 
# Changelog
- `vad_utils.py`: Replaced 3 `print()` calls with `logging.info()`/`logging.warning()` calls
- `streaming_utils.py`: Replaced 7 `print()` calls with appropriate logging levels; updated `import logging` to `from nemo.utils import logging`
- `transcribe_utils.py`: Replaced 5 `print()` calls with `logging.info()`/`logging.warning()` calls
All logging levels assigned based on message severity (info for status updates, warning for edge cases/fallbacks).
 
# Usage
No API changes. Users will see identical log output, now with NeMo's standard formatting: `[NeMo I/W/E timestamp module:line] message`
 
Example (before):
```python
print("Processing complete.")
```
 
Example (after):
```python
logging.info("Processing complete.")
# Output: [NeMo I 2026-05-14 12:34:56 vad_utils:123] Processing complete.
```
 
# GitHub Actions CI
The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
 
# Before your PR is "Ready for review"
 
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? — No tests needed (refactor only, no behavior change)
- [x] Did you add or update any necessary documentation? — No documentation changes needed
- [x] Does the PR affect components that are optional to install? — No
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [x] Documentation / Code Style
# Additional Information
Relates to CONTRIBUTING.md rule #11: "Loggers are preferred to print. In NeMo, you can use logger from `from nemo.utils import logging`."
 
No breaking changes. Fully backward compatible — users see the same information, just in NeMo's standard log format.