### PR TITLE
Fix datastore cache miss download path

### DIFF
--- a/nemo/utils/data_utils.py
+++ b/nemo/utils/data_utils.py
@@ -234,12 +234,14 @@ def open_datastore_object_with_binary(path: str, num_retries: int = 5):
     return None
 
 
-def open_best(path: str, mode: str = "rb"):
+def open_best(path: str, mode: str = "rb", num_retries: int = 5):
     """Open a file using the best available method (Lhotse, datastore binary, or standard open).
 
     Args:
         path: path to the file or datastore object
         mode: file opening mode (default: "rb")
+        num_retries: number of retries if the get command fails with ais binary,
+            as AIS Python SDK has its own retry mechanism
 
     Returns:
         File-like object
@@ -247,7 +249,7 @@ def open_best(path: str, mode: str = "rb"):
     if LHOTSE_AVAILABLE:
         return lhotse_open_best(path, mode=mode)
     if is_datastore_path(path):
-        return open_datastore_object_with_binary(path)
+        return open_datastore_object_with_binary(path, num_retries=num_retries)
     return open(path, mode=mode, encoding='utf-8' if 'b' not in mode else None)
 
 
@@ -276,8 +278,8 @@ def get_datastore_object(path: str, force: bool = False, num_retries: int = 5) -
             if not os.path.isdir(local_dir):
                 os.makedirs(local_dir, exist_ok=True)
 
-            with open(local_path, 'wb') as f:
-                f.write(open_best(path).read(), num_retries=num_retries)
+            with open(local_path, 'wb') as f, open_best(path, num_retries=num_retries) as stream:
+                f.write(stream.read())
 
         return local_path
 

--- a/nemo/utils/data_utils.py
+++ b/nemo/utils/data_utils.py
@@ -18,6 +18,7 @@ import os
 import pathlib
 import shutil
 import subprocess
+import tempfile
 from functools import lru_cache
 from typing import Any, Callable, Dict, Iterable, Tuple
 from urllib.parse import urlparse
@@ -137,6 +138,38 @@ def ais_endpoint_to_dir(endpoint: str) -> str:
     return os.path.join(result.hostname, str(result.port))
 
 
+class _AISProcessStream:
+    """Wrap an AIS subprocess stream and keep the process alive until the stream is closed."""
+
+    def __init__(self, process: subprocess.Popen):
+        self._process = process
+        self._stream = process.stdout
+
+    def __getattr__(self, name):
+        return getattr(self._stream, name)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._stream)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def close(self):
+        """Close the output stream and wait for the AIS subprocess to finish."""
+        try:
+            self._stream.close()
+        finally:
+            if self._process.stderr is not None:
+                self._process.stderr.close()
+            self._process.wait()
+
+
 @lru_cache(maxsize=1)
 def ais_binary() -> str:
     """Return location of `ais` binary if available."""
@@ -211,26 +244,21 @@ def open_datastore_object_with_binary(path: str, num_retries: int = 5):
 
         cmd = [binary, 'get', path, '-']
 
-        done = False
-
+        last_error = ""
         for _ in range(num_retries):
-            with subprocess.Popen(
+            proc = subprocess.Popen(
                 cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=False  # bytes mode
-            ) as proc:
-                stream = proc.stdout
-                if stream.peek(1):
-                    done = True
-                    return stream
-
-        if not done:
-            with subprocess.Popen(
-                cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=False
-            ) as proc:
-                error = proc.stderr.read().decode("utf-8", errors="ignore").strip()
-            raise ValueError(
-                f"{path} couldn't be opened with AIS binary "
-                f"after {num_retries} attempts because of the following exception: {error}"
             )
+            if proc.stdout.peek(1):
+                return _AISProcessStream(proc)
+
+            with proc:
+                last_error = proc.stderr.read().decode("utf-8", errors="ignore").strip()
+
+        raise ValueError(
+            f"{path} couldn't be opened with AIS binary "
+            f"after {num_retries} attempts because of the following exception: {last_error}"
+        )
     return None
 
 
@@ -278,8 +306,16 @@ def get_datastore_object(path: str, force: bool = False, num_retries: int = 5) -
             if not os.path.isdir(local_dir):
                 os.makedirs(local_dir, exist_ok=True)
 
-            with open(local_path, 'wb') as f, open_best(path, num_retries=num_retries) as stream:
-                f.write(stream.read())
+            temp_path = None
+            try:
+                with tempfile.NamedTemporaryFile(mode='wb', dir=local_dir, prefix='.download-', delete=False) as f:
+                    temp_path = f.name
+                    with open_best(path, num_retries=num_retries) as stream:
+                        shutil.copyfileobj(stream, f)
+                os.replace(temp_path, local_path)
+            finally:
+                if temp_path is not None and os.path.exists(temp_path):
+                    os.unlink(temp_path)
 
         return local_path
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import os
 from unittest import mock
 
@@ -22,6 +23,7 @@ from nemo.utils.data_utils import (
     ais_binary,
     ais_endpoint_to_dir,
     bucket_and_object_from_uri,
+    get_datastore_object,
     is_datastore_path,
     resolve_cache_dir,
 )
@@ -90,3 +92,25 @@ class TestDataUtils:
         with mock.patch('shutil.which', lambda x: None), mock.patch('os.path.isfile', lambda x: None):
             ais_binary.cache_clear()
             assert ais_binary() is None
+
+    @pytest.mark.unit
+    def test_get_datastore_object_passes_num_retries_to_datastore_open_on_cache_miss(self, tmp_path):
+        """Test datastore cache misses preserve caller retries when downloading through the AIS fallback."""
+        local_path = tmp_path / 'cache' / 'object.bin'
+        opened_with = {}
+
+        def fake_open_datastore_object_with_binary(path, num_retries=5):
+            opened_with['path'] = path
+            opened_with['num_retries'] = num_retries
+            return io.BytesIO(b'payload')
+
+        with (
+            mock.patch('nemo.utils.data_utils.LHOTSE_AVAILABLE', False),
+            mock.patch('nemo.utils.data_utils.open_datastore_object_with_binary', side_effect=fake_open_datastore_object_with_binary),
+            mock.patch('nemo.utils.data_utils.datastore_path_to_local_path', return_value=str(local_path)),
+        ):
+            resolved_path = get_datastore_object('ais://bucket/object', num_retries=7)
+
+        assert resolved_path == str(local_path)
+        assert local_path.read_bytes() == b'payload'
+        assert opened_with == {'path': 'ais://bucket/object', 'num_retries': 7}

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -25,6 +25,7 @@ from nemo.utils.data_utils import (
     bucket_and_object_from_uri,
     get_datastore_object,
     is_datastore_path,
+    open_datastore_object_with_binary,
     resolve_cache_dir,
 )
 
@@ -106,7 +107,10 @@ class TestDataUtils:
 
         with (
             mock.patch('nemo.utils.data_utils.LHOTSE_AVAILABLE', False),
-            mock.patch('nemo.utils.data_utils.open_datastore_object_with_binary', side_effect=fake_open_datastore_object_with_binary),
+            mock.patch(
+                'nemo.utils.data_utils.open_datastore_object_with_binary',
+                side_effect=fake_open_datastore_object_with_binary,
+            ),
             mock.patch('nemo.utils.data_utils.datastore_path_to_local_path', return_value=str(local_path)),
         ):
             resolved_path = get_datastore_object('ais://bucket/object', num_retries=7)
@@ -114,3 +118,41 @@ class TestDataUtils:
         assert resolved_path == str(local_path)
         assert local_path.read_bytes() == b'payload'
         assert opened_with == {'path': 'ais://bucket/object', 'num_retries': 7}
+
+    @pytest.mark.unit
+    def test_open_datastore_object_with_binary_keeps_stream_open_until_consumed(self, tmp_path):
+        """Test the AIS fallback keeps its real subprocess stream readable after returning."""
+        ais_binary_path = tmp_path / 'ais'
+        ais_binary_path.write_text('#!/bin/sh\nprintf payload\n')
+        ais_binary_path.chmod(0o755)
+
+        with (
+            mock.patch('nemo.utils.data_utils.ais_endpoint', return_value='http://local:123'),
+            mock.patch('nemo.utils.data_utils.ais_binary', return_value=str(ais_binary_path)),
+        ):
+            with open_datastore_object_with_binary('ais://bucket/object', num_retries=1) as stream:
+                assert stream.read() == b'payload'
+
+    @pytest.mark.unit
+    def test_get_datastore_object_does_not_leave_partial_file_on_download_failure(self, tmp_path):
+        """Test a failed datastore download does not create a cache file."""
+        local_path = tmp_path / 'cache' / 'object.bin'
+
+        class FailingStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                return False
+
+            def read(self, *args):
+                raise RuntimeError('download failed')
+
+        with (
+            mock.patch('nemo.utils.data_utils.open_best', return_value=FailingStream()),
+            mock.patch('nemo.utils.data_utils.datastore_path_to_local_path', return_value=str(local_path)),
+        ):
+            with pytest.raises(RuntimeError, match='download failed'):
+                get_datastore_object('ais://bucket/object')
+
+        assert not local_path.exists()


### PR DESCRIPTION
> [!IMPORTANT]
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Fix the datastore cache-miss download path so it writes the downloaded bytes correctly and preserves the caller's retry count when falling back to the AIS binary.

**Collection**: Common

# Changelog

- remove the invalid `num_retries` keyword from the cache file `write()` call
- thread `num_retries` through `open_best()` so `get_datastore_object(..., num_retries=...)` reaches `open_datastore_object_with_binary(...)` when Lhotse is unavailable
- close the opened stream in `get_datastore_object()` and add a regression test for the cache-miss path

# Usage

```python
local_path = get_datastore_object("ais://bucket/object", num_retries=7)
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to #
- I couldn't run `pytest` in this checkout because the active interpreter is missing `pytest`, so I verified the change with `python3 -m compileall`, `git diff --check`, and a focused isolated smoke test of the datastore cache-miss path.
