### PR TITLE
Add MTP speculative-decoding support to NeMo SpeechLM vLLM plugin

### DIFF
--- a/examples/speechlm2/to_hf.py
+++ b/examples/speechlm2/to_hf.py
@@ -232,14 +232,25 @@ def prepare_for_vllm(output_dir: str, model_cfg: dict) -> None:
     # 1. Patch config.json (arch, model_type, audio_locator_tag for vLLM plugin).
     arch_model_cfg = dict(model_cfg)
     llm_backbone_dir = output_dir / LLM_BACKBONE_DIR
-    if (llm_backbone_dir / "config.json").exists():
+    llm_backbone_config_path = llm_backbone_dir / "config.json"
+    llm_backbone_config = None
+    if llm_backbone_config_path.exists():
         arch_model_cfg["pretrained_llm"] = str(llm_backbone_dir)
+        llm_backbone_config = json.loads(llm_backbone_config_path.read_text())
     arch, base_vocab_size = _detect_vllm_architecture(arch_model_cfg)
     config_path = output_dir / "config.json"
     config = json.loads(config_path.read_text())
     config["model_type"] = "nemo_speechlm"
     config["architectures"] = [arch]
     config["audio_locator_tag"] = audio_token
+    if llm_backbone_config is not None:
+        # Keep the export portable while making the bundled config authoritative.
+        # NeMo's HF loader resolves this relative marker to a cached local path;
+        # the vLLM config consumes the embedded copy without another Hub lookup.
+        config["pretrained_llm"] = LLM_BACKBONE_DIR
+        config["llm_config"] = llm_backbone_config
+    else:
+        config.pop("llm_config", None)
     config.pop("audio_token_index", None)
     config.pop("image_token_index", None)
 

--- a/examples/speechlm2/to_hf.py
+++ b/examples/speechlm2/to_hf.py
@@ -147,15 +147,13 @@ def save_llm_backbone_config(model: torch.nn.Module, output_dir: str | Path) -> 
     llm_config.save_pretrained(str(llm_backbone_dir))
 
 
-def _inspect_vllm_backbone(model_cfg: dict) -> tuple[str, int]:
-    """Determine the vLLM plugin class and model embedding vocabulary size.
+def _detect_vllm_architecture(model_cfg: dict) -> str:
+    """Determine the vLLM plugin model class for the checkpoint.
 
     The SALM plugin registers a single architecture name and selects between
     transformer and hybrid backends at instantiation time, so this function
-    verifies the backbone config is reachable and returns the unified name
-    plus the model config's vocabulary size. The latter is authoritative for
-    the embedding-table bound; tokenizer ``vocab_size`` can exclude added
-    tokens and need not equal it.
+    just verifies the backbone config is reachable and returns the unified
+    name; the hybrid-vs-transformer split is handled inside the plugin.
 
     Raises:
         ValueError: if the HF config can't be loaded or has no 'architectures'.
@@ -174,11 +172,8 @@ def _inspect_vllm_backbone(model_cfg: dict) -> tuple[str, int]:
     archs = getattr(llm_cfg, "architectures", [])
     if not archs:
         raise ValueError(f"HF config for {pretrained_llm!r} has empty 'architectures'.")
-    vocab_size = getattr(llm_cfg, "vocab_size", None)
-    if isinstance(vocab_size, bool) or not isinstance(vocab_size, int) or vocab_size <= 0:
-        raise ValueError(f"HF config for {pretrained_llm!r} has invalid 'vocab_size': {vocab_size!r}.")
 
-    return "NeMoSpeechLMForConditionalGeneration", vocab_size
+    return "NeMoSpeechLMForConditionalGeneration"
 
 
 def prepare_for_vllm(output_dir: str, model_cfg: dict) -> None:
@@ -196,7 +191,6 @@ def prepare_for_vllm(output_dir: str, model_cfg: dict) -> None:
     """
     from transformers import AutoTokenizer
 
-    from nemo.collections.speechlm2.vllm.salm.config import _SPEECHLM_EMBED_EXTRA_ROWS
     from nemo.utils import logging as LOG
 
     output_dir = Path(output_dir)
@@ -215,12 +209,15 @@ def prepare_for_vllm(output_dir: str, model_cfg: dict) -> None:
     llm_backbone_dir = output_dir / LLM_BACKBONE_DIR
     if (llm_backbone_dir / "config.json").exists():
         arch_model_cfg["pretrained_llm"] = str(llm_backbone_dir)
-    arch, base_vocab_size = _inspect_vllm_backbone(arch_model_cfg)
+    arch = _detect_vllm_architecture(arch_model_cfg)
     config_path = output_dir / "config.json"
     config = json.loads(config_path.read_text())
     config["model_type"] = "nemo_speechlm"
     config["architectures"] = [arch]
     config["audio_locator_tag"] = audio_token
+    config.pop("audio_token_index", None)
+    config.pop("image_token_index", None)
+    config_path.write_text(json.dumps(config, indent=2) + "\n")
 
     # 2. Save tokenizer (backbone chat_template carries over via save_pretrained)
     existing = [
@@ -234,21 +231,6 @@ def prepare_for_vllm(output_dir: str, model_cfg: dict) -> None:
     tok = AutoTokenizer.from_pretrained(tokenizer_src, trust_remote_code=True)
     if audio_token not in tok.get_vocab():
         tok.add_special_tokens({"additional_special_tokens": [audio_token]})
-    audio_token_id = tok.get_vocab().get(audio_token)
-    if isinstance(audio_token_id, bool) or not isinstance(audio_token_id, int) or audio_token_id < 0:
-        raise ValueError(f"Tokenizer did not assign a valid ID to audio token {audio_token!r}.")
-    padded_vocab_size = base_vocab_size + _SPEECHLM_EMBED_EXTRA_ROWS
-    if audio_token_id >= padded_vocab_size:
-        raise ValueError(
-            f"Audio token ID {audio_token_id} is outside the SpeechLM embedding table with "
-            f"{padded_vocab_size} rows. Reduce the tokenizer's added-token count before training/export."
-        )
-    # Persist the exact placeholder ID under the SALM-specific name. The
-    # runtime config exposes vLLM's historical ``image_token_index`` spelling
-    # as a compatibility property for its EAGLE-style proposer.
-    config.pop("image_token_index", None)
-    config["audio_token_index"] = audio_token_id
-    config_path.write_text(json.dumps(config, indent=2) + "\n")
     tok.save_pretrained(str(output_dir))
     # Newer transformers splits long chat_template into a separate
     # ``chat_template.jinja`` file; inline it back and drop the file.

--- a/examples/speechlm2/to_hf.py
+++ b/examples/speechlm2/to_hf.py
@@ -114,6 +114,22 @@ def _hf_export_config(model: torch.nn.Module, dtype: str | torch.dtype) -> dict[
         # requested replacement pattern. Persist the pattern of the head that
         # was actually built so vLLM instantiates the matching physical layers.
         mtp_cfg["hybrid_override_pattern"] = actual_mtp_pattern
+        actual_mtp_depth = getattr(llm_config, "num_nextn_predict_layers", None)
+        if actual_mtp_depth is not None:
+            if isinstance(actual_mtp_depth, bool) or not isinstance(actual_mtp_depth, int) or actual_mtp_depth <= 0:
+                raise ValueError(
+                    f"Built LLM has invalid num_nextn_predict_layers={actual_mtp_depth!r}; cannot export it."
+                )
+            if mtp_cfg.get("use_repeated_layer", False):
+                if actual_mtp_depth != 1:
+                    raise ValueError(
+                        "A repeated MTP head must serialize exactly one physical layer, but the built LLM "
+                        f"declares num_nextn_predict_layers={actual_mtp_depth}."
+                    )
+            else:
+                # For a preserved native head, the recipe depth is advisory.
+                # Export the physical/logical depth that is actually present.
+                mtp_cfg["num_nextn_predict_layers"] = actual_mtp_depth
     dtype_name = _canonical_torch_dtype_name(dtype)
     config["dtype"] = dtype_name
     config["torch_dtype"] = dtype_name
@@ -128,9 +144,8 @@ def save_hf_checkpoint(model: torch.nn.Module, state_dict: dict, cfg: HfExportCo
     target_dtype = str_to_dtype(cfg.dtype)
     state_dict = {k: v.to(target_dtype) for k, v in state_dict.items()}
 
-    save_file(state_dict, output_dir / "model.safetensors")
-
     config = _hf_export_config(model, cfg.dtype)
+    save_file(state_dict, output_dir / "model.safetensors")
     with open(output_dir / "config.json", "w") as f:
         json.dump(config, f, indent=2)
     save_llm_backbone_config(model, output_dir)
@@ -147,16 +162,18 @@ def save_llm_backbone_config(model: torch.nn.Module, output_dir: str | Path) -> 
     llm_config.save_pretrained(str(llm_backbone_dir))
 
 
-def _detect_vllm_architecture(model_cfg: dict) -> str:
-    """Determine the vLLM plugin model class for the checkpoint.
+def _detect_vllm_architecture(model_cfg: dict) -> tuple[str, int]:
+    """Determine the vLLM plugin model class and backbone vocabulary size.
 
     The SALM plugin registers a single architecture name and selects between
     transformer and hybrid backends at instantiation time, so this function
-    just verifies the backbone config is reachable and returns the unified
-    name; the hybrid-vs-transformer split is handled inside the plugin.
+    verifies the backbone config is reachable and returns the unified name
+    plus the embedding-table vocabulary bound. The hybrid-vs-transformer split
+    is handled inside the plugin.
 
     Raises:
-        ValueError: if the HF config can't be loaded or has no 'architectures'.
+        ValueError: If the HF config cannot be loaded, has no architecture, or
+            declares an invalid vocabulary size.
     """
     pretrained_llm = model_cfg.get("pretrained_llm", "")
     try:
@@ -172,8 +189,11 @@ def _detect_vllm_architecture(model_cfg: dict) -> str:
     archs = getattr(llm_cfg, "architectures", [])
     if not archs:
         raise ValueError(f"HF config for {pretrained_llm!r} has empty 'architectures'.")
+    vocab_size = getattr(llm_cfg, "vocab_size", None)
+    if isinstance(vocab_size, bool) or not isinstance(vocab_size, int) or vocab_size <= 0:
+        raise ValueError(f"HF config for {pretrained_llm!r} has invalid 'vocab_size': {vocab_size!r}.")
 
-    return "NeMoSpeechLMForConditionalGeneration"
+    return "NeMoSpeechLMForConditionalGeneration", vocab_size
 
 
 def prepare_for_vllm(output_dir: str, model_cfg: dict) -> None:
@@ -187,10 +207,12 @@ def prepare_for_vllm(output_dir: str, model_cfg: dict) -> None:
         model_cfg: Model config dict (from experiment YAML).
 
     Raises:
-        ValueError: If ``pretrained_llm`` or ``audio_locator_tag`` is missing.
+        ValueError: If required model metadata is missing, or the tokenizer's
+            audio token does not fit the SpeechLM embedding table.
     """
     from transformers import AutoTokenizer
 
+    from nemo.collections.speechlm2.vllm.salm.config import _SPEECHLM_EMBED_EXTRA_ROWS
     from nemo.utils import logging as LOG
 
     output_dir = Path(output_dir)
@@ -209,7 +231,7 @@ def prepare_for_vllm(output_dir: str, model_cfg: dict) -> None:
     llm_backbone_dir = output_dir / LLM_BACKBONE_DIR
     if (llm_backbone_dir / "config.json").exists():
         arch_model_cfg["pretrained_llm"] = str(llm_backbone_dir)
-    arch = _detect_vllm_architecture(arch_model_cfg)
+    arch, base_vocab_size = _detect_vllm_architecture(arch_model_cfg)
     config_path = output_dir / "config.json"
     config = json.loads(config_path.read_text())
     config["model_type"] = "nemo_speechlm"
@@ -217,7 +239,6 @@ def prepare_for_vllm(output_dir: str, model_cfg: dict) -> None:
     config["audio_locator_tag"] = audio_token
     config.pop("audio_token_index", None)
     config.pop("image_token_index", None)
-    config_path.write_text(json.dumps(config, indent=2) + "\n")
 
     # 2. Save tokenizer (backbone chat_template carries over via save_pretrained)
     existing = [
@@ -231,6 +252,16 @@ def prepare_for_vllm(output_dir: str, model_cfg: dict) -> None:
     tok = AutoTokenizer.from_pretrained(tokenizer_src, trust_remote_code=True)
     if audio_token not in tok.get_vocab():
         tok.add_special_tokens({"additional_special_tokens": [audio_token]})
+    audio_token_id = tok.get_vocab().get(audio_token)
+    if isinstance(audio_token_id, bool) or not isinstance(audio_token_id, int) or audio_token_id < 0:
+        raise ValueError(f"Tokenizer did not assign a valid ID to audio token {audio_token!r}.")
+    padded_vocab_size = base_vocab_size + _SPEECHLM_EMBED_EXTRA_ROWS
+    if audio_token_id >= padded_vocab_size:
+        raise ValueError(
+            f"Audio token ID {audio_token_id} is outside the SpeechLM embedding table with "
+            f"{padded_vocab_size} rows. Reduce the tokenizer's added-token count before training/export."
+        )
+    config_path.write_text(json.dumps(config, indent=2) + "\n")
     tok.save_pretrained(str(output_dir))
     # Newer transformers splits long chat_template into a separate
     # ``chat_template.jinja`` file; inline it back and drop the file.

--- a/examples/speechlm2/to_hf.py
+++ b/examples/speechlm2/to_hf.py
@@ -102,6 +102,9 @@ def _canonical_torch_dtype_name(dtype: str | torch.dtype) -> str:
 def _hf_export_config(model: torch.nn.Module, dtype: str | torch.dtype) -> dict[str, Any]:
     """Build the exported root config without mutating the training config."""
     config = OmegaConf.to_container(model.cfg) if isinstance(model.cfg, DictConfig) else deepcopy(model.cfg)
+    # Remote-code trust is a runtime security decision. Do not persist a
+    # training-time opt-in in checkpoints that may be loaded by another user.
+    config.pop("trust_remote_code", None)
     mtp_cfg = config.get("mtp")
     llm_config = getattr(getattr(model, "llm", None), "config", None)
     actual_mtp_pattern = getattr(llm_config, "mtp_hybrid_override_pattern", None)

--- a/examples/speechlm2/to_hf.py
+++ b/examples/speechlm2/to_hf.py
@@ -102,6 +102,18 @@ def _canonical_torch_dtype_name(dtype: str | torch.dtype) -> str:
 def _hf_export_config(model: torch.nn.Module, dtype: str | torch.dtype) -> dict[str, Any]:
     """Build the exported root config without mutating the training config."""
     config = OmegaConf.to_container(model.cfg) if isinstance(model.cfg, DictConfig) else deepcopy(model.cfg)
+    mtp_cfg = config.get("mtp")
+    llm_config = getattr(getattr(model, "llm", None), "config", None)
+    actual_mtp_pattern = getattr(llm_config, "mtp_hybrid_override_pattern", None)
+    if isinstance(mtp_cfg, dict) and mtp_cfg.get("enabled", False) and actual_mtp_pattern is not None:
+        if not isinstance(actual_mtp_pattern, str) or not actual_mtp_pattern:
+            raise ValueError(
+                f"Built LLM has invalid mtp_hybrid_override_pattern={actual_mtp_pattern!r}; cannot export it."
+            )
+        # A preserved checkpoint-native MTP head can differ from the recipe's
+        # requested replacement pattern. Persist the pattern of the head that
+        # was actually built so vLLM instantiates the matching physical layers.
+        mtp_cfg["hybrid_override_pattern"] = actual_mtp_pattern
     dtype_name = _canonical_torch_dtype_name(dtype)
     config["dtype"] = dtype_name
     config["torch_dtype"] = dtype_name
@@ -135,13 +147,15 @@ def save_llm_backbone_config(model: torch.nn.Module, output_dir: str | Path) -> 
     llm_config.save_pretrained(str(llm_backbone_dir))
 
 
-def _detect_vllm_architecture(model_cfg: dict) -> str:
-    """Determine the vLLM plugin model class for the checkpoint.
+def _inspect_vllm_backbone(model_cfg: dict) -> tuple[str, int]:
+    """Determine the vLLM plugin class and model embedding vocabulary size.
 
     The SALM plugin registers a single architecture name and selects between
     transformer and hybrid backends at instantiation time, so this function
-    just verifies the backbone config is reachable and returns the unified
-    name; the hybrid-vs-transformer split is handled inside the plugin.
+    verifies the backbone config is reachable and returns the unified name
+    plus the model config's vocabulary size. The latter is authoritative for
+    the embedding-table bound; tokenizer ``vocab_size`` can exclude added
+    tokens and need not equal it.
 
     Raises:
         ValueError: if the HF config can't be loaded or has no 'architectures'.
@@ -160,8 +174,11 @@ def _detect_vllm_architecture(model_cfg: dict) -> str:
     archs = getattr(llm_cfg, "architectures", [])
     if not archs:
         raise ValueError(f"HF config for {pretrained_llm!r} has empty 'architectures'.")
+    vocab_size = getattr(llm_cfg, "vocab_size", None)
+    if isinstance(vocab_size, bool) or not isinstance(vocab_size, int) or vocab_size <= 0:
+        raise ValueError(f"HF config for {pretrained_llm!r} has invalid 'vocab_size': {vocab_size!r}.")
 
-    return "NeMoSpeechLMForConditionalGeneration"
+    return "NeMoSpeechLMForConditionalGeneration", vocab_size
 
 
 def prepare_for_vllm(output_dir: str, model_cfg: dict) -> None:
@@ -179,6 +196,7 @@ def prepare_for_vllm(output_dir: str, model_cfg: dict) -> None:
     """
     from transformers import AutoTokenizer
 
+    from nemo.collections.speechlm2.vllm.salm.config import _SPEECHLM_EMBED_EXTRA_ROWS
     from nemo.utils import logging as LOG
 
     output_dir = Path(output_dir)
@@ -197,13 +215,12 @@ def prepare_for_vllm(output_dir: str, model_cfg: dict) -> None:
     llm_backbone_dir = output_dir / LLM_BACKBONE_DIR
     if (llm_backbone_dir / "config.json").exists():
         arch_model_cfg["pretrained_llm"] = str(llm_backbone_dir)
-    arch = _detect_vllm_architecture(arch_model_cfg)
+    arch, base_vocab_size = _inspect_vllm_backbone(arch_model_cfg)
     config_path = output_dir / "config.json"
     config = json.loads(config_path.read_text())
     config["model_type"] = "nemo_speechlm"
     config["architectures"] = [arch]
     config["audio_locator_tag"] = audio_token
-    config_path.write_text(json.dumps(config, indent=2) + "\n")
 
     # 2. Save tokenizer (backbone chat_template carries over via save_pretrained)
     existing = [
@@ -213,9 +230,25 @@ def prepare_for_vllm(output_dir: str, model_cfg: dict) -> None:
     ]
     if existing:
         LOG.info("Overwriting existing files in %s: %s", output_dir, existing)
-    tok = AutoTokenizer.from_pretrained(pretrained_llm, trust_remote_code=True)
+    tokenizer_src = model_cfg.get("tokenizer_path") or pretrained_llm
+    tok = AutoTokenizer.from_pretrained(tokenizer_src, trust_remote_code=True)
     if audio_token not in tok.get_vocab():
         tok.add_special_tokens({"additional_special_tokens": [audio_token]})
+    audio_token_id = tok.get_vocab().get(audio_token)
+    if isinstance(audio_token_id, bool) or not isinstance(audio_token_id, int) or audio_token_id < 0:
+        raise ValueError(f"Tokenizer did not assign a valid ID to audio token {audio_token!r}.")
+    padded_vocab_size = base_vocab_size + _SPEECHLM_EMBED_EXTRA_ROWS
+    if audio_token_id >= padded_vocab_size:
+        raise ValueError(
+            f"Audio token ID {audio_token_id} is outside the SpeechLM embedding table with "
+            f"{padded_vocab_size} rows. Reduce the tokenizer's added-token count before training/export."
+        )
+    # Persist the exact placeholder ID under the SALM-specific name. The
+    # runtime config exposes vLLM's historical ``image_token_index`` spelling
+    # as a compatibility property for its EAGLE-style proposer.
+    config.pop("image_token_index", None)
+    config["audio_token_index"] = audio_token_id
+    config_path.write_text(json.dumps(config, indent=2) + "\n")
     tok.save_pretrained(str(output_dir))
     # Newer transformers splits long chat_template into a separate
     # ``chat_template.jinja`` file; inline it back and drop the file.

--- a/nemo/collections/speechlm2/vllm/salm/__init__.py
+++ b/nemo/collections/speechlm2/vllm/salm/__init__.py
@@ -82,9 +82,9 @@ def _nemo_speechlm_mtp_hf_config_override(hf_config):
         # A spawn child can import this module while unpickling the function
         # without running the vLLM plugin hook first. In that case the class
         # still exposes its native override, which is safe to capture lazily.
-        from vllm.config.speculative import SpeculativeConfig
+        import vllm.config.speculative as _spec_mod
 
-        current_override = SpeculativeConfig.hf_config_override
+        current_override = _spec_mod.SpeculativeConfig.hf_config_override
         if current_override is _nemo_speechlm_mtp_hf_config_override:
             raise RuntimeError("NeMo SpeechLM MTP override was installed without preserving vLLM's original hook.")
         _ORIGINAL_VLLM_HF_CONFIG_OVERRIDE = current_override
@@ -115,7 +115,6 @@ def _patch_vllm_for_nemo_speechlm_mtp() -> None:
     from typing import Literal, get_args
 
     import vllm.config.speculative as _spec_mod
-    from vllm.config.speculative import SpeculativeConfig
 
     # Extend vLLM's recognized MTP model types.
     old_args = get_args(_spec_mod.MTPModelTypes)
@@ -123,7 +122,7 @@ def _patch_vllm_for_nemo_speechlm_mtp() -> None:
         _spec_mod.MTPModelTypes = Literal[old_args + ("nemo_speechlm_mtp",)]
 
     # Route SpeechLM MTP checkpoints through SpeculativeConfig.hf_config_override.
-    current_override = SpeculativeConfig.hf_config_override
+    current_override = _spec_mod.SpeculativeConfig.hf_config_override
     if not getattr(current_override, "_nemo_speechlm_mtp_override", False):
         global _ORIGINAL_VLLM_HF_CONFIG_OVERRIDE
         # Preserve the first native hook for the lifetime of this process.
@@ -131,7 +130,7 @@ def _patch_vllm_for_nemo_speechlm_mtp() -> None:
         # wrapper that already delegates to us, creating an override cycle.
         if _ORIGINAL_VLLM_HF_CONFIG_OVERRIDE is None:
             _ORIGINAL_VLLM_HF_CONFIG_OVERRIDE = current_override
-        SpeculativeConfig.hf_config_override = staticmethod(_nemo_speechlm_mtp_hf_config_override)
+        _spec_mod.SpeculativeConfig.hf_config_override = staticmethod(_nemo_speechlm_mtp_hf_config_override)
 
     # Register the SpeechLM MTP draft architecture with vLLM.
     from vllm.model_executor.models.registry import ModelRegistry

--- a/nemo/collections/speechlm2/vllm/salm/__init__.py
+++ b/nemo/collections/speechlm2/vllm/salm/__init__.py
@@ -49,20 +49,22 @@ def _patch_vllm_for_nemo_speechlm_mtp() -> None:
     import vllm.config.speculative as _spec_mod
     from vllm.config.speculative import SpeculativeConfig
 
-    # 1 ── Extend MTPModelTypes -------------------------------------------
+    # Extend vLLM's recognized MTP model types.
     old_args = get_args(_spec_mod.MTPModelTypes)
     if "nemo_speechlm_mtp" not in old_args:
         _spec_mod.MTPModelTypes = Literal[old_args + ("nemo_speechlm_mtp",)]
 
-    # 2 ── Wrap hf_config_override ----------------------------------------
+    # Route SpeechLM MTP checkpoints through SpeculativeConfig.hf_config_override.
     current_override = SpeculativeConfig.hf_config_override
     if not getattr(current_override, "_nemo_speechlm_mtp_override", False):
         original_override = current_override
 
         def _patched_override(hf_config):
             if hf_config.model_type == "nemo_speechlm":
-                mtp_cfg = getattr(hf_config, "mtp", {}) or {}
-                n_predict = mtp_cfg.get("num_nextn_predict_layers", 0) if isinstance(mtp_cfg, dict) else 0
+                mtp_cfg = getattr(hf_config, "mtp", None)
+                if not isinstance(mtp_cfg, dict):
+                    mtp_cfg = {}
+                n_predict = mtp_cfg.get("num_nextn_predict_layers", 0)
                 if n_predict > 0:
                     use_repeated_layer = bool(mtp_cfg.get("use_repeated_layer", False))
                     if n_predict > 1 and not use_repeated_layer:
@@ -97,7 +99,7 @@ def _patch_vllm_for_nemo_speechlm_mtp() -> None:
         _patched_override._nemo_speechlm_mtp_override = True
         SpeculativeConfig.hf_config_override = staticmethod(_patched_override)
 
-    # 3 ── Register NeMoSpeechLMMTPModel ----------------------------------
+    # Register the SpeechLM MTP draft architecture with vLLM.
     from vllm.model_executor.models.registry import ModelRegistry
 
     ModelRegistry.register_model(

--- a/nemo/collections/speechlm2/vllm/salm/__init__.py
+++ b/nemo/collections/speechlm2/vllm/salm/__init__.py
@@ -26,6 +26,84 @@ Backbone-specific behavior is selected at instantiation time.
 _PKG = "nemo.collections.speechlm2.vllm.salm"
 
 
+def _patch_vllm_for_nemo_speechlm_mtp() -> None:
+    """Extend vLLM's speculative-decoding framework to support nemo_speechlm MTP.
+
+    Three patches are applied:
+
+    1. ``MTPModelTypes`` — the Literal type that guards the MTP detection
+       branch in ``SpeculativeConfig.__post_init__`` is extended to include
+       ``"nemo_speechlm_mtp"``.
+
+    2. ``SpeculativeConfig.hf_config_override`` — the static method that
+       rewrites the draft-model HF config is wrapped to detect
+       ``nemo_speechlm`` checkpoints that carry MTP heads (``mtp.enabled``
+       and ``mtp.num_nextn_predict_layers > 0``) and redirect them to the
+       ``NeMoSpeechLMMTPModel`` architecture with the right ``n_predict``.
+
+    3. ``ModelRegistry`` — ``NeMoSpeechLMMTPModel`` is registered so that
+       vLLM can resolve and instantiate it as the draft model.
+    """
+    from typing import Literal, get_args
+
+    import vllm.config.speculative as _spec_mod
+    from vllm.config.speculative import SpeculativeConfig
+
+    # 1 ── Extend MTPModelTypes -------------------------------------------
+    old_args = get_args(_spec_mod.MTPModelTypes)
+    if "nemo_speechlm_mtp" not in old_args:
+        _spec_mod.MTPModelTypes = Literal[old_args + ("nemo_speechlm_mtp",)]
+
+    # 2 ── Wrap hf_config_override ----------------------------------------
+    current_override = SpeculativeConfig.hf_config_override
+    if not getattr(current_override, "_nemo_speechlm_mtp_override", False):
+        original_override = current_override
+
+        def _patched_override(hf_config):
+            if hf_config.model_type == "nemo_speechlm":
+                mtp_cfg = getattr(hf_config, "mtp", {}) or {}
+                n_predict = mtp_cfg.get("num_nextn_predict_layers", 0) if isinstance(mtp_cfg, dict) else 0
+                if n_predict > 0:
+                    use_repeated_layer = bool(mtp_cfg.get("use_repeated_layer", False))
+                    if n_predict > 1 and not use_repeated_layer:
+                        raise ValueError(
+                            f"NeMo SpeechLM MTP with {n_predict} distinct head layers is not "
+                            f"supported: vLLM's NemotronHMultiTokenPredictor builds a single "
+                            f"physical MTP layer and reuses it every speculative step. Only "
+                            f"checkpoints trained with mtp.use_repeated_layer=true match that "
+                            f"execution model."
+                        )
+                    hf_config.model_type = "nemo_speechlm_mtp"
+                    hf_config.update(
+                        {
+                            # Draft-able tokens per target step: SpeculativeConfig caps/validates
+                            # num_speculative_tokens against this.
+                            "n_predict": n_predict,
+                            # Physical MTP layers to instantiate. Repeated-layer checkpoints ship
+                            # one shared layer (mtp.layers.0.*) that is reapplied every step, which
+                            # is exactly how the vLLM proposer drives an MTP draft. This also
+                            # shadows the backbone text_config's num_nextn_predict_layers (e.g. 4),
+                            # which would otherwise trip the single-layer assert in
+                            # NemotronHMultiTokenPredictor.
+                            "num_nextn_predict_layers": 1,
+                            "architectures": ["NeMoSpeechLMMTPModel"],
+                        }
+                    )
+                    return hf_config
+            return original_override(hf_config)
+
+        _patched_override._nemo_speechlm_mtp_override = True
+        SpeculativeConfig.hf_config_override = staticmethod(_patched_override)
+
+    # 3 ── Register NeMoSpeechLMMTPModel ----------------------------------
+    from vllm.model_executor.models.registry import ModelRegistry
+
+    ModelRegistry.register_model(
+        "NeMoSpeechLMMTPModel",
+        f"{_PKG}.mtp:NeMoSpeechLMMTP",
+    )
+
+
 def register():
     """Register the NeMo Speech LM model and config with vLLM."""
     from transformers import AutoConfig
@@ -44,3 +122,5 @@ def register():
         "NeMoSpeechLMForConditionalGeneration",
         f"{_PKG}.model:NeMoSpeechLMForConditionalGeneration",
     )
+
+    _patch_vllm_for_nemo_speechlm_mtp()

--- a/nemo/collections/speechlm2/vllm/salm/__init__.py
+++ b/nemo/collections/speechlm2/vllm/salm/__init__.py
@@ -76,9 +76,11 @@ def _patch_vllm_for_nemo_speechlm_mtp() -> None:
                     hf_config.model_type = "nemo_speechlm_mtp"
                     hf_config.update(
                         {
-                            # Draft-able tokens per target step: SpeculativeConfig caps/validates
-                            # num_speculative_tokens against this.
-                            "n_predict": n_predict,
+                            # Size of the physical MTP block that vLLM reuses. A
+                            # repeated-layer checkpoint ships one shared head even
+                            # when it was trained for multiple next-token positions,
+                            # so arbitrary inference K values must be multiples of 1.
+                            "n_predict": 1 if use_repeated_layer else n_predict,
                             # Physical MTP layers to instantiate. Repeated-layer checkpoints ship
                             # one shared layer (mtp.layers.0.*) that is reapplied every step, which
                             # is exactly how the vLLM proposer drives an MTP draft. This also

--- a/nemo/collections/speechlm2/vllm/salm/__init__.py
+++ b/nemo/collections/speechlm2/vllm/salm/__init__.py
@@ -24,6 +24,74 @@ Backbone-specific behavior is selected at instantiation time.
 """
 
 _PKG = "nemo.collections.speechlm2.vllm.salm"
+_ORIGINAL_VLLM_HF_CONFIG_OVERRIDE = None
+
+
+def _nemo_speechlm_mtp_hf_config_override(hf_config):
+    """Apply the SpeechLM MTP rewrite, then defer unrelated configs to vLLM.
+
+    This function must remain at module scope: vLLM retains it on the draft
+    ``ModelConfig``, which can cross a spawned process boundary. The original
+    vLLM callable stays in process-local module state because binding the
+    replaced static method inside a ``partial`` also makes that method
+    unresolvable by standard pickle.
+    """
+    if hf_config.model_type == "nemo_speechlm":
+        mtp_cfg = getattr(hf_config, "mtp", None)
+        if not isinstance(mtp_cfg, dict):
+            mtp_cfg = {}
+        # Match SALMAutomodel's training defaults exactly: merely retaining a
+        # recipe depth does not enable MTP, while an enabled block with no
+        # explicit depth constructs one logical head.
+        mtp_enabled = bool(mtp_cfg.get("enabled", False))
+        n_predict = mtp_cfg.get("num_nextn_predict_layers", 1 if mtp_enabled else 0)
+        if mtp_enabled and n_predict > 0:
+            use_repeated_layer = bool(mtp_cfg.get("use_repeated_layer", False))
+            if n_predict > 1 and not use_repeated_layer:
+                raise ValueError(
+                    f"NeMo SpeechLM MTP with {n_predict} distinct head layers is not "
+                    f"supported: vLLM's NemotronHMultiTokenPredictor builds a single "
+                    f"physical MTP layer and reuses it every speculative step. Only "
+                    f"checkpoints trained with mtp.use_repeated_layer=true match that "
+                    f"execution model."
+                )
+            hf_config.model_type = "nemo_speechlm_mtp"
+            hf_config.update(
+                {
+                    # Size of the physical MTP block that vLLM reuses. A
+                    # repeated-layer checkpoint ships one shared head even
+                    # when it was trained for multiple next-token positions,
+                    # so arbitrary inference K values must be multiples of 1.
+                    # Consequently vLLM defaults to K=1 when K is omitted;
+                    # callers should set num_speculative_tokens explicitly.
+                    "n_predict": 1,
+                    # Physical MTP prediction steps to instantiate. Repeated-layer checkpoints
+                    # ship one shared step (one mtp.layers.* module per hybrid-pattern character)
+                    # that is reapplied every speculative iteration, exactly as vLLM drives its
+                    # MTP draft. This also shadows the backbone text_config's
+                    # num_nextn_predict_layers (e.g. 4), which would otherwise trip the
+                    # single-step assert in NemotronHMultiTokenPredictor.
+                    "num_nextn_predict_layers": 1,
+                    "architectures": ["NeMoSpeechLMMTPModel"],
+                }
+            )
+            return hf_config
+
+    global _ORIGINAL_VLLM_HF_CONFIG_OVERRIDE
+    if _ORIGINAL_VLLM_HF_CONFIG_OVERRIDE is None:
+        # A spawn child can import this module while unpickling the function
+        # without running the vLLM plugin hook first. In that case the class
+        # still exposes its native override, which is safe to capture lazily.
+        from vllm.config.speculative import SpeculativeConfig
+
+        current_override = SpeculativeConfig.hf_config_override
+        if current_override is _nemo_speechlm_mtp_hf_config_override:
+            raise RuntimeError("NeMo SpeechLM MTP override was installed without preserving vLLM's original hook.")
+        _ORIGINAL_VLLM_HF_CONFIG_OVERRIDE = current_override
+    return _ORIGINAL_VLLM_HF_CONFIG_OVERRIDE(hf_config)
+
+
+_nemo_speechlm_mtp_hf_config_override._nemo_speechlm_mtp_override = True
 
 
 def _patch_vllm_for_nemo_speechlm_mtp() -> None:
@@ -57,53 +125,13 @@ def _patch_vllm_for_nemo_speechlm_mtp() -> None:
     # Route SpeechLM MTP checkpoints through SpeculativeConfig.hf_config_override.
     current_override = SpeculativeConfig.hf_config_override
     if not getattr(current_override, "_nemo_speechlm_mtp_override", False):
-        original_override = current_override
-
-        def _patched_override(hf_config):
-            if hf_config.model_type == "nemo_speechlm":
-                mtp_cfg = getattr(hf_config, "mtp", None)
-                if not isinstance(mtp_cfg, dict):
-                    mtp_cfg = {}
-                # Match SALMAutomodel's training defaults exactly: merely
-                # retaining a recipe depth does not enable MTP, while an enabled
-                # block with no explicit depth constructs one logical head.
-                mtp_enabled = bool(mtp_cfg.get("enabled", False))
-                n_predict = mtp_cfg.get("num_nextn_predict_layers", 1 if mtp_enabled else 0)
-                if mtp_enabled and n_predict > 0:
-                    use_repeated_layer = bool(mtp_cfg.get("use_repeated_layer", False))
-                    if n_predict > 1 and not use_repeated_layer:
-                        raise ValueError(
-                            f"NeMo SpeechLM MTP with {n_predict} distinct head layers is not "
-                            f"supported: vLLM's NemotronHMultiTokenPredictor builds a single "
-                            f"physical MTP layer and reuses it every speculative step. Only "
-                            f"checkpoints trained with mtp.use_repeated_layer=true match that "
-                            f"execution model."
-                        )
-                    hf_config.model_type = "nemo_speechlm_mtp"
-                    hf_config.update(
-                        {
-                            # Size of the physical MTP block that vLLM reuses. A
-                            # repeated-layer checkpoint ships one shared head even
-                            # when it was trained for multiple next-token positions,
-                            # so arbitrary inference K values must be multiples of 1.
-                            # Consequently vLLM defaults to K=1 when K is omitted;
-                            # callers should set num_speculative_tokens explicitly.
-                            "n_predict": 1,
-                            # Physical MTP prediction steps to instantiate. Repeated-layer checkpoints
-                            # ship one shared step (one mtp.layers.* module per hybrid-pattern character)
-                            # that is reapplied every speculative iteration, exactly as vLLM drives its
-                            # MTP draft. This also shadows the backbone text_config's
-                            # num_nextn_predict_layers (e.g. 4), which would otherwise trip the
-                            # single-step assert in NemotronHMultiTokenPredictor.
-                            "num_nextn_predict_layers": 1,
-                            "architectures": ["NeMoSpeechLMMTPModel"],
-                        }
-                    )
-                    return hf_config
-            return original_override(hf_config)
-
-        _patched_override._nemo_speechlm_mtp_override = True
-        SpeculativeConfig.hf_config_override = staticmethod(_patched_override)
+        global _ORIGINAL_VLLM_HF_CONFIG_OVERRIDE
+        # Preserve the first native hook for the lifetime of this process.
+        # Replacing it during a later registration could capture a third-party
+        # wrapper that already delegates to us, creating an override cycle.
+        if _ORIGINAL_VLLM_HF_CONFIG_OVERRIDE is None:
+            _ORIGINAL_VLLM_HF_CONFIG_OVERRIDE = current_override
+        SpeculativeConfig.hf_config_override = staticmethod(_nemo_speechlm_mtp_hf_config_override)
 
     # Register the SpeechLM MTP draft architecture with vLLM.
     from vllm.model_executor.models.registry import ModelRegistry

--- a/nemo/collections/speechlm2/vllm/salm/__init__.py
+++ b/nemo/collections/speechlm2/vllm/salm/__init__.py
@@ -23,17 +23,13 @@ decoder-only LLMs like Qwen3, hybrid Mamba+MoE like NemotronH).
 Backbone-specific behavior is selected at instantiation time.
 """
 
-import logging
-
 _PKG = "nemo.collections.speechlm2.vllm.salm"
-_LOG = logging.getLogger(__name__)
 
 
 def _patch_vllm_for_nemo_speechlm_mtp() -> None:
     """Extend vLLM's speculative-decoding framework to support nemo_speechlm MTP.
 
-    Releases without ``MTPModelTypes`` return without patching so the ordinary
-    SpeechLM target model remains usable. Otherwise, three patches are applied:
+    Three patches are applied on the supported vLLM 0.19+ releases:
 
     1. ``MTPModelTypes`` — the Literal type that guards the MTP detection
        branch in ``SpeculativeConfig.__post_init__`` is extended to include
@@ -52,17 +48,6 @@ def _patch_vllm_for_nemo_speechlm_mtp() -> None:
 
     import vllm.config.speculative as _spec_mod
     from vllm.config.speculative import SpeculativeConfig
-
-    # MTP support was added incrementally across vLLM releases. Keep the
-    # ordinary SpeechLM target-model plugin usable on releases that do not yet
-    # expose this type guard; speculative decoding will remain unavailable and
-    # vLLM will report that if the user tries to enable it.
-    if not hasattr(_spec_mod, "MTPModelTypes"):
-        _LOG.warning(
-            "This vLLM release does not expose MTPModelTypes; NeMo SpeechLM "
-            "will be registered without MTP speculative-decoding support."
-        )
-        return
 
     # Extend vLLM's recognized MTP model types.
     old_args = get_args(_spec_mod.MTPModelTypes)

--- a/nemo/collections/speechlm2/vllm/salm/__init__.py
+++ b/nemo/collections/speechlm2/vllm/salm/__init__.py
@@ -23,13 +23,17 @@ decoder-only LLMs like Qwen3, hybrid Mamba+MoE like NemotronH).
 Backbone-specific behavior is selected at instantiation time.
 """
 
+import logging
+
 _PKG = "nemo.collections.speechlm2.vllm.salm"
+_LOG = logging.getLogger(__name__)
 
 
 def _patch_vllm_for_nemo_speechlm_mtp() -> None:
     """Extend vLLM's speculative-decoding framework to support nemo_speechlm MTP.
 
-    Three patches are applied:
+    Releases without ``MTPModelTypes`` return without patching so the ordinary
+    SpeechLM target model remains usable. Otherwise, three patches are applied:
 
     1. ``MTPModelTypes`` — the Literal type that guards the MTP detection
        branch in ``SpeculativeConfig.__post_init__`` is extended to include
@@ -49,6 +53,17 @@ def _patch_vllm_for_nemo_speechlm_mtp() -> None:
     import vllm.config.speculative as _spec_mod
     from vllm.config.speculative import SpeculativeConfig
 
+    # MTP support was added incrementally across vLLM releases. Keep the
+    # ordinary SpeechLM target-model plugin usable on releases that do not yet
+    # expose this type guard; speculative decoding will remain unavailable and
+    # vLLM will report that if the user tries to enable it.
+    if not hasattr(_spec_mod, "MTPModelTypes"):
+        _LOG.warning(
+            "This vLLM release does not expose MTPModelTypes; NeMo SpeechLM "
+            "will be registered without MTP speculative-decoding support."
+        )
+        return
+
     # Extend vLLM's recognized MTP model types.
     old_args = get_args(_spec_mod.MTPModelTypes)
     if "nemo_speechlm_mtp" not in old_args:
@@ -64,8 +79,12 @@ def _patch_vllm_for_nemo_speechlm_mtp() -> None:
                 mtp_cfg = getattr(hf_config, "mtp", None)
                 if not isinstance(mtp_cfg, dict):
                     mtp_cfg = {}
-                n_predict = mtp_cfg.get("num_nextn_predict_layers", 0)
-                if n_predict > 0:
+                # Match SALMAutomodel's training defaults exactly: merely
+                # retaining a recipe depth does not enable MTP, while an enabled
+                # block with no explicit depth constructs one logical head.
+                mtp_enabled = bool(mtp_cfg.get("enabled", False))
+                n_predict = mtp_cfg.get("num_nextn_predict_layers", 1 if mtp_enabled else 0)
+                if mtp_enabled and n_predict > 0:
                     use_repeated_layer = bool(mtp_cfg.get("use_repeated_layer", False))
                     if n_predict > 1 and not use_repeated_layer:
                         raise ValueError(
@@ -82,13 +101,15 @@ def _patch_vllm_for_nemo_speechlm_mtp() -> None:
                             # repeated-layer checkpoint ships one shared head even
                             # when it was trained for multiple next-token positions,
                             # so arbitrary inference K values must be multiples of 1.
-                            "n_predict": 1 if use_repeated_layer else n_predict,
-                            # Physical MTP layers to instantiate. Repeated-layer checkpoints ship
-                            # one shared layer (mtp.layers.0.*) that is reapplied every step, which
-                            # is exactly how the vLLM proposer drives an MTP draft. This also
-                            # shadows the backbone text_config's num_nextn_predict_layers (e.g. 4),
-                            # which would otherwise trip the single-layer assert in
-                            # NemotronHMultiTokenPredictor.
+                            # Consequently vLLM defaults to K=1 when K is omitted;
+                            # callers should set num_speculative_tokens explicitly.
+                            "n_predict": 1,
+                            # Physical MTP prediction steps to instantiate. Repeated-layer checkpoints
+                            # ship one shared step (one mtp.layers.* module per hybrid-pattern character)
+                            # that is reapplied every speculative iteration, exactly as vLLM drives its
+                            # MTP draft. This also shadows the backbone text_config's
+                            # num_nextn_predict_layers (e.g. 4), which would otherwise trip the
+                            # single-step assert in NemotronHMultiTokenPredictor.
                             "num_nextn_predict_layers": 1,
                             "architectures": ["NeMoSpeechLMMTPModel"],
                         }

--- a/nemo/collections/speechlm2/vllm/salm/audio.py
+++ b/nemo/collections/speechlm2/vllm/salm/audio.py
@@ -82,9 +82,12 @@ _MIN_CHUNK_SIZE_SAMPLES = 320
 
 
 def _ensure_special_tokens(tokenizer: PreTrainedTokenizerBase) -> None:
-    special = [_AUDIO_PLACEHOLDER]
-    existing = set(tokenizer.get_vocab().keys())
-    to_add = [t for t in special if t not in existing]
+    # NOTE: called per request from _call_hf_processor on the API-server event loop.
+    # Use O(1) dict membership; `set(get_vocab().keys())` rebuilt a 131k-entry set
+    # every request (~5-6 ms) purely to check one token. get_vocab() returns vLLM's
+    # cached dict, so membership is O(1).
+    vocab = tokenizer.get_vocab()
+    to_add = [t for t in (_AUDIO_PLACEHOLDER,) if t not in vocab]
     if to_add:
         tokenizer.add_special_tokens({"additional_special_tokens": to_add})
 

--- a/nemo/collections/speechlm2/vllm/salm/config.py
+++ b/nemo/collections/speechlm2/vllm/salm/config.py
@@ -176,13 +176,12 @@ class NeMoSpeechLMConfig(PretrainedConfig):
             if num_layers > 0:
                 self.text_config.layer_types = ["attention"] * num_layers
 
-        self.text_config.vocab_size += _SPEECHLM_EMBED_EXTRA_ROWS
-
         # vLLM's MTP llm_base_proposer reads image_token_index from the target
         # model's config to locate multimodal placeholder positions during
         # speculative decoding. For SpeechLM the <|audio|> token is the first
         # extra row added above the base backbone vocab.
-        self.image_token_index = self.text_config.vocab_size - _SPEECHLM_EMBED_EXTRA_ROWS
+        self.image_token_index = self.text_config.vocab_size
+        self.text_config.vocab_size += _SPEECHLM_EMBED_EXTRA_ROWS
 
     @property
     def llm_architectures(self) -> list[str]:

--- a/nemo/collections/speechlm2/vllm/salm/config.py
+++ b/nemo/collections/speechlm2/vllm/salm/config.py
@@ -178,6 +178,12 @@ class NeMoSpeechLMConfig(PretrainedConfig):
 
         self.text_config.vocab_size += _SPEECHLM_EMBED_EXTRA_ROWS
 
+        # vLLM's MTP llm_base_proposer reads image_token_index from the target
+        # model's config to locate multimodal placeholder positions during
+        # speculative decoding. For SpeechLM the <|audio|> token is the first
+        # extra row added above the base backbone vocab.
+        self.image_token_index = self.text_config.vocab_size - _SPEECHLM_EMBED_EXTRA_ROWS
+
     @property
     def llm_architectures(self) -> list[str]:
         """Return the LLM backbone architectures list."""
@@ -185,6 +191,16 @@ class NeMoSpeechLMConfig(PretrainedConfig):
 
     def get_text_config(self, decoder=False) -> PretrainedConfig:
         return self.text_config
+
+    @property
+    def mtp_hybrid_override_pattern(self) -> str:
+        """Hybrid layer pattern for MTP heads, consumed by NemotronHMultiTokenPredictor.
+
+        Reads from the ``mtp.hybrid_override_pattern`` field in config.json.
+        '*' means all-attention; 'M' means all-Mamba2.
+        """
+        mtp_cfg = self.__dict__.get("mtp") or {}
+        return mtp_cfg.get("hybrid_override_pattern", "*") if isinstance(mtp_cfg, dict) else "*"
 
     _ATTR_ALIASES = {
         "rms_norm_eps": "layer_norm_epsilon",

--- a/nemo/collections/speechlm2/vllm/salm/config.py
+++ b/nemo/collections/speechlm2/vllm/salm/config.py
@@ -39,10 +39,10 @@ _HYBRID_ARCHITECTURES = frozenset(
 # silently rendering the wrong placeholder at request time.
 _AUDIO_PLACEHOLDER = "<|audio|>"
 
-# Number of extra embedding rows the SpeechLM adds on top of the backbone's
-# native vocab during training for special tokens and alignment. New exports
-# record the exact ``<|audio|>`` token ID; legacy exports placed it in the first
-# extra row and fall back to the base vocabulary size.
+# Historical serving-time headroom above the backbone vocabulary. vLLM builds
+# the target and draft embedding tables at this padded size, and the weight
+# loader zero-pads the smaller training tensors to match. ``<|audio|>`` is the
+# first padded ID; the remaining rows are unused.
 _SPEECHLM_EMBED_EXTRA_ROWS = 10
 
 
@@ -74,8 +74,6 @@ class NeMoSpeechLMConfig(PretrainedConfig):
         pretrained_llm: str | None = None,
         pretrained_asr: str | None = None,
         audio_locator_tag: str | None = None,
-        audio_token_index: int | None = None,
-        image_token_index: int | None = None,
         prompt_format: str | None = None,
         pretrained_weights: bool | None = None,
         lora: dict | None = None,
@@ -93,8 +91,6 @@ class NeMoSpeechLMConfig(PretrainedConfig):
             perception is None
             and lora is None
             and encoder_chunk_size_seconds is None
-            and audio_token_index is None
-            and image_token_index is None
             and not kwargs
             and all(value is None for value in required_fields.values())
         )
@@ -116,7 +112,6 @@ class NeMoSpeechLMConfig(PretrainedConfig):
             self.pretrained_llm = None
             self.pretrained_asr = None
             self.audio_locator_tag = None
-            self.audio_token_index = None
             self.prompt_format = None
             self.pretrained_weights = None
             self.lora = None
@@ -182,31 +177,7 @@ class NeMoSpeechLMConfig(PretrainedConfig):
             if num_layers > 0:
                 self.text_config.layer_types = ["attention"] * num_layers
 
-        # New exports persist the exact audio placeholder ID under the
-        # modality-correct name. Accept the historical vLLM field for
-        # compatibility, and keep the base-vocab fallback for older NeMo
-        # checkpoints that persisted neither field and appended <|audio|>
-        # immediately after the backbone vocabulary.
-        base_vocab_size = int(self.text_config.vocab_size)
-        if audio_token_index is not None and image_token_index is not None and audio_token_index != image_token_index:
-            raise ValueError(
-                f"audio_token_index={audio_token_index} conflicts with legacy "
-                f"image_token_index={image_token_index}."
-            )
-        if audio_token_index is None:
-            audio_token_index = image_token_index
-        if audio_token_index is None:
-            audio_token_index = base_vocab_size
-        if isinstance(audio_token_index, bool) or not isinstance(audio_token_index, int):
-            raise ValueError(f"audio_token_index must be an integer, got {audio_token_index!r}.")
-        padded_vocab_size = base_vocab_size + _SPEECHLM_EMBED_EXTRA_ROWS
-        if not 0 <= audio_token_index < padded_vocab_size:
-            raise ValueError(
-                f"audio_token_index={audio_token_index} is outside the SpeechLM embedding table "
-                f"with {padded_vocab_size} rows."
-            )
-        self.audio_token_index = audio_token_index
-        self.text_config.vocab_size = padded_vocab_size
+        self.text_config.vocab_size += _SPEECHLM_EMBED_EXTRA_ROWS
 
     @property
     def llm_architectures(self) -> list[str]:
@@ -218,8 +189,23 @@ class NeMoSpeechLMConfig(PretrainedConfig):
 
     @property
     def image_token_index(self) -> int | None:
-        """Compatibility alias required by vLLM's EAGLE/MTP proposer."""
-        return self.audio_token_index
+        """Return the audio placeholder ID expected by vLLM 0.26's MTP proposer.
+
+        SpeechLM training appends ``<|audio|>`` directly after the backbone
+        vocabulary. The vision-era vLLM proposer calls this field
+        ``image_token_index`` even for an audio multimodal target.
+        """
+        vocab_size = getattr(self.text_config, "vocab_size", None)
+        if vocab_size is None:
+            return None
+        return int(vocab_size) - _SPEECHLM_EMBED_EXTRA_ROWS
+
+    @image_token_index.setter
+    def image_token_index(self, value: int | None) -> None:
+        """Accept vLLM's runtime target-to-draft copy without serializing it."""
+        expected = self.image_token_index
+        if expected is not None and value != expected:
+            raise ValueError(f"image_token_index={value!r} does not match the backbone vocabulary size {expected}.")
 
     @property
     def mtp_hybrid_override_pattern(self) -> str:
@@ -258,7 +244,6 @@ class NeMoSpeechLMConfig(PretrainedConfig):
             "pretrained_llm",
             "pretrained_asr",
             "audio_locator_tag",
-            "audio_token_index",
             "image_token_index",
             "prompt_format",
             "pretrained_weights",

--- a/nemo/collections/speechlm2/vllm/salm/config.py
+++ b/nemo/collections/speechlm2/vllm/salm/config.py
@@ -40,8 +40,9 @@ _HYBRID_ARCHITECTURES = frozenset(
 _AUDIO_PLACEHOLDER = "<|audio|>"
 
 # Number of extra embedding rows the SpeechLM adds on top of the backbone's
-# native vocab during training: ``<|audio|>`` locator plus headroom for other
-# special tokens and TensorCore-friendly alignment.
+# native vocab during training for special tokens and alignment. New exports
+# record the exact ``<|audio|>`` token ID; legacy exports placed it in the first
+# extra row and fall back to the base vocabulary size.
 _SPEECHLM_EMBED_EXTRA_ROWS = 10
 
 
@@ -73,6 +74,8 @@ class NeMoSpeechLMConfig(PretrainedConfig):
         pretrained_llm: str | None = None,
         pretrained_asr: str | None = None,
         audio_locator_tag: str | None = None,
+        audio_token_index: int | None = None,
+        image_token_index: int | None = None,
         prompt_format: str | None = None,
         pretrained_weights: bool | None = None,
         lora: dict | None = None,
@@ -90,6 +93,8 @@ class NeMoSpeechLMConfig(PretrainedConfig):
             perception is None
             and lora is None
             and encoder_chunk_size_seconds is None
+            and audio_token_index is None
+            and image_token_index is None
             and not kwargs
             and all(value is None for value in required_fields.values())
         )
@@ -111,6 +116,7 @@ class NeMoSpeechLMConfig(PretrainedConfig):
             self.pretrained_llm = None
             self.pretrained_asr = None
             self.audio_locator_tag = None
+            self.audio_token_index = None
             self.prompt_format = None
             self.pretrained_weights = None
             self.lora = None
@@ -176,12 +182,31 @@ class NeMoSpeechLMConfig(PretrainedConfig):
             if num_layers > 0:
                 self.text_config.layer_types = ["attention"] * num_layers
 
-        # vLLM's MTP llm_base_proposer reads image_token_index from the target
-        # model's config to locate multimodal placeholder positions during
-        # speculative decoding. For SpeechLM the <|audio|> token is the first
-        # extra row added above the base backbone vocab.
-        self.image_token_index = self.text_config.vocab_size
-        self.text_config.vocab_size += _SPEECHLM_EMBED_EXTRA_ROWS
+        # New exports persist the exact audio placeholder ID under the
+        # modality-correct name. Accept the historical vLLM field for
+        # compatibility, and keep the base-vocab fallback for older NeMo
+        # checkpoints that persisted neither field and appended <|audio|>
+        # immediately after the backbone vocabulary.
+        base_vocab_size = int(self.text_config.vocab_size)
+        if audio_token_index is not None and image_token_index is not None and audio_token_index != image_token_index:
+            raise ValueError(
+                f"audio_token_index={audio_token_index} conflicts with legacy "
+                f"image_token_index={image_token_index}."
+            )
+        if audio_token_index is None:
+            audio_token_index = image_token_index
+        if audio_token_index is None:
+            audio_token_index = base_vocab_size
+        if isinstance(audio_token_index, bool) or not isinstance(audio_token_index, int):
+            raise ValueError(f"audio_token_index must be an integer, got {audio_token_index!r}.")
+        padded_vocab_size = base_vocab_size + _SPEECHLM_EMBED_EXTRA_ROWS
+        if not 0 <= audio_token_index < padded_vocab_size:
+            raise ValueError(
+                f"audio_token_index={audio_token_index} is outside the SpeechLM embedding table "
+                f"with {padded_vocab_size} rows."
+            )
+        self.audio_token_index = audio_token_index
+        self.text_config.vocab_size = padded_vocab_size
 
     @property
     def llm_architectures(self) -> list[str]:
@@ -190,6 +215,11 @@ class NeMoSpeechLMConfig(PretrainedConfig):
 
     def get_text_config(self, decoder=False) -> PretrainedConfig:
         return self.text_config
+
+    @property
+    def image_token_index(self) -> int | None:
+        """Compatibility alias required by vLLM's EAGLE/MTP proposer."""
+        return self.audio_token_index
 
     @property
     def mtp_hybrid_override_pattern(self) -> str:
@@ -228,6 +258,8 @@ class NeMoSpeechLMConfig(PretrainedConfig):
             "pretrained_llm",
             "pretrained_asr",
             "audio_locator_tag",
+            "audio_token_index",
+            "image_token_index",
             "prompt_format",
             "pretrained_weights",
             "text_config",

--- a/nemo/collections/speechlm2/vllm/salm/config.py
+++ b/nemo/collections/speechlm2/vllm/salm/config.py
@@ -41,8 +41,8 @@ _AUDIO_PLACEHOLDER = "<|audio|>"
 
 # Historical serving-time headroom above the backbone vocabulary. vLLM builds
 # the target and draft embedding tables at this padded size, and the weight
-# loader zero-pads the smaller training tensors to match. ``<|audio|>`` is the
-# first padded ID; the remaining rows are unused.
+# loader zero-pads the smaller training tensors to match. The tokenizer's
+# actual audio-token ID is validated against this bound during export.
 _SPEECHLM_EMBED_EXTRA_ROWS = 10
 
 
@@ -101,6 +101,7 @@ class NeMoSpeechLMConfig(PretrainedConfig):
         # path; real checkpoint loads replace it below after field validation.
         self.text_config = PretrainedConfig()
         self.is_hybrid = False
+        self._pending_image_token_index = None
 
         super().__init__(**kwargs)
 
@@ -116,6 +117,7 @@ class NeMoSpeechLMConfig(PretrainedConfig):
             self.pretrained_weights = None
             self.lora = None
             self.encoder_chunk_size_seconds = None
+            self.__dict__.pop("_pending_image_token_index", None)
             return
 
         for name, value in required_fields.items():
@@ -178,6 +180,13 @@ class NeMoSpeechLMConfig(PretrainedConfig):
                 self.text_config.layer_types = ["attention"] * num_layers
 
         self.text_config.vocab_size += _SPEECHLM_EMBED_EXTRA_ROWS
+        pending_image_token_index = self.__dict__.pop("_pending_image_token_index", None)
+        if pending_image_token_index is not None and pending_image_token_index != self.image_token_index:
+            raise ValueError(
+                f"image_token_index={pending_image_token_index!r} does not match the backbone vocabulary "
+                f"boundary {self.image_token_index}. Remove this legacy serialized field; SpeechLM derives "
+                f"the vLLM compatibility value at runtime."
+            )
 
     @property
     def llm_architectures(self) -> list[str]:
@@ -189,11 +198,11 @@ class NeMoSpeechLMConfig(PretrainedConfig):
 
     @property
     def image_token_index(self) -> int | None:
-        """Return the audio placeholder ID expected by vLLM 0.26's MTP proposer.
+        """Return the vocabulary-boundary value expected by vLLM's MTP proposer.
 
-        SpeechLM training appends ``<|audio|>`` directly after the backbone
-        vocabulary. The vision-era vLLM proposer calls this field
-        ``image_token_index`` even for an audio multimodal target.
+        vLLM calls this compatibility field ``image_token_index`` even for an
+        audio multimodal target. Actual audio locations come from vLLM's
+        placeholder ranges; no token-index field is serialized by SpeechLM.
         """
         vocab_size = getattr(self.text_config, "vocab_size", None)
         if vocab_size is None:
@@ -204,8 +213,16 @@ class NeMoSpeechLMConfig(PretrainedConfig):
     def image_token_index(self, value: int | None) -> None:
         """Accept vLLM's runtime target-to-draft copy without serializing it."""
         expected = self.image_token_index
-        if expected is not None and value != expected:
-            raise ValueError(f"image_token_index={value!r} does not match the backbone vocabulary size {expected}.")
+        if expected is None:
+            # Transformers applies unknown config kwargs in its base-class
+            # constructor, before this wrapper has loaded the real backbone.
+            # Defer validation and discard the temporary value afterwards so
+            # it never becomes serialized state.
+            self._pending_image_token_index = value
+        elif value is not None and value != expected:
+            raise ValueError(
+                f"image_token_index={value!r} does not match the backbone vocabulary boundary {expected}."
+            )
 
     @property
     def mtp_hybrid_override_pattern(self) -> str:

--- a/nemo/collections/speechlm2/vllm/salm/config.py
+++ b/nemo/collections/speechlm2/vllm/salm/config.py
@@ -74,6 +74,7 @@ class NeMoSpeechLMConfig(PretrainedConfig):
         self,
         perception: dict | None = None,
         pretrained_llm: str | None = None,
+        llm_config: dict | None = None,
         pretrained_asr: str | None = None,
         audio_locator_tag: str | None = None,
         prompt_format: str | None = None,
@@ -113,6 +114,7 @@ class NeMoSpeechLMConfig(PretrainedConfig):
             # path inert; real checkpoint loads continue through validation below.
             self.perception = {}
             self.pretrained_llm = None
+            self.llm_config = None
             self.pretrained_asr = None
             self.audio_locator_tag = None
             self.prompt_format = None
@@ -140,6 +142,7 @@ class NeMoSpeechLMConfig(PretrainedConfig):
             )
         self.perception = perception or {}
         self.pretrained_llm = pretrained_llm
+        self.llm_config = llm_config
         self.pretrained_asr = pretrained_asr
         self.audio_locator_tag = audio_locator_tag
         self.prompt_format = prompt_format
@@ -147,7 +150,16 @@ class NeMoSpeechLMConfig(PretrainedConfig):
         self.lora = lora
         self.encoder_chunk_size_seconds = encoder_chunk_size_seconds
 
-        self.text_config = AutoConfig.from_pretrained(pretrained_llm, trust_remote_code=True)
+        if llm_config is None:
+            self.text_config = AutoConfig.from_pretrained(pretrained_llm, trust_remote_code=True)
+        else:
+            if not isinstance(llm_config, dict):
+                raise ValueError(f"NeMo SpeechLM llm_config must be a dict, got {type(llm_config).__name__}.")
+            embedded_config = dict(llm_config)
+            model_type = embedded_config.pop("model_type", None)
+            if not model_type:
+                raise ValueError("NeMo SpeechLM llm_config must declare model_type.")
+            self.text_config = AutoConfig.for_model(model_type, **embedded_config)
 
         raw_archs = getattr(self.text_config, "architectures", [])
         if len(raw_archs) != 1:

--- a/nemo/collections/speechlm2/vllm/salm/config.py
+++ b/nemo/collections/speechlm2/vllm/salm/config.py
@@ -41,8 +41,10 @@ _AUDIO_PLACEHOLDER = "<|audio|>"
 
 # Historical serving-time headroom above the backbone vocabulary. vLLM builds
 # the target and draft embedding tables at this padded size, and the weight
-# loader zero-pads the smaller training tensors to match. The tokenizer's
-# actual audio-token ID is validated against this bound during export.
+# loader zero-pads the smaller training tensors to match. ``prepare_for_vllm``
+# validates the tokenizer's audio-token ID against this bound during export;
+# the default export flow treats a validation failure as non-fatal and leaves
+# an HF-only checkpoint.
 _SPEECHLM_EMBED_EXTRA_ROWS = 10
 
 
@@ -229,7 +231,9 @@ class NeMoSpeechLMConfig(PretrainedConfig):
         """Hybrid layer pattern for MTP heads, consumed by NemotronHMultiTokenPredictor.
 
         Reads from the ``mtp.hybrid_override_pattern`` field in config.json.
-        '*' means all-attention; 'M' means all-Mamba2.
+        vLLM supports any sequence of ``"*"`` (attention) and ``"E"`` (MoE),
+        with one physical MTP layer module instantiated per character. Other
+        characters are rejected by vLLM during model construction.
         """
         mtp_cfg = self.__dict__.get("mtp") or {}
         return mtp_cfg.get("hybrid_override_pattern", "*") if isinstance(mtp_cfg, dict) else "*"

--- a/nemo/collections/speechlm2/vllm/salm/model.py
+++ b/nemo/collections/speechlm2/vllm/salm/model.py
@@ -180,33 +180,6 @@ class NeMoSpeechLMForConditionalGeneration(
             return []
         return self._process_audio(audio_input)
 
-    def embed_input_ids(
-        self,
-        input_ids: torch.Tensor,
-        multimodal_embeddings: MultiModalEmbeddings | None = None,
-        *,
-        is_multimodal: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        """Embed token IDs and fuse audio embeddings at placeholder positions.
-
-        Required so that vLLM's MTP speculator probe
-        (``draft_model.embed_input_ids(ids, multimodal_embeddings=None)``)
-        succeeds and ``speculator.supports_mm_inputs`` stays True.
-        Without this method the probe raises AttributeError and the
-        speculator silently falls back to text-only draft mode.
-        """
-        inputs_embeds = self.language_model.embed_input_ids(input_ids)
-
-        if multimodal_embeddings is None or is_multimodal is None or not is_multimodal.any():
-            return inputs_embeds
-
-        # Concatenate per-audio embedding tensors and overwrite the audio
-        # placeholder token positions with the actual audio embeddings.
-        audio_embeds = torch.cat(list(multimodal_embeddings), dim=0)
-        inputs_embeds = inputs_embeds.clone()
-        inputs_embeds[is_multimodal] = audio_embeds.to(inputs_embeds.dtype)
-        return inputs_embeds
-
     # ── forward / logits ──
 
     def forward(

--- a/nemo/collections/speechlm2/vllm/salm/model.py
+++ b/nemo/collections/speechlm2/vllm/salm/model.py
@@ -224,6 +224,11 @@ class NeMoSpeechLMForConditionalGeneration(
                 perception[name[len("perception.") :]] = tensor
             elif name.startswith("llm.mtp."):
                 pass  # MTP draft-head weights; loaded by the speculative draft model, not here
+            elif name.startswith("mtp."):
+                raise ValueError(
+                    f"Unsupported bare MTP tensor {name!r}; NeMo SpeechLM exports must store draft weights "
+                    f"under the 'llm.mtp.*' namespace."
+                )
             else:
                 llm.append((name, tensor))
         return perception, llm

--- a/nemo/collections/speechlm2/vllm/salm/model.py
+++ b/nemo/collections/speechlm2/vllm/salm/model.py
@@ -180,6 +180,33 @@ class NeMoSpeechLMForConditionalGeneration(
             return []
         return self._process_audio(audio_input)
 
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Embed token IDs and fuse audio embeddings at placeholder positions.
+
+        Required so that vLLM's MTP speculator probe
+        (``draft_model.embed_input_ids(ids, multimodal_embeddings=None)``)
+        succeeds and ``speculator.supports_mm_inputs`` stays True.
+        Without this method the probe raises AttributeError and the
+        speculator silently falls back to text-only draft mode.
+        """
+        inputs_embeds = self.language_model.embed_input_ids(input_ids)
+
+        if multimodal_embeddings is None or is_multimodal is None or not is_multimodal.any():
+            return inputs_embeds
+
+        # Concatenate per-audio embedding tensors and overwrite the audio
+        # placeholder token positions with the actual audio embeddings.
+        audio_embeds = torch.cat(list(multimodal_embeddings), dim=0)
+        inputs_embeds = inputs_embeds.clone()
+        inputs_embeds[is_multimodal] = audio_embeds.to(inputs_embeds.dtype)
+        return inputs_embeds
+
     # ── forward / logits ──
 
     def forward(
@@ -222,6 +249,8 @@ class NeMoSpeechLMForConditionalGeneration(
                 continue
             if name.startswith("perception."):
                 perception[name[len("perception.") :]] = tensor
+            elif name.startswith("llm.mtp.") or name.startswith("mtp."):
+                pass  # MTP draft-head weights; loaded by the speculative draft model, not here
             else:
                 llm.append((name, tensor))
         return perception, llm

--- a/nemo/collections/speechlm2/vllm/salm/model.py
+++ b/nemo/collections/speechlm2/vllm/salm/model.py
@@ -222,7 +222,7 @@ class NeMoSpeechLMForConditionalGeneration(
                 continue
             if name.startswith("perception."):
                 perception[name[len("perception.") :]] = tensor
-            elif name.startswith("llm.mtp.") or name.startswith("mtp."):
+            elif name.startswith("llm.mtp."):
                 pass  # MTP draft-head weights; loaded by the speculative draft model, not here
             else:
                 llm.append((name, tensor))

--- a/nemo/collections/speechlm2/vllm/salm/mtp.py
+++ b/nemo/collections/speechlm2/vllm/salm/mtp.py
@@ -82,9 +82,10 @@ class NeMoSpeechLMMTP(NemotronHMTP):
     ) -> torch.Tensor:
         """Embed token IDs and merge audio embeddings at placeholder positions.
 
-        Mirrors ``NeMoSpeechLMForConditionalGeneration.embed_input_ids``. The
-        embedding table itself is shared from the target model by vLLM's MTP
-        framework, so text-token rows are identical to the target's.
+        The target model inherits this fusion from ``SupportsMultiModal``; the
+        draft must implement it itself because ``NemotronHMTP`` is not
+        multimodal. The embedding table is shared from the target by vLLM's
+        MTP framework, so text-token rows stay identical.
         """
         inputs_embeds = self.model.get_input_embeddings(input_ids)
 

--- a/nemo/collections/speechlm2/vllm/salm/mtp.py
+++ b/nemo/collections/speechlm2/vllm/salm/mtp.py
@@ -22,10 +22,10 @@ weights (including MTP layers) carry an ``llm.`` prefix:
     ──────────────────────     ────────────────────
     llm.mtp.layers.0.*    →    mtp.layers.0.*
     llm.lm_head.weight    →    lm_head.weight
-    llm.model.embed_*     →    (embeddings shared from target model)
+    llm.model.embed_*     →    backbone.embeddings.*
 
-Only the ``mtp.*`` and ``lm_head.*`` weights are loaded here; the
-embedding table is shared with the target model by vLLM's MTP framework.
+The embedding alias is required by vLLM's Nemotron-H MTP loader even though
+the proposer subsequently shares the table with the target model.
 """
 
 from collections.abc import Iterable
@@ -34,6 +34,26 @@ import torch
 from vllm.model_executor.models.nemotron_h_mtp import NemotronHMTP
 
 from nemo.collections.speechlm2.vllm.salm.audio import _pad_to_vocab_size
+
+
+def _remap_nemo_mtp_weights(
+    items: Iterable[tuple[str, torch.Tensor]], target_vocab: int | None = None
+) -> Iterable[tuple[str, torch.Tensor]]:
+    """Map exported NeMo SpeechLM names to ``NemotronHMTP`` aliases."""
+    for name, tensor in items:
+        if name.startswith("llm."):
+            name = name[len("llm.") :]
+
+        # NemotronHMTP.load_weights only admits embedding names containing
+        # ``embeddings`` and then maps this backbone alias to
+        # ``model.embed_tokens``. Passing model.embed_tokens through directly
+        # is silently skipped and DefaultModelLoader reports it uninitialized.
+        if name == "model.embed_tokens.weight":
+            name = "backbone.embeddings.weight"
+
+        if name in {"backbone.embeddings.weight", "lm_head.weight"} and target_vocab is not None:
+            tensor = _pad_to_vocab_size(tensor, target_vocab)
+        yield name, tensor
 
 
 class NeMoSpeechLMMTP(NemotronHMTP):
@@ -77,18 +97,10 @@ class NeMoSpeechLMMTP(NemotronHMTP):
         return inputs_embeds
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        lm_head_vocab = None
+        target_vocab = None
         for name, module in self.named_modules():
             if hasattr(module, "org_vocab_size") and "lm_head" in name:
-                lm_head_vocab = module.org_vocab_size
+                target_vocab = module.org_vocab_size
                 break
 
-        def _strip_llm_prefix(items):
-            for name, tensor in items:
-                if name.startswith("llm."):
-                    name = name[len("llm.") :]
-                if name == "lm_head.weight" and lm_head_vocab is not None:
-                    tensor = _pad_to_vocab_size(tensor, lm_head_vocab)
-                yield name, tensor
-
-        return super().load_weights(_strip_llm_prefix(weights))
+        return super().load_weights(_remap_nemo_mtp_weights(weights, target_vocab))

--- a/nemo/collections/speechlm2/vllm/salm/mtp.py
+++ b/nemo/collections/speechlm2/vllm/salm/mtp.py
@@ -32,7 +32,6 @@ from collections.abc import Iterable
 
 import torch
 from vllm.model_executor.models.nemotron_h_mtp import NemotronHMTP
-from vllm.sequence import IntermediateTensors
 
 from nemo.collections.speechlm2.vllm.salm.audio import _pad_to_vocab_size
 

--- a/nemo/collections/speechlm2/vllm/salm/mtp.py
+++ b/nemo/collections/speechlm2/vllm/salm/mtp.py
@@ -15,7 +15,7 @@
 """MTP speculative-decoding draft model for NeMo SpeechLM checkpoints.
 
 ``NeMoSpeechLMMTP`` wraps vLLM's ``NemotronHMTP`` and adapts the
-weight-loading step for the NeMo checkpoint layout where all LLM
+weight-loading step for the NeMo SpeechLM checkpoint layout where all LLM
 weights (including MTP layers) carry an ``llm.`` prefix:
 
     NeMo checkpoint            NemotronHMTP expects
@@ -33,16 +33,77 @@ from collections.abc import Iterable
 import torch
 from vllm.model_executor.models.nemotron_h_mtp import NemotronHMTP
 
+try:
+    from vllm.model_executor.models.utils import _merge_multimodal_embeddings as _vllm_merge_multimodal_embeddings
+except ImportError:  # pragma: no cover - exercised by monkeypatching the resolved helper
+    _vllm_merge_multimodal_embeddings = None
+
 from nemo.collections.speechlm2.vllm.salm.audio import _pad_to_vocab_size
 
 
+def _flatten_multimodal_embeddings(embeddings) -> torch.Tensor:
+    """Flatten vLLM-style nested embedding tensors on every dimension but the last."""
+    if isinstance(embeddings, torch.Tensor):
+        return embeddings.flatten(0, -2)
+    return torch.cat(tuple(_flatten_multimodal_embeddings(item) for item in embeddings))
+
+
+def _merge_multimodal_embeddings(
+    inputs_embeds: torch.Tensor,
+    multimodal_embeddings,
+    is_multimodal: torch.Tensor,
+) -> torch.Tensor:
+    """Use vLLM's merge helper when available, with a compatible fallback for older releases."""
+    if _vllm_merge_multimodal_embeddings is not None:
+        return _vllm_merge_multimodal_embeddings(inputs_embeds, multimodal_embeddings, is_multimodal)
+
+    mm_embeds_flat = _flatten_multimodal_embeddings(multimodal_embeddings)
+    try:
+        inputs_embeds[is_multimodal] = mm_embeds_flat.to(dtype=inputs_embeds.dtype)
+    except RuntimeError as error:
+        actual_tokens = len(mm_embeds_flat)
+        expected_tokens = is_multimodal.sum().item()
+        if actual_tokens != expected_tokens:
+            raise ValueError(
+                f"Attempted to assign {actual_tokens} multimodal tokens to {expected_tokens} placeholders"
+            ) from error
+        raise ValueError("Error during multimodal embedding index assignment") from error
+    return inputs_embeds
+
+
 def _remap_nemo_mtp_weights(
-    items: Iterable[tuple[str, torch.Tensor]], target_vocab: int | None = None
+    items: Iterable[tuple[str, torch.Tensor]],
+    target_vocab: int | None = None,
+    expected_layer_modules: int | None = None,
 ) -> Iterable[tuple[str, torch.Tensor]]:
-    """Map exported NeMo SpeechLM names to ``NemotronHMTP`` aliases."""
+    """Select and map exported SpeechLM draft weights to ``NemotronHMTP`` aliases.
+
+    ``expected_layer_modules`` is the number of sublayers instantiated for one
+    EAGLE prediction step (the hybrid pattern length), not the logical draft K.
+    Rejecting higher checkpoint indices prevents vLLM from silently dropping
+    weights from a distinct multi-head checkpoint routed as a repeated head.
+    Non-``llm.`` tensors (including perception weights) are intentionally
+    omitted because the target model loads them separately.
+    """
     for name, tensor in items:
-        if name.startswith("llm."):
-            name = name[len("llm.") :]
+        if not name.startswith("llm."):
+            continue
+        name = name[len("llm.") :]
+
+        parts = name.split(".")
+        if expected_layer_modules is not None and len(parts) > 2 and parts[:2] == ["mtp", "layers"]:
+            try:
+                layer_index = int(parts[2])
+            except ValueError:
+                layer_index = None
+            if layer_index is not None and layer_index >= expected_layer_modules:
+                raise ValueError(
+                    f"Checkpoint contains {name!r}, but the configured repeated MTP step instantiates "
+                    f"only {expected_layer_modules} hybrid-pattern layer module(s). This looks like a "
+                    f"distinct multi-head checkpoint or stale hybrid-pattern metadata. Verify that the "
+                    f"exported mtp.hybrid_override_pattern describes the built head; vLLM's NemotronH "
+                    f"MTP proposer can reuse only one EAGLE-style prediction step."
+                )
 
         # NemotronHMTP.load_weights only admits embedding names containing
         # ``embeddings`` and then maps this backbone alias to
@@ -61,7 +122,7 @@ class NeMoSpeechLMMTP(NemotronHMTP):
 
     Extends NemotronHMTP in two ways:
 
-    * ``load_weights`` strips the ``llm.`` prefix from checkpoint names.
+    * ``load_weights`` strips the NeMo SpeechLM ``llm.`` prefix from checkpoint names.
     * ``embed_input_ids`` fuses audio-feature embeddings into the token
       embeddings at placeholder positions, exactly like the target model.
       The MTP heads were trained on the same mixed text+audio embedding
@@ -89,19 +150,39 @@ class NeMoSpeechLMMTP(NemotronHMTP):
         """
         inputs_embeds = self.model.get_input_embeddings(input_ids)
 
-        if multimodal_embeddings is None or is_multimodal is None or not is_multimodal.any():
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
             return inputs_embeds
 
-        audio_embeds = torch.cat(list(multimodal_embeddings), dim=0)
-        inputs_embeds = inputs_embeds.clone()
-        inputs_embeds[is_multimodal] = audio_embeds.to(inputs_embeds.dtype)
-        return inputs_embeds
+        if is_multimodal is None:
+            raise ValueError("is_multimodal is required when multimodal_embeddings are provided.")
+
+        return _merge_multimodal_embeddings(
+            inputs_embeds=inputs_embeds,
+            multimodal_embeddings=multimodal_embeddings,
+            is_multimodal=is_multimodal,
+        )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        target_vocab = None
-        for name, module in self.named_modules():
-            if hasattr(module, "org_vocab_size") and "lm_head" in name:
-                target_vocab = module.org_vocab_size
-                break
+        """Load only the SALM-prefixed weights required by the reusable draft head."""
+        # NeMoSpeechLMConfig delegates this to the already padded text-config
+        # vocabulary used to construct NemotronHMTP. Reading config directly
+        # avoids coupling padding to vLLM's internal module names.
+        target_vocab = int(self.config.vocab_size)
+        if target_vocab <= 0:
+            raise ValueError(f"Draft model vocabulary size must be positive, got {target_vocab}.")
 
-        return super().load_weights(_remap_nemo_mtp_weights(weights, target_vocab))
+        # vLLM instantiates one physical module per character in the configured
+        # hybrid pattern. Derive the checkpoint bound from the serialized
+        # configuration instead of silently depending on a predictor-internal
+        # attribute that could drift between vLLM releases.
+        pattern = self.config.mtp_hybrid_override_pattern
+        if not isinstance(pattern, str) or not pattern:
+            raise ValueError(f"mtp_hybrid_override_pattern must be a non-empty string, got {pattern!r}.")
+        expected_layer_modules = len(pattern)
+        return super().load_weights(
+            _remap_nemo_mtp_weights(
+                weights,
+                target_vocab,
+                expected_layer_modules=expected_layer_modules,
+            )
+        )

--- a/nemo/collections/speechlm2/vllm/salm/mtp.py
+++ b/nemo/collections/speechlm2/vllm/salm/mtp.py
@@ -32,43 +32,9 @@ from collections.abc import Iterable
 
 import torch
 from vllm.model_executor.models.nemotron_h_mtp import NemotronHMTP
-
-try:
-    from vllm.model_executor.models.utils import _merge_multimodal_embeddings as _vllm_merge_multimodal_embeddings
-except ImportError:  # pragma: no cover - exercised by monkeypatching the resolved helper
-    _vllm_merge_multimodal_embeddings = None
+from vllm.model_executor.models.utils import _merge_multimodal_embeddings
 
 from nemo.collections.speechlm2.vllm.salm.audio import _pad_to_vocab_size
-
-
-def _flatten_multimodal_embeddings(embeddings) -> torch.Tensor:
-    """Flatten vLLM-style nested embedding tensors on every dimension but the last."""
-    if isinstance(embeddings, torch.Tensor):
-        return embeddings.flatten(0, -2)
-    return torch.cat(tuple(_flatten_multimodal_embeddings(item) for item in embeddings))
-
-
-def _merge_multimodal_embeddings(
-    inputs_embeds: torch.Tensor,
-    multimodal_embeddings,
-    is_multimodal: torch.Tensor,
-) -> torch.Tensor:
-    """Use vLLM's merge helper when available, with a compatible fallback for older releases."""
-    if _vllm_merge_multimodal_embeddings is not None:
-        return _vllm_merge_multimodal_embeddings(inputs_embeds, multimodal_embeddings, is_multimodal)
-
-    mm_embeds_flat = _flatten_multimodal_embeddings(multimodal_embeddings)
-    try:
-        inputs_embeds[is_multimodal] = mm_embeds_flat.to(dtype=inputs_embeds.dtype)
-    except RuntimeError as error:
-        actual_tokens = len(mm_embeds_flat)
-        expected_tokens = is_multimodal.sum().item()
-        if actual_tokens != expected_tokens:
-            raise ValueError(
-                f"Attempted to assign {actual_tokens} multimodal tokens to {expected_tokens} placeholders"
-            ) from error
-        raise ValueError("Error during multimodal embedding index assignment") from error
-    return inputs_embeds
 
 
 def _remap_nemo_mtp_weights(

--- a/nemo/collections/speechlm2/vllm/salm/mtp.py
+++ b/nemo/collections/speechlm2/vllm/salm/mtp.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MTP speculative-decoding draft model for NeMo SpeechLM checkpoints.
+
+``NeMoSpeechLMMTP`` wraps vLLM's ``NemotronHMTP`` and adapts the
+weight-loading step for the NeMo checkpoint layout where all LLM
+weights (including MTP layers) carry an ``llm.`` prefix:
+
+    NeMo checkpoint            NemotronHMTP expects
+    ──────────────────────     ────────────────────
+    llm.mtp.layers.0.*    →    mtp.layers.0.*
+    llm.lm_head.weight    →    lm_head.weight
+    llm.model.embed_*     →    (embeddings shared from target model)
+
+Only the ``mtp.*`` and ``lm_head.*`` weights are loaded here; the
+embedding table is shared with the target model by vLLM's MTP framework.
+"""
+
+from collections.abc import Iterable
+
+import torch
+from vllm.model_executor.models.nemotron_h_mtp import NemotronHMTP
+from vllm.sequence import IntermediateTensors
+
+from nemo.collections.speechlm2.vllm.salm.audio import _pad_to_vocab_size
+
+
+class NeMoSpeechLMMTP(NemotronHMTP):
+    """NemotronH MTP draft model for NeMo SpeechLM checkpoints.
+
+    Extends NemotronHMTP in two ways:
+
+    * ``load_weights`` strips the ``llm.`` prefix from checkpoint names.
+    * ``embed_input_ids`` fuses audio-feature embeddings into the token
+      embeddings at placeholder positions, exactly like the target model.
+      The MTP heads were trained on the same mixed text+audio embedding
+      stream as the backbone, so the draft must see it too. vLLM probes
+      ``draft_model.embed_input_ids(ids, multimodal_embeddings=None)`` at
+      load time (``llm_base_proposer.load_model``); without this method
+      the probe raises AttributeError and speculative decoding silently
+      falls back to text-only draft inputs, which collapses acceptance
+      rates on audio prompts.
+    """
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings=None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Embed token IDs and merge audio embeddings at placeholder positions.
+
+        Mirrors ``NeMoSpeechLMForConditionalGeneration.embed_input_ids``. The
+        embedding table itself is shared from the target model by vLLM's MTP
+        framework, so text-token rows are identical to the target's.
+        """
+        inputs_embeds = self.model.get_input_embeddings(input_ids)
+
+        if multimodal_embeddings is None or is_multimodal is None or not is_multimodal.any():
+            return inputs_embeds
+
+        audio_embeds = torch.cat(list(multimodal_embeddings), dim=0)
+        inputs_embeds = inputs_embeds.clone()
+        inputs_embeds[is_multimodal] = audio_embeds.to(inputs_embeds.dtype)
+        return inputs_embeds
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        lm_head_vocab = None
+        for name, module in self.named_modules():
+            if hasattr(module, "org_vocab_size") and "lm_head" in name:
+                lm_head_vocab = module.org_vocab_size
+                break
+
+        def _strip_llm_prefix(items):
+            for name, tensor in items:
+                if name.startswith("llm."):
+                    name = name[len("llm.") :]
+                if name == "lm_head.weight" and lm_head_vocab is not None:
+                    tensor = _pad_to_vocab_size(tensor, lm_head_vocab)
+                yield name, tensor
+
+        return super().load_weights(_strip_llm_prefix(weights))

--- a/tests/collections/speechlm2/test_to_hf.py
+++ b/tests/collections/speechlm2/test_to_hf.py
@@ -146,6 +146,15 @@ def test_hf_export_config_persists_built_mtp_pattern_without_mutating_recipe():
     assert model.cfg["mtp"]["hybrid_override_pattern"] == "*"
 
 
+def test_hf_export_config_does_not_persist_remote_code_trust():
+    model = SimpleNamespace(cfg={"trust_remote_code": True})
+
+    config = to_hf._hf_export_config(model, "bfloat16")
+
+    assert "trust_remote_code" not in config
+    assert model.cfg["trust_remote_code"] is True
+
+
 def test_hf_export_config_persists_built_non_repeated_mtp_depth():
     """A preserved native head's actual depth must override stale recipe metadata."""
     model = SimpleNamespace(

--- a/tests/collections/speechlm2/test_to_hf.py
+++ b/tests/collections/speechlm2/test_to_hf.py
@@ -14,7 +14,7 @@
 """Unit tests for ``examples/speechlm2/to_hf.py::prepare_for_vllm``.
 
 The script lives under ``examples/`` (not an importable package), so we load
-it via ``importlib`` and patch ``AutoTokenizer`` / ``_inspect_vllm_backbone``
+it via ``importlib`` and patch ``AutoTokenizer`` / ``_detect_vllm_architecture``
 to avoid any network or real-model dependencies.
 """
 import importlib.util
@@ -55,10 +55,8 @@ class _FakeTokenizer:
         split_chat_template=False,
         tokenizer_class="Qwen2Tokenizer",
         eos_token_id=42,
-        base_vocab_size=None,
     ):
         self._vocab = {tok: i for i, tok in enumerate(vocab_tokens)}
-        self.vocab_size = len(self._vocab) if base_vocab_size is None else base_vocab_size
         self._chat_template = chat_template
         self._split_chat_template = split_chat_template
         self._tokenizer_class = tokenizer_class
@@ -212,28 +210,8 @@ def test_prepare_for_vllm_missing_audio_locator_tag(tmp_path):
         to_hf.prepare_for_vllm(str(tmp_path), {"pretrained_llm": "fake-model"})
 
 
-def test_inspect_vllm_backbone_returns_model_embedding_vocab():
-    """Exporter bounds must use the model config, not tokenizer.vocab_size."""
-    backbone = SimpleNamespace(architectures=["Qwen2ForCausalLM"], vocab_size=151936)
-    with patch("transformers.AutoConfig.from_pretrained", return_value=backbone):
-        architecture, vocab_size = to_hf._inspect_vllm_backbone({"pretrained_llm": "fake-model"})
-
-    assert architecture == "NeMoSpeechLMForConditionalGeneration"
-    assert vocab_size == 151936
-
-
-@pytest.mark.parametrize("vocab_size", [None, True, 0, -1])
-def test_inspect_vllm_backbone_rejects_invalid_model_vocab(vocab_size):
-    backbone = SimpleNamespace(architectures=["Qwen2ForCausalLM"], vocab_size=vocab_size)
-    with (
-        patch("transformers.AutoConfig.from_pretrained", return_value=backbone),
-        pytest.raises(ValueError, match="vocab_size"),
-    ):
-        to_hf._inspect_vllm_backbone({"pretrained_llm": "fake-model"})
-
-
 # ──────────────────────────────────────────────────────────────────────
-# Happy paths (mock AutoTokenizer + _inspect_vllm_backbone)
+# Happy paths (mock AutoTokenizer + _detect_vllm_architecture)
 # ──────────────────────────────────────────────────────────────────────
 
 
@@ -242,11 +220,10 @@ def _run_prepare(
     fake_tok,
     arch="NeMoSpeechLMForConditionalGeneration",
     llm_arch="Qwen2ForCausalLM",
-    backbone_vocab_size=100,
 ):
     output_dir = _seed_output_dir(tmp_path, llm_arch=llm_arch)
     with (
-        patch.object(to_hf, "_inspect_vllm_backbone", return_value=(arch, backbone_vocab_size)),
+        patch.object(to_hf, "_detect_vllm_architecture", return_value=arch),
         patch("transformers.AutoTokenizer.from_pretrained", return_value=fake_tok),
     ):
         to_hf.prepare_for_vllm(
@@ -257,13 +234,13 @@ def _run_prepare(
 
 
 def test_prepare_for_vllm_patches_config_json(tmp_path):
-    """config.json gets model metadata and the tokenizer's exact audio-token ID."""
+    """config.json gets model metadata without persisting a token-index field."""
     output_dir = _run_prepare(tmp_path, _FakeTokenizer())
     cfg = json.loads((output_dir / "config.json").read_text())
     assert cfg["model_type"] == "nemo_speechlm"
     assert cfg["architectures"] == ["NeMoSpeechLMForConditionalGeneration"]
     assert cfg["audio_locator_tag"] == AUDIO_TOKEN
-    assert cfg["audio_token_index"] == 0
+    assert "audio_token_index" not in cfg
     assert "image_token_index" not in cfg
     # Original LLM fields are preserved.
     assert cfg["hidden_size"] == 2048
@@ -284,53 +261,12 @@ def test_prepare_for_vllm_skips_add_if_audio_token_already_in_vocab(tmp_path):
     assert fake_tok.add_special_tokens_calls == []
 
 
-def test_prepare_for_vllm_records_existing_audio_token_id(tmp_path):
-    """An existing audio token need not sit at the backbone vocabulary boundary."""
-    fake_tok = _FakeTokenizer(vocab_tokens=["<pad>", AUDIO_TOKEN, "<extra>"])
-    output_dir = _run_prepare(tmp_path, fake_tok)
-
-    cfg = json.loads((output_dir / "config.json").read_text())
-    assert cfg["audio_token_index"] == 1
-
-
-def test_prepare_for_vllm_rejects_invalid_audio_token_id(tmp_path):
-    """An invalid tokenizer mapping should fail during export, not at serving time."""
-    fake_tok = _FakeTokenizer(vocab_tokens=[AUDIO_TOKEN])
-    fake_tok._vocab[AUDIO_TOKEN] = -1
-
-    with pytest.raises(ValueError, match="valid ID"):
-        _run_prepare(tmp_path, fake_tok)
-
-
-def test_prepare_for_vllm_rejects_audio_token_outside_padded_embeddings(tmp_path):
-    """The exported placeholder ID must fit the embedding table created by the plugin."""
-    tokens = [f"<extra_{i}>" for i in range(11)] + [AUDIO_TOKEN]
-    fake_tok = _FakeTokenizer(vocab_tokens=tokens, base_vocab_size=1)
-
-    with pytest.raises(ValueError, match="outside the SpeechLM embedding table"):
-        _run_prepare(tmp_path, fake_tok, backbone_vocab_size=1)
-
-
-def test_prepare_for_vllm_uses_model_vocab_bound_not_tokenizer_base_vocab(tmp_path):
-    """Pre-existing added tokens may exceed tokenizer.vocab_size while fitting model embeddings."""
-    tokens = [f"<added_{i}>" for i in range(30)] + [AUDIO_TOKEN]
-    fake_tok = _FakeTokenizer(vocab_tokens=tokens, base_vocab_size=1)
-    output_dir = _run_prepare(tmp_path, fake_tok, backbone_vocab_size=40)
-
-    cfg = json.loads((output_dir / "config.json").read_text())
-    assert cfg["audio_token_index"] == 30
-
-
 def test_prepare_for_vllm_uses_training_tokenizer_path(tmp_path):
     """Conversion must persist the tokenizer that supplied training token IDs."""
     output_dir = _seed_output_dir(tmp_path)
     fake_tok = _FakeTokenizer()
     with (
-        patch.object(
-            to_hf,
-            "_inspect_vllm_backbone",
-            return_value=("NeMoSpeechLMForConditionalGeneration", 100),
-        ),
+        patch.object(to_hf, "_detect_vllm_architecture", return_value="NeMoSpeechLMForConditionalGeneration"),
         patch("transformers.AutoTokenizer.from_pretrained", return_value=fake_tok) as load_tokenizer,
     ):
         to_hf.prepare_for_vllm(

--- a/tests/collections/speechlm2/test_to_hf.py
+++ b/tests/collections/speechlm2/test_to_hf.py
@@ -345,6 +345,43 @@ def test_prepare_for_vllm_patches_config_json(tmp_path):
     assert cfg["hidden_size"] == 2048
 
 
+def test_prepare_for_vllm_embeds_bundled_backbone_config(tmp_path):
+    """The vLLM root config must not reload the stale training backbone reference."""
+    output_dir = _seed_output_dir(tmp_path)
+    backbone_dir = output_dir / "llm_backbone"
+    backbone_dir.mkdir()
+    backbone_config = {
+        "model_type": "qwen2",
+        "architectures": ["Qwen2ForCausalLM"],
+        "hidden_size": 2048,
+        "vocab_size": 100,
+    }
+    (backbone_dir / "config.json").write_text(json.dumps(backbone_config))
+
+    with (
+        patch.object(
+            to_hf,
+            "_detect_vllm_architecture",
+            return_value=("NeMoSpeechLMForConditionalGeneration", 100),
+        ) as detect_architecture,
+        patch("transformers.AutoTokenizer.from_pretrained", return_value=_FakeTokenizer()),
+    ):
+        to_hf.prepare_for_vllm(
+            str(output_dir),
+            {"pretrained_llm": "stale-training-model", "audio_locator_tag": AUDIO_TOKEN},
+        )
+
+    cfg = json.loads((output_dir / "config.json").read_text())
+    assert cfg["pretrained_llm"] == "llm_backbone"
+    assert cfg["llm_config"] == backbone_config
+    detect_architecture.assert_called_once_with(
+        {
+            "pretrained_llm": str(backbone_dir),
+            "audio_locator_tag": AUDIO_TOKEN,
+        }
+    )
+
+
 def test_prepare_for_vllm_adds_audio_token_to_vocab(tmp_path):
     """Audio token is registered via add_special_tokens when not already in vocab."""
     fake_tok = _FakeTokenizer(vocab_tokens=["<|im_start|>", "<|im_end|>"])

--- a/tests/collections/speechlm2/test_to_hf.py
+++ b/tests/collections/speechlm2/test_to_hf.py
@@ -98,6 +98,8 @@ def _seed_output_dir(tmp_path, llm_arch="Qwen2ForCausalLM"):
                 "architectures": [llm_arch],
                 "hidden_size": 2048,
                 "num_hidden_layers": 24,
+                "audio_token_index": 17,
+                "image_token_index": 18,
             }
         )
     )
@@ -144,6 +146,55 @@ def test_hf_export_config_persists_built_mtp_pattern_without_mutating_recipe():
     assert model.cfg["mtp"]["hybrid_override_pattern"] == "*"
 
 
+def test_hf_export_config_persists_built_non_repeated_mtp_depth():
+    """A preserved native head's actual depth must override stale recipe metadata."""
+    model = SimpleNamespace(
+        cfg={
+            "mtp": {
+                "enabled": True,
+                "hybrid_override_pattern": "*",
+                "num_nextn_predict_layers": 4,
+                "use_repeated_layer": False,
+            }
+        },
+        llm=SimpleNamespace(config=SimpleNamespace(mtp_hybrid_override_pattern="*E", num_nextn_predict_layers=1)),
+    )
+
+    config = to_hf._hf_export_config(model, "bfloat16")
+
+    assert config["mtp"]["num_nextn_predict_layers"] == 1
+    assert model.cfg["mtp"]["num_nextn_predict_layers"] == 4
+
+
+def test_hf_export_config_keeps_logical_depth_for_repeated_mtp():
+    model = SimpleNamespace(
+        cfg={
+            "mtp": {
+                "enabled": True,
+                "hybrid_override_pattern": "*",
+                "num_nextn_predict_layers": 4,
+                "use_repeated_layer": True,
+            }
+        },
+        llm=SimpleNamespace(config=SimpleNamespace(mtp_hybrid_override_pattern="*E", num_nextn_predict_layers=1)),
+    )
+
+    config = to_hf._hf_export_config(model, "bfloat16")
+
+    assert config["mtp"]["num_nextn_predict_layers"] == 4
+
+
+@pytest.mark.parametrize("depth", [False, 0, -1])
+def test_hf_export_config_rejects_invalid_built_mtp_depth(depth):
+    model = SimpleNamespace(
+        cfg={"mtp": {"enabled": True, "hybrid_override_pattern": "*"}},
+        llm=SimpleNamespace(config=SimpleNamespace(mtp_hybrid_override_pattern="*", num_nextn_predict_layers=depth)),
+    )
+
+    with pytest.raises(ValueError, match="num_nextn_predict_layers"):
+        to_hf._hf_export_config(model, "bfloat16")
+
+
 @pytest.mark.parametrize("pattern", ["", 3])
 def test_hf_export_config_rejects_invalid_built_mtp_pattern(pattern):
     model = SimpleNamespace(
@@ -153,6 +204,24 @@ def test_hf_export_config_rejects_invalid_built_mtp_pattern(pattern):
 
     with pytest.raises(ValueError, match="mtp_hybrid_override_pattern"):
         to_hf._hf_export_config(model, "bfloat16")
+
+
+def test_save_hf_checkpoint_validates_config_before_writing_weights(tmp_path):
+    model = SimpleNamespace(
+        cfg={"mtp": {"enabled": True, "hybrid_override_pattern": "*"}},
+        llm=SimpleNamespace(config=SimpleNamespace(mtp_hybrid_override_pattern="")),
+    )
+    cfg = to_hf.HfExportConfig(
+        class_path="fake.Class",
+        ckpt_path="fake.ckpt",
+        ckpt_config="fake.yaml",
+        output_dir=str(tmp_path),
+    )
+
+    with pytest.raises(ValueError, match="mtp_hybrid_override_pattern"):
+        to_hf.save_hf_checkpoint(model, {"weight": torch.zeros(1)}, cfg)
+
+    assert not (tmp_path / "model.safetensors").exists()
 
 
 def test_save_hf_checkpoint_writes_llm_backbone_config(tmp_path):
@@ -210,6 +279,26 @@ def test_prepare_for_vllm_missing_audio_locator_tag(tmp_path):
         to_hf.prepare_for_vllm(str(tmp_path), {"pretrained_llm": "fake-model"})
 
 
+def test_detect_vllm_architecture_returns_model_embedding_vocab():
+    """Exporter bounds must use the model config, not tokenizer.vocab_size."""
+    backbone = SimpleNamespace(architectures=["Qwen2ForCausalLM"], vocab_size=151936)
+    with patch("transformers.AutoConfig.from_pretrained", return_value=backbone):
+        architecture, vocab_size = to_hf._detect_vllm_architecture({"pretrained_llm": "fake-model"})
+
+    assert architecture == "NeMoSpeechLMForConditionalGeneration"
+    assert vocab_size == 151936
+
+
+@pytest.mark.parametrize("vocab_size", [None, True, 0, -1])
+def test_detect_vllm_architecture_rejects_invalid_model_vocab(vocab_size):
+    backbone = SimpleNamespace(architectures=["Qwen2ForCausalLM"], vocab_size=vocab_size)
+    with (
+        patch("transformers.AutoConfig.from_pretrained", return_value=backbone),
+        pytest.raises(ValueError, match="vocab_size"),
+    ):
+        to_hf._detect_vllm_architecture({"pretrained_llm": "fake-model"})
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Happy paths (mock AutoTokenizer + _detect_vllm_architecture)
 # ──────────────────────────────────────────────────────────────────────
@@ -220,10 +309,11 @@ def _run_prepare(
     fake_tok,
     arch="NeMoSpeechLMForConditionalGeneration",
     llm_arch="Qwen2ForCausalLM",
+    backbone_vocab_size=100,
 ):
     output_dir = _seed_output_dir(tmp_path, llm_arch=llm_arch)
     with (
-        patch.object(to_hf, "_detect_vllm_architecture", return_value=arch),
+        patch.object(to_hf, "_detect_vllm_architecture", return_value=(arch, backbone_vocab_size)),
         patch("transformers.AutoTokenizer.from_pretrained", return_value=fake_tok),
     ):
         to_hf.prepare_for_vllm(
@@ -261,12 +351,43 @@ def test_prepare_for_vllm_skips_add_if_audio_token_already_in_vocab(tmp_path):
     assert fake_tok.add_special_tokens_calls == []
 
 
+def test_prepare_for_vllm_rejects_invalid_audio_token_id(tmp_path):
+    fake_tok = _FakeTokenizer(vocab_tokens=[AUDIO_TOKEN])
+    fake_tok._vocab[AUDIO_TOKEN] = -1
+
+    with pytest.raises(ValueError, match="valid ID"):
+        _run_prepare(tmp_path, fake_tok)
+
+
+def test_prepare_for_vllm_rejects_audio_token_outside_padded_embeddings(tmp_path):
+    tokens = [f"<extra_{i}>" for i in range(11)] + [AUDIO_TOKEN]
+    fake_tok = _FakeTokenizer(vocab_tokens=tokens)
+
+    with pytest.raises(ValueError, match="outside the SpeechLM embedding table"):
+        _run_prepare(tmp_path, fake_tok, backbone_vocab_size=1)
+
+
+def test_prepare_for_vllm_accepts_audio_token_inside_non_boundary_embedding_row(tmp_path):
+    """Qwen-style reserved rows may put the audio token below the model-vocab boundary."""
+    fake_tok = _FakeTokenizer(vocab_tokens=["<pad>", AUDIO_TOKEN, "<extra>"])
+
+    output_dir = _run_prepare(tmp_path, fake_tok, backbone_vocab_size=100)
+
+    cfg = json.loads((output_dir / "config.json").read_text())
+    assert "audio_token_index" not in cfg
+    assert "image_token_index" not in cfg
+
+
 def test_prepare_for_vllm_uses_training_tokenizer_path(tmp_path):
     """Conversion must persist the tokenizer that supplied training token IDs."""
     output_dir = _seed_output_dir(tmp_path)
     fake_tok = _FakeTokenizer()
     with (
-        patch.object(to_hf, "_detect_vllm_architecture", return_value="NeMoSpeechLMForConditionalGeneration"),
+        patch.object(
+            to_hf,
+            "_detect_vllm_architecture",
+            return_value=("NeMoSpeechLMForConditionalGeneration", 100),
+        ),
         patch("transformers.AutoTokenizer.from_pretrained", return_value=fake_tok) as load_tokenizer,
     ):
         to_hf.prepare_for_vllm(

--- a/tests/collections/speechlm2/test_to_hf.py
+++ b/tests/collections/speechlm2/test_to_hf.py
@@ -14,12 +14,13 @@
 """Unit tests for ``examples/speechlm2/to_hf.py::prepare_for_vllm``.
 
 The script lives under ``examples/`` (not an importable package), so we load
-it via ``importlib`` and patch ``AutoTokenizer`` / ``_detect_vllm_architecture``
+it via ``importlib`` and patch ``AutoTokenizer`` / ``_inspect_vllm_backbone``
 to avoid any network or real-model dependencies.
 """
 import importlib.util
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -54,8 +55,10 @@ class _FakeTokenizer:
         split_chat_template=False,
         tokenizer_class="Qwen2Tokenizer",
         eos_token_id=42,
+        base_vocab_size=None,
     ):
         self._vocab = {tok: i for i, tok in enumerate(vocab_tokens)}
+        self.vocab_size = len(self._vocab) if base_vocab_size is None else base_vocab_size
         self._chat_template = chat_template
         self._split_chat_template = split_chat_template
         self._tokenizer_class = tokenizer_class
@@ -130,6 +133,30 @@ class _FakeExportModel:
     llm = type("_FakeLLM", (), {"config": _FakeLLMConfig()})()
 
 
+def test_hf_export_config_persists_built_mtp_pattern_without_mutating_recipe():
+    """A preserved native head's physical pattern must override stale recipe metadata."""
+    model = SimpleNamespace(
+        cfg={"mtp": {"enabled": True, "hybrid_override_pattern": "*"}},
+        llm=SimpleNamespace(config=SimpleNamespace(mtp_hybrid_override_pattern="*E")),
+    )
+
+    config = to_hf._hf_export_config(model, "bfloat16")
+
+    assert config["mtp"]["hybrid_override_pattern"] == "*E"
+    assert model.cfg["mtp"]["hybrid_override_pattern"] == "*"
+
+
+@pytest.mark.parametrize("pattern", ["", 3])
+def test_hf_export_config_rejects_invalid_built_mtp_pattern(pattern):
+    model = SimpleNamespace(
+        cfg={"mtp": {"enabled": True, "hybrid_override_pattern": "*"}},
+        llm=SimpleNamespace(config=SimpleNamespace(mtp_hybrid_override_pattern=pattern)),
+    )
+
+    with pytest.raises(ValueError, match="mtp_hybrid_override_pattern"):
+        to_hf._hf_export_config(model, "bfloat16")
+
+
 def test_save_hf_checkpoint_writes_llm_backbone_config(tmp_path):
     cfg = to_hf.HfExportConfig(
         class_path="fake.Class",
@@ -185,15 +212,41 @@ def test_prepare_for_vllm_missing_audio_locator_tag(tmp_path):
         to_hf.prepare_for_vllm(str(tmp_path), {"pretrained_llm": "fake-model"})
 
 
+def test_inspect_vllm_backbone_returns_model_embedding_vocab():
+    """Exporter bounds must use the model config, not tokenizer.vocab_size."""
+    backbone = SimpleNamespace(architectures=["Qwen2ForCausalLM"], vocab_size=151936)
+    with patch("transformers.AutoConfig.from_pretrained", return_value=backbone):
+        architecture, vocab_size = to_hf._inspect_vllm_backbone({"pretrained_llm": "fake-model"})
+
+    assert architecture == "NeMoSpeechLMForConditionalGeneration"
+    assert vocab_size == 151936
+
+
+@pytest.mark.parametrize("vocab_size", [None, True, 0, -1])
+def test_inspect_vllm_backbone_rejects_invalid_model_vocab(vocab_size):
+    backbone = SimpleNamespace(architectures=["Qwen2ForCausalLM"], vocab_size=vocab_size)
+    with (
+        patch("transformers.AutoConfig.from_pretrained", return_value=backbone),
+        pytest.raises(ValueError, match="vocab_size"),
+    ):
+        to_hf._inspect_vllm_backbone({"pretrained_llm": "fake-model"})
+
+
 # ──────────────────────────────────────────────────────────────────────
-# Happy paths (mock AutoTokenizer + _detect_vllm_architecture)
+# Happy paths (mock AutoTokenizer + _inspect_vllm_backbone)
 # ──────────────────────────────────────────────────────────────────────
 
 
-def _run_prepare(tmp_path, fake_tok, arch="NeMoSpeechLMForConditionalGeneration", llm_arch="Qwen2ForCausalLM"):
+def _run_prepare(
+    tmp_path,
+    fake_tok,
+    arch="NeMoSpeechLMForConditionalGeneration",
+    llm_arch="Qwen2ForCausalLM",
+    backbone_vocab_size=100,
+):
     output_dir = _seed_output_dir(tmp_path, llm_arch=llm_arch)
     with (
-        patch.object(to_hf, "_detect_vllm_architecture", return_value=arch),
+        patch.object(to_hf, "_inspect_vllm_backbone", return_value=(arch, backbone_vocab_size)),
         patch("transformers.AutoTokenizer.from_pretrained", return_value=fake_tok),
     ):
         to_hf.prepare_for_vllm(
@@ -204,12 +257,14 @@ def _run_prepare(tmp_path, fake_tok, arch="NeMoSpeechLMForConditionalGeneration"
 
 
 def test_prepare_for_vllm_patches_config_json(tmp_path):
-    """config.json gets model_type, architectures, and audio_locator_tag."""
+    """config.json gets model metadata and the tokenizer's exact audio-token ID."""
     output_dir = _run_prepare(tmp_path, _FakeTokenizer())
     cfg = json.loads((output_dir / "config.json").read_text())
     assert cfg["model_type"] == "nemo_speechlm"
     assert cfg["architectures"] == ["NeMoSpeechLMForConditionalGeneration"]
     assert cfg["audio_locator_tag"] == AUDIO_TOKEN
+    assert cfg["audio_token_index"] == 0
+    assert "image_token_index" not in cfg
     # Original LLM fields are preserved.
     assert cfg["hidden_size"] == 2048
 
@@ -227,6 +282,67 @@ def test_prepare_for_vllm_skips_add_if_audio_token_already_in_vocab(tmp_path):
     fake_tok = _FakeTokenizer(vocab_tokens=["<|im_start|>", "<|im_end|>", AUDIO_TOKEN])
     _run_prepare(tmp_path, fake_tok)
     assert fake_tok.add_special_tokens_calls == []
+
+
+def test_prepare_for_vllm_records_existing_audio_token_id(tmp_path):
+    """An existing audio token need not sit at the backbone vocabulary boundary."""
+    fake_tok = _FakeTokenizer(vocab_tokens=["<pad>", AUDIO_TOKEN, "<extra>"])
+    output_dir = _run_prepare(tmp_path, fake_tok)
+
+    cfg = json.loads((output_dir / "config.json").read_text())
+    assert cfg["audio_token_index"] == 1
+
+
+def test_prepare_for_vllm_rejects_invalid_audio_token_id(tmp_path):
+    """An invalid tokenizer mapping should fail during export, not at serving time."""
+    fake_tok = _FakeTokenizer(vocab_tokens=[AUDIO_TOKEN])
+    fake_tok._vocab[AUDIO_TOKEN] = -1
+
+    with pytest.raises(ValueError, match="valid ID"):
+        _run_prepare(tmp_path, fake_tok)
+
+
+def test_prepare_for_vllm_rejects_audio_token_outside_padded_embeddings(tmp_path):
+    """The exported placeholder ID must fit the embedding table created by the plugin."""
+    tokens = [f"<extra_{i}>" for i in range(11)] + [AUDIO_TOKEN]
+    fake_tok = _FakeTokenizer(vocab_tokens=tokens, base_vocab_size=1)
+
+    with pytest.raises(ValueError, match="outside the SpeechLM embedding table"):
+        _run_prepare(tmp_path, fake_tok, backbone_vocab_size=1)
+
+
+def test_prepare_for_vllm_uses_model_vocab_bound_not_tokenizer_base_vocab(tmp_path):
+    """Pre-existing added tokens may exceed tokenizer.vocab_size while fitting model embeddings."""
+    tokens = [f"<added_{i}>" for i in range(30)] + [AUDIO_TOKEN]
+    fake_tok = _FakeTokenizer(vocab_tokens=tokens, base_vocab_size=1)
+    output_dir = _run_prepare(tmp_path, fake_tok, backbone_vocab_size=40)
+
+    cfg = json.loads((output_dir / "config.json").read_text())
+    assert cfg["audio_token_index"] == 30
+
+
+def test_prepare_for_vllm_uses_training_tokenizer_path(tmp_path):
+    """Conversion must persist the tokenizer that supplied training token IDs."""
+    output_dir = _seed_output_dir(tmp_path)
+    fake_tok = _FakeTokenizer()
+    with (
+        patch.object(
+            to_hf,
+            "_inspect_vllm_backbone",
+            return_value=("NeMoSpeechLMForConditionalGeneration", 100),
+        ),
+        patch("transformers.AutoTokenizer.from_pretrained", return_value=fake_tok) as load_tokenizer,
+    ):
+        to_hf.prepare_for_vllm(
+            str(output_dir),
+            {
+                "pretrained_llm": "fake-model",
+                "tokenizer_path": "custom-tokenizer",
+                "audio_locator_tag": AUDIO_TOKEN,
+            },
+        )
+
+    load_tokenizer.assert_called_once_with("custom-tokenizer", trust_remote_code=True)
 
 
 def test_prepare_for_vllm_tokenizer_config_normalized(tmp_path):

--- a/tests/collections/speechlm2/test_vllm_plugin.py
+++ b/tests/collections/speechlm2/test_vllm_plugin.py
@@ -20,7 +20,6 @@ weights.
 """
 
 import importlib.util
-import logging
 from types import SimpleNamespace
 
 import pytest
@@ -769,31 +768,6 @@ class TestMTPPlugin:
 
         assert "nemo_speechlm_mtp" in get_args(_spec_mod.MTPModelTypes)
 
-    def test_mtp_patch_keeps_target_plugin_usable_without_vllm_mtp_guard(self, monkeypatch, caplog):
-        """Older vLLM releases should degrade cleanly instead of breaking registration."""
-        import vllm.config.speculative as _spec_mod
-        from vllm.model_executor.models.registry import ModelRegistry
-
-        from nemo.collections.speechlm2.vllm.salm import register
-
-        registered_archs = []
-        original_register_model = ModelRegistry.register_model
-
-        def _record_registration(architecture, model):
-            registered_archs.append(architecture)
-            return original_register_model(architecture, model)
-
-        monkeypatch.setattr(ModelRegistry, "register_model", _record_registration)
-        monkeypatch.delattr(_spec_mod, "MTPModelTypes")
-
-        with caplog.at_level(logging.WARNING, logger="nemo.collections.speechlm2.vllm.salm"):
-            register()
-
-        assert "NeMoSpeechLMForConditionalGeneration" in registered_archs
-        assert "NeMoSpeechLMMTPModel" not in registered_archs
-        assert "NeMoSpeechLMForConditionalGeneration" in ModelRegistry.get_supported_archs()
-        assert "without MTP speculative-decoding support" in caplog.text
-
     def test_patched_override_routes_nemo_mtp_config(self, monkeypatch):
         """hf_config_override should rewrite nemo_speechlm configs with MTP heads."""
         from transformers import AutoConfig
@@ -1050,83 +1024,29 @@ class TestMTPPlugin:
 
         assert torch.equal(result, torch.zeros(2, 2))
 
-    def test_embed_input_ids_fallback_supports_nested_audio_chunks(self, monkeypatch):
-        """Older vLLM releases without the private merge helper retain nested-input behavior."""
-        import torch
-
-        from nemo.collections.speechlm2.vllm.salm import mtp as mtp_module
-
-        monkeypatch.setattr(mtp_module, "_vllm_merge_multimodal_embeddings", None)
-        model = object.__new__(mtp_module.NeMoSpeechLMMTP)
-        model.model = SimpleNamespace(get_input_embeddings=lambda ids: torch.zeros(4, 2))
-        result = model.embed_input_ids(
-            torch.tensor([0, 1, 2, 3]),
-            multimodal_embeddings=[[torch.ones(1, 2) * 3], [torch.ones(1, 2) * 7]],
-            is_multimodal=torch.tensor([True, False, True, False]),
-        )
-
-        assert torch.equal(result[0], torch.ones(2) * 3)
-        assert torch.equal(result[1], torch.zeros(2))
-        assert torch.equal(result[2], torch.ones(2) * 7)
-        assert torch.equal(result[3], torch.zeros(2))
-
-    def test_embed_input_ids_fallback_preserves_all_text_mask_noop(self, monkeypatch):
-        """The compatibility fallback should match vLLM for an all-False mask."""
-        import torch
-
-        from nemo.collections.speechlm2.vllm.salm import mtp as mtp_module
-
-        monkeypatch.setattr(mtp_module, "_vllm_merge_multimodal_embeddings", None)
-        model = object.__new__(mtp_module.NeMoSpeechLMMTP)
-        model.model = SimpleNamespace(get_input_embeddings=lambda ids: torch.zeros(2, 2))
-        result = model.embed_input_ids(
-            torch.tensor([0, 1]),
-            multimodal_embeddings=[torch.ones(1, 2)],
-            is_multimodal=torch.tensor([False, False]),
-        )
-
-        assert torch.equal(result, torch.zeros(2, 2))
-
-    def test_embed_input_ids_fallback_rejects_embedding_count_mismatch(self, monkeypatch):
-        """The compatibility fallback should report mismatched audio and placeholder counts."""
-        import torch
-
-        from nemo.collections.speechlm2.vllm.salm import mtp as mtp_module
-
-        monkeypatch.setattr(mtp_module, "_vllm_merge_multimodal_embeddings", None)
-        model = object.__new__(mtp_module.NeMoSpeechLMMTP)
-        model.model = SimpleNamespace(get_input_embeddings=lambda ids: torch.zeros(2, 2))
-
-        with pytest.raises(ValueError, match="2 multimodal tokens to 1 placeholders"):
-            model.embed_input_ids(
-                torch.tensor([0, 1]),
-                multimodal_embeddings=[torch.ones(2, 2)],
-                is_multimodal=torch.tensor([True, False]),
-            )
-
-    def test_target_weight_split_excludes_only_salm_mtp_and_extra_state(self):
-        """The target loader should retain LLM weights while routing SALM draft weights away."""
+    def test_target_weight_split_excludes_salm_mtp_and_rejects_bare_mtp(self):
+        """The target loader should route SALM draft weights and reject unsupported native names."""
         import torch
 
         from nemo.collections.speechlm2.vllm.salm.model import NeMoSpeechLMForConditionalGeneration
 
         perception_tensor = torch.ones(1)
         llm_tensor = torch.ones(2)
-        bare_mtp_tensor = torch.ones(3)
         perception, llm = NeMoSpeechLMForConditionalGeneration._split_perception_llm(
             [
                 ("perception.encoder.weight", perception_tensor),
                 ("llm.mtp.layers.0.weight", torch.ones(4)),
                 ("llm.model.layers.0.weight", llm_tensor),
-                ("mtp.layers.0.weight", bare_mtp_tensor),
                 ("llm.model.layers.0._extra_state", torch.ones(5)),
             ]
         )
 
         assert perception == {"encoder.weight": perception_tensor}
-        assert [name for name, _ in llm] == ["llm.model.layers.0.weight", "mtp.layers.0.weight"]
+        assert [name for name, _ in llm] == ["llm.model.layers.0.weight"]
         assert llm[0][1] is llm_tensor
-        assert llm[1][1] is bare_mtp_tensor
+
+        with pytest.raises(ValueError, match=r"llm\.mtp\.\*"):
+            NeMoSpeechLMForConditionalGeneration._split_perception_llm([("mtp.layers.0.weight", torch.ones(3))])
 
     def test_mtp_weight_remap_uses_vllm_embedding_alias(self):
         """Exported SpeechLM embeddings must pass NemotronHMTP's name filter."""
@@ -1289,6 +1209,15 @@ class TestMTPPlugin:
         assert cfg.image_token_index == base_vocab
         assert "audio_token_index" not in cfg.to_dict()
         assert "image_token_index" not in cfg.to_dict()
+
+    @pytest.mark.skipif(not _HAS_CONFIG, reason="NeMoSpeechLMConfig not available")
+    def test_legacy_image_token_index_is_validated_after_backbone_load(self):
+        cfg = NeMoSpeechLMConfig(**_DEFAULT_CONFIG_KWARGS, image_token_index=131072)
+        assert cfg.image_token_index == 131072
+        assert "image_token_index" not in cfg.to_dict()
+
+        with pytest.raises(ValueError, match="backbone vocabulary boundary"):
+            NeMoSpeechLMConfig(**_DEFAULT_CONFIG_KWARGS, image_token_index=42)
 
 
 class _FakeTokenizer:

--- a/tests/collections/speechlm2/test_vllm_plugin.py
+++ b/tests/collections/speechlm2/test_vllm_plugin.py
@@ -777,6 +777,7 @@ class TestMTPPlugin:
     def test_patched_override_routes_nemo_mtp_config(self, monkeypatch):
         """hf_config_override should rewrite nemo_speechlm configs with MTP heads."""
         from transformers import AutoConfig
+
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         register()
 
@@ -856,6 +857,7 @@ class TestMTPPlugin:
     def test_patched_override_enabled_mtp_defaults_to_one_head(self, monkeypatch):
         """An enabled training block without an explicit depth constructs one head."""
         from transformers import AutoConfig
+
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         register()
 
@@ -869,6 +871,7 @@ class TestMTPPlugin:
     def test_patched_override_repeated_layer_exposes_one_reusable_head(self, monkeypatch):
         """Repeated-layer training depth must not constrain inference-time K."""
         from transformers import AutoConfig
+
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         register()
 
@@ -955,6 +958,7 @@ class TestMTPPlugin:
     def test_patched_override_multi_head_without_repeated_layer_raises(self, monkeypatch):
         """hf_config_override should raise for multi-head checkpoints without use_repeated_layer."""
         from transformers import AutoConfig
+
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         register()
 
@@ -968,6 +972,7 @@ class TestMTPPlugin:
     def test_mtp_override_registration_is_idempotent(self, monkeypatch):
         """register() should not repeatedly wrap the config override."""
         from transformers import AutoConfig
+
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         register()
         first_override = SpeculativeConfig.hf_config_override

--- a/tests/collections/speechlm2/test_vllm_plugin.py
+++ b/tests/collections/speechlm2/test_vllm_plugin.py
@@ -117,9 +117,7 @@ class TestNeMoSpeechLMConfig:
     )
     def test_is_hybrid_backend_helper(self, architectures, expected_is_hybrid):
         """``_is_hybrid_backend`` should match the documented hybrid allow-list."""
-        from nemo.collections.speechlm2.vllm.salm.config import _is_hybrid_backend
-
-        assert _is_hybrid_backend(architectures) is expected_is_hybrid
+        assert _config_module._is_hybrid_backend(architectures) is expected_is_hybrid
 
     @pytest.mark.parametrize(
         "backbone_archs, expected_is_hybrid",

--- a/tests/collections/speechlm2/test_vllm_plugin.py
+++ b/tests/collections/speechlm2/test_vllm_plugin.py
@@ -20,6 +20,7 @@ weights.
 """
 
 import importlib.util
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -78,10 +79,18 @@ class TestNeMoSpeechLMConfig:
         assert cfg.pretrained_llm is None
         assert cfg.pretrained_asr is None
         assert cfg.audio_locator_tag is None
+        assert cfg.audio_token_index is None
+        assert cfg.image_token_index is None
         assert cfg.prompt_format is None
         assert cfg.pretrained_weights is None
         assert cfg.llm_architectures == []
         assert cfg.get_text_config() is cfg.text_config
+
+    @pytest.mark.parametrize("field", ["audio_token_index", "image_token_index"])
+    def test_token_index_alone_is_not_default_construction(self, field):
+        """Checkpoint data must not be silently discarded by HF's no-arg path."""
+        with pytest.raises(ValueError, match="pretrained_llm"):
+            NeMoSpeechLMConfig(**{field: 42})
 
     def test_loads_text_config(self):
         """Config should load a text_config from the pretrained LLM."""
@@ -709,6 +718,25 @@ class TestPluginRegistration:
 class TestMTPPlugin:
     """Tests for NeMo SpeechLM MTP speculative-decoding support."""
 
+    @pytest.fixture(autouse=True)
+    def mock_backbone_config(self, monkeypatch):
+        """Keep registration tests independent of Hugging Face network access."""
+        if not _HAS_CONFIG:
+            return
+
+        monkeypatch.setattr(
+            _config_module.AutoConfig,
+            "from_pretrained",
+            lambda *args, **kwargs: SimpleNamespace(
+                architectures=["NemotronHybridForCausalLM"],
+                hidden_size=2048,
+                vocab_size=131072,
+                num_hidden_layers=4,
+                num_key_value_heads=2,
+                layer_norm_epsilon=1e-5,
+            ),
+        )
+
     class _HFConfigLike:
         """Minimal stand-in for a HuggingFace PretrainedConfig."""
 
@@ -748,6 +776,31 @@ class TestMTPPlugin:
 
         assert "nemo_speechlm_mtp" in get_args(_spec_mod.MTPModelTypes)
 
+    def test_mtp_patch_keeps_target_plugin_usable_without_vllm_mtp_guard(self, monkeypatch, caplog):
+        """Older vLLM releases should degrade cleanly instead of breaking registration."""
+        import vllm.config.speculative as _spec_mod
+        from vllm.model_executor.models.registry import ModelRegistry
+
+        from nemo.collections.speechlm2.vllm.salm import register
+
+        registered_archs = []
+        original_register_model = ModelRegistry.register_model
+
+        def _record_registration(architecture, model):
+            registered_archs.append(architecture)
+            return original_register_model(architecture, model)
+
+        monkeypatch.setattr(ModelRegistry, "register_model", _record_registration)
+        monkeypatch.delattr(_spec_mod, "MTPModelTypes")
+
+        with caplog.at_level(logging.WARNING, logger="nemo.collections.speechlm2.vllm.salm"):
+            register()
+
+        assert "NeMoSpeechLMForConditionalGeneration" in registered_archs
+        assert "NeMoSpeechLMMTPModel" not in registered_archs
+        assert "NeMoSpeechLMForConditionalGeneration" in ModelRegistry.get_supported_archs()
+        assert "without MTP speculative-decoding support" in caplog.text
+
     def test_patched_override_routes_nemo_mtp_config(self, monkeypatch):
         """hf_config_override should rewrite nemo_speechlm configs with MTP heads."""
         from transformers import AutoConfig
@@ -760,12 +813,29 @@ class TestMTPPlugin:
 
         hf_cfg = self._HFConfigLike(
             model_type="nemo_speechlm",
-            mtp={"num_nextn_predict_layers": 1, "use_repeated_layer": True},
+            mtp={"enabled": True, "num_nextn_predict_layers": 1, "use_repeated_layer": True},
         )
         result = SpeculativeConfig.hf_config_override(hf_cfg)
 
         assert result.model_type == "nemo_speechlm_mtp"
         assert result.architectures == ["NeMoSpeechLMMTPModel"]
+        assert result.n_predict == 1
+        assert result.num_nextn_predict_layers == 1
+
+    def test_patched_override_enabled_mtp_defaults_to_one_head(self, monkeypatch):
+        """An enabled training block without an explicit depth constructs one head."""
+        from transformers import AutoConfig
+        from vllm.config.speculative import SpeculativeConfig
+
+        from nemo.collections.speechlm2.vllm.salm import register
+
+        monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
+        register()
+
+        hf_cfg = self._HFConfigLike(model_type="nemo_speechlm", mtp={"enabled": True})
+        result = SpeculativeConfig.hf_config_override(hf_cfg)
+
+        assert result.model_type == "nemo_speechlm_mtp"
         assert result.n_predict == 1
         assert result.num_nextn_predict_layers == 1
 
@@ -781,7 +851,7 @@ class TestMTPPlugin:
 
         hf_cfg = self._HFConfigLike(
             model_type="nemo_speechlm",
-            mtp={"num_nextn_predict_layers": 4, "use_repeated_layer": True},
+            mtp={"enabled": True, "num_nextn_predict_layers": 4, "use_repeated_layer": True},
         )
         result = SpeculativeConfig.hf_config_override(hf_cfg)
 
@@ -810,6 +880,58 @@ class TestMTPPlugin:
 
         assert len(original_calls) == 1
 
+    def test_patched_override_depth_without_enabled_flag_falls_through(self, monkeypatch):
+        """A retained recipe depth must not enable a head that training did not construct."""
+        from transformers import AutoConfig
+        from vllm.config.speculative import SpeculativeConfig
+
+        from nemo.collections.speechlm2.vllm.salm import register
+
+        monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
+        original_calls = []
+
+        def _recording_orig(cfg):
+            original_calls.append(cfg)
+            return cfg
+
+        monkeypatch.setattr(SpeculativeConfig, "hf_config_override", staticmethod(_recording_orig))
+        register()
+
+        hf_cfg = self._HFConfigLike(
+            model_type="nemo_speechlm",
+            mtp={"num_nextn_predict_layers": 4, "use_repeated_layer": True},
+        )
+        result = SpeculativeConfig.hf_config_override(hf_cfg)
+
+        assert result.model_type == "nemo_speechlm"
+        assert original_calls == [hf_cfg]
+
+    def test_patched_override_explicitly_disabled_mtp_falls_through(self, monkeypatch):
+        """An exported recipe depth must not override mtp.enabled=false."""
+        from transformers import AutoConfig
+        from vllm.config.speculative import SpeculativeConfig
+
+        from nemo.collections.speechlm2.vllm.salm import register
+
+        monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
+        original_calls = []
+
+        def _recording_orig(cfg):
+            original_calls.append(cfg)
+            return cfg
+
+        monkeypatch.setattr(SpeculativeConfig, "hf_config_override", staticmethod(_recording_orig))
+        register()
+
+        hf_cfg = self._HFConfigLike(
+            model_type="nemo_speechlm",
+            mtp={"enabled": False, "num_nextn_predict_layers": 4, "use_repeated_layer": True},
+        )
+        result = SpeculativeConfig.hf_config_override(hf_cfg)
+
+        assert result.model_type == "nemo_speechlm"
+        assert original_calls == [hf_cfg]
+
     def test_patched_override_multi_head_without_repeated_layer_raises(self, monkeypatch):
         """hf_config_override should raise for multi-head checkpoints without use_repeated_layer."""
         from transformers import AutoConfig
@@ -822,7 +944,7 @@ class TestMTPPlugin:
 
         hf_cfg = self._HFConfigLike(
             model_type="nemo_speechlm",
-            mtp={"num_nextn_predict_layers": 3, "use_repeated_layer": False},
+            mtp={"enabled": True, "num_nextn_predict_layers": 3, "use_repeated_layer": False},
         )
         with pytest.raises(ValueError, match="use_repeated_layer"):
             SpeculativeConfig.hf_config_override(hf_cfg)
@@ -879,6 +1001,140 @@ class TestMTPPlugin:
         assert torch.equal(result[2], torch.ones(2) * 9.0)
         assert torch.equal(result[3], torch.zeros(2))
 
+    def test_embed_input_ids_fuses_multiple_audio_chunks(self):
+        """embed_input_ids should preserve vLLM's nested multimodal embedding order."""
+        import torch
+
+        from nemo.collections.speechlm2.vllm.salm.mtp import NeMoSpeechLMMTP
+
+        m = object.__new__(NeMoSpeechLMMTP)
+        base_embeds = torch.zeros(5, 2)
+        m.model = SimpleNamespace(get_input_embeddings=lambda ids: base_embeds.clone())
+
+        audio_feats = [[torch.ones(1, 2) * 3.0], [torch.ones(2, 2) * 7.0]]
+        is_audio = torch.tensor([True, False, True, True, False])
+        result = m.embed_input_ids(
+            torch.tensor([0, 1, 2, 3, 4]),
+            multimodal_embeddings=audio_feats,
+            is_multimodal=is_audio,
+        )
+
+        assert torch.equal(result[0], torch.ones(2) * 3.0)
+        assert torch.equal(result[1], torch.zeros(2))
+        assert torch.equal(result[2], torch.ones(2) * 7.0)
+        assert torch.equal(result[3], torch.ones(2) * 7.0)
+        assert torch.equal(result[4], torch.zeros(2))
+
+    def test_embed_input_ids_requires_multimodal_mask(self):
+        """Audio embeddings without placeholder positions should fail clearly."""
+        import torch
+
+        from nemo.collections.speechlm2.vllm.salm.mtp import NeMoSpeechLMMTP
+
+        m = object.__new__(NeMoSpeechLMMTP)
+        m.model = SimpleNamespace(get_input_embeddings=lambda ids: torch.zeros(2, 2))
+
+        with pytest.raises(ValueError, match="is_multimodal"):
+            m.embed_input_ids(
+                torch.tensor([0, 1]),
+                multimodal_embeddings=[torch.ones(1, 2)],
+            )
+
+    def test_embed_input_ids_ignores_embeddings_without_placeholder_positions(self):
+        """vLLM's merge semantics leave embeddings unchanged for an all-text mask."""
+        import torch
+
+        from nemo.collections.speechlm2.vllm.salm.mtp import NeMoSpeechLMMTP
+
+        model = object.__new__(NeMoSpeechLMMTP)
+        model.model = SimpleNamespace(get_input_embeddings=lambda ids: torch.zeros(2, 2))
+
+        result = model.embed_input_ids(
+            torch.tensor([0, 1]),
+            multimodal_embeddings=[torch.ones(1, 2)],
+            is_multimodal=torch.tensor([False, False]),
+        )
+
+        assert torch.equal(result, torch.zeros(2, 2))
+
+    def test_embed_input_ids_fallback_supports_nested_audio_chunks(self, monkeypatch):
+        """Older vLLM releases without the private merge helper retain nested-input behavior."""
+        import torch
+
+        from nemo.collections.speechlm2.vllm.salm import mtp as mtp_module
+
+        monkeypatch.setattr(mtp_module, "_vllm_merge_multimodal_embeddings", None)
+        model = object.__new__(mtp_module.NeMoSpeechLMMTP)
+        model.model = SimpleNamespace(get_input_embeddings=lambda ids: torch.zeros(4, 2))
+        result = model.embed_input_ids(
+            torch.tensor([0, 1, 2, 3]),
+            multimodal_embeddings=[[torch.ones(1, 2) * 3], [torch.ones(1, 2) * 7]],
+            is_multimodal=torch.tensor([True, False, True, False]),
+        )
+
+        assert torch.equal(result[0], torch.ones(2) * 3)
+        assert torch.equal(result[1], torch.zeros(2))
+        assert torch.equal(result[2], torch.ones(2) * 7)
+        assert torch.equal(result[3], torch.zeros(2))
+
+    def test_embed_input_ids_fallback_preserves_all_text_mask_noop(self, monkeypatch):
+        """The compatibility fallback should match vLLM for an all-False mask."""
+        import torch
+
+        from nemo.collections.speechlm2.vllm.salm import mtp as mtp_module
+
+        monkeypatch.setattr(mtp_module, "_vllm_merge_multimodal_embeddings", None)
+        model = object.__new__(mtp_module.NeMoSpeechLMMTP)
+        model.model = SimpleNamespace(get_input_embeddings=lambda ids: torch.zeros(2, 2))
+        result = model.embed_input_ids(
+            torch.tensor([0, 1]),
+            multimodal_embeddings=[torch.ones(1, 2)],
+            is_multimodal=torch.tensor([False, False]),
+        )
+
+        assert torch.equal(result, torch.zeros(2, 2))
+
+    def test_embed_input_ids_fallback_rejects_embedding_count_mismatch(self, monkeypatch):
+        """The compatibility fallback should report mismatched audio and placeholder counts."""
+        import torch
+
+        from nemo.collections.speechlm2.vllm.salm import mtp as mtp_module
+
+        monkeypatch.setattr(mtp_module, "_vllm_merge_multimodal_embeddings", None)
+        model = object.__new__(mtp_module.NeMoSpeechLMMTP)
+        model.model = SimpleNamespace(get_input_embeddings=lambda ids: torch.zeros(2, 2))
+
+        with pytest.raises(ValueError, match="2 multimodal tokens to 1 placeholders"):
+            model.embed_input_ids(
+                torch.tensor([0, 1]),
+                multimodal_embeddings=[torch.ones(2, 2)],
+                is_multimodal=torch.tensor([True, False]),
+            )
+
+    def test_target_weight_split_excludes_only_salm_mtp_and_extra_state(self):
+        """The target loader should retain LLM weights while routing SALM draft weights away."""
+        import torch
+
+        from nemo.collections.speechlm2.vllm.salm.model import NeMoSpeechLMForConditionalGeneration
+
+        perception_tensor = torch.ones(1)
+        llm_tensor = torch.ones(2)
+        bare_mtp_tensor = torch.ones(3)
+        perception, llm = NeMoSpeechLMForConditionalGeneration._split_perception_llm(
+            [
+                ("perception.encoder.weight", perception_tensor),
+                ("llm.mtp.layers.0.weight", torch.ones(4)),
+                ("llm.model.layers.0.weight", llm_tensor),
+                ("mtp.layers.0.weight", bare_mtp_tensor),
+                ("llm.model.layers.0._extra_state", torch.ones(5)),
+            ]
+        )
+
+        assert perception == {"encoder.weight": perception_tensor}
+        assert [name for name, _ in llm] == ["llm.model.layers.0.weight", "mtp.layers.0.weight"]
+        assert llm[0][1] is llm_tensor
+        assert llm[1][1] is bare_mtp_tensor
+
     def test_mtp_weight_remap_uses_vllm_embedding_alias(self):
         """Exported SpeechLM embeddings must pass NemotronHMTP's name filter."""
         import torch
@@ -912,6 +1168,102 @@ class TestMTPPlugin:
         assert padded["backbone.embeddings.weight"].shape == (5, 3)
         assert padded["lm_head.weight"].shape == (5, 3)
 
+    def test_mtp_weight_remap_rejects_distinct_head_layers(self):
+        """Unsupported distinct heads in a NeMo SpeechLM export should fail loudly."""
+        import torch
+
+        from nemo.collections.speechlm2.vllm.salm.mtp import _remap_nemo_mtp_weights
+
+        tensor = torch.ones(2, 3)
+        with pytest.raises(ValueError, match="distinct multi-head"):
+            list(
+                _remap_nemo_mtp_weights(
+                    [("llm.mtp.layers.1.enorm.weight", tensor)],
+                    expected_layer_modules=1,
+                )
+            )
+
+    def test_mtp_weight_remap_ignores_non_salm_names(self):
+        """The draft loader supports final NeMo SpeechLM exports, not bare backbone checkpoints."""
+        import torch
+
+        from nemo.collections.speechlm2.vllm.salm.mtp import _remap_nemo_mtp_weights
+
+        assert list(_remap_nemo_mtp_weights([("mtp.layers.0.norm.weight", torch.ones(1))])) == []
+
+    def test_mtp_weight_remap_allows_all_sublayers_in_hybrid_pattern(self):
+        """Hybrid-pattern sublayers belong to one reusable prediction step."""
+        import torch
+
+        from nemo.collections.speechlm2.vllm.salm.mtp import _remap_nemo_mtp_weights
+
+        tensor = torch.ones(2, 3)
+        remapped = dict(
+            _remap_nemo_mtp_weights(
+                [(f"llm.mtp.layers.{i}.norm.weight", tensor) for i in range(3)],
+                expected_layer_modules=3,
+            )
+        )
+        assert set(remapped) == {f"mtp.layers.{i}.norm.weight" for i in range(3)}
+
+    def test_mtp_load_weights_bounds_layers_from_serialized_pattern(self, monkeypatch):
+        """The real loader wiring should derive its physical-layer bound from config."""
+        import torch
+        from vllm.model_executor.models.nemotron_h_mtp import NemotronHMTP
+
+        from nemo.collections.speechlm2.vllm.salm.mtp import NeMoSpeechLMMTP
+
+        model = object.__new__(NeMoSpeechLMMTP)
+        object.__setattr__(
+            model,
+            "config",
+            SimpleNamespace(mtp_hybrid_override_pattern="*E", vocab_size=3),
+        )
+        captured = []
+
+        def _capture_weights(self, weights):
+            captured.extend(weights)
+            return set()
+
+        monkeypatch.setattr(NemotronHMTP, "load_weights", _capture_weights)
+        tensor = torch.ones(1, 2)
+        NeMoSpeechLMMTP.load_weights(
+            model,
+            [
+                ("llm.model.embed_tokens.weight", tensor),
+                ("llm.mtp.layers.0.norm.weight", tensor),
+                ("llm.mtp.layers.1.norm.weight", tensor),
+                ("llm.lm_head.weight", tensor),
+            ],
+        )
+        assert [name for name, _ in captured] == [
+            "backbone.embeddings.weight",
+            "mtp.layers.0.norm.weight",
+            "mtp.layers.1.norm.weight",
+            "lm_head.weight",
+        ]
+        captured_tensors = dict(captured)
+        assert captured_tensors["backbone.embeddings.weight"].shape == (3, 2)
+        assert captured_tensors["lm_head.weight"].shape == (3, 2)
+        assert captured_tensors["mtp.layers.0.norm.weight"] is tensor
+        assert captured_tensors["mtp.layers.1.norm.weight"] is tensor
+
+        with pytest.raises(ValueError, match="distinct multi-head"):
+            NeMoSpeechLMMTP.load_weights(model, [("llm.mtp.layers.2.norm.weight", tensor)])
+
+    @pytest.mark.parametrize("pattern", [None, "", 3])
+    def test_mtp_load_weights_rejects_invalid_serialized_pattern(self, monkeypatch, pattern):
+        from vllm.model_executor.models.nemotron_h_mtp import NemotronHMTP
+
+        from nemo.collections.speechlm2.vllm.salm.mtp import NeMoSpeechLMMTP
+
+        model = object.__new__(NeMoSpeechLMMTP)
+        object.__setattr__(model, "config", SimpleNamespace(mtp_hybrid_override_pattern=pattern, vocab_size=3))
+        monkeypatch.setattr(NemotronHMTP, "load_weights", lambda self, weights: set())
+
+        with pytest.raises(ValueError, match="non-empty string"):
+            NeMoSpeechLMMTP.load_weights(model, [])
+
     @pytest.mark.skipif(not _HAS_CONFIG, reason="NeMoSpeechLMConfig not available")
     def test_mtp_hybrid_override_pattern_from_config(self):
         """mtp_hybrid_override_pattern should read hybrid_override_pattern from mtp config dict."""
@@ -928,8 +1280,8 @@ class TestMTPPlugin:
         assert cfg.mtp_hybrid_override_pattern == "*"
 
     @pytest.mark.skipif(not _HAS_CONFIG, reason="NeMoSpeechLMConfig not available")
-    def test_image_token_index_is_base_vocab_size(self):
-        """image_token_index should equal the backbone base vocab size (before padding)."""
+    def test_audio_token_index_legacy_fallback_is_base_vocab_size(self):
+        """Legacy exports should fall back to the backbone base vocab size."""
         import importlib
 
         config_mod = importlib.import_module("nemo.collections.speechlm2.vllm.salm.config")
@@ -937,7 +1289,39 @@ class TestMTPPlugin:
 
         cfg = NeMoSpeechLMConfig(**_DEFAULT_CONFIG_KWARGS)
         base_vocab = cfg.text_config.vocab_size - extra_rows
+        assert cfg.audio_token_index == base_vocab
         assert cfg.image_token_index == base_vocab
+
+    @pytest.mark.skipif(not _HAS_CONFIG, reason="NeMoSpeechLMConfig not available")
+    def test_audio_token_index_uses_exported_tokenizer_id(self):
+        """New exports should use the tokenizer's exact placeholder ID."""
+        cfg = NeMoSpeechLMConfig(**_DEFAULT_CONFIG_KWARGS, audio_token_index=42)
+        assert cfg.audio_token_index == 42
+        assert cfg.image_token_index == 42
+        assert cfg.to_dict()["audio_token_index"] == 42
+        assert "image_token_index" not in cfg.to_dict()
+
+    @pytest.mark.skipif(not _HAS_CONFIG, reason="NeMoSpeechLMConfig not available")
+    def test_legacy_image_token_index_is_accepted_as_vllm_alias(self):
+        cfg = NeMoSpeechLMConfig(**_DEFAULT_CONFIG_KWARGS, image_token_index=42)
+        assert cfg.audio_token_index == 42
+        assert cfg.image_token_index == 42
+
+    @pytest.mark.skipif(not _HAS_CONFIG, reason="NeMoSpeechLMConfig not available")
+    @pytest.mark.parametrize("field", ["audio_token_index", "image_token_index"])
+    @pytest.mark.parametrize("token_index", [True, "42", -1, 131082])
+    def test_audio_token_index_rejects_invalid_type_or_range(self, field, token_index):
+        with pytest.raises(ValueError, match="audio_token_index"):
+            NeMoSpeechLMConfig(**_DEFAULT_CONFIG_KWARGS, **{field: token_index})
+
+    @pytest.mark.skipif(not _HAS_CONFIG, reason="NeMoSpeechLMConfig not available")
+    def test_conflicting_audio_and_legacy_image_token_indices_raise(self):
+        with pytest.raises(ValueError, match="conflicts"):
+            NeMoSpeechLMConfig(
+                **_DEFAULT_CONFIG_KWARGS,
+                audio_token_index=42,
+                image_token_index=43,
+            )
 
 
 class _FakeTokenizer:

--- a/tests/collections/speechlm2/test_vllm_plugin.py
+++ b/tests/collections/speechlm2/test_vllm_plugin.py
@@ -103,6 +103,38 @@ class TestNeMoSpeechLMConfig:
         assert hasattr(cfg.text_config, "hidden_size")
         assert cfg.get_text_config() is cfg.text_config
 
+    def test_uses_embedded_backbone_config(self, monkeypatch):
+        """Bundled exports must not reload the stale training backbone reference."""
+        embedded_config = {
+            "model_type": "qwen2",
+            "architectures": ["Qwen2ForCausalLM"],
+            "hidden_size": 2048,
+            "vocab_size": 151936,
+            "num_hidden_layers": 4,
+            "rms_norm_eps": 1e-6,
+        }
+        text_config = SimpleNamespace(**embedded_config)
+        from_pretrained = pytest.fail
+
+        monkeypatch.setattr(
+            _config_module.AutoConfig,
+            "from_pretrained",
+            lambda *args, **kwargs: from_pretrained("must not load pretrained_llm when llm_config is embedded"),
+        )
+        monkeypatch.setattr(_config_module.AutoConfig, "for_model", lambda model_type, **kwargs: text_config)
+
+        cfg = NeMoSpeechLMConfig(
+            **{
+                **_DEFAULT_CONFIG_KWARGS,
+                "pretrained_llm": "llm_backbone",
+                "llm_config": embedded_config,
+            }
+        )
+
+        assert cfg.pretrained_llm == "llm_backbone"
+        assert cfg.llm_config == embedded_config
+        assert cfg.text_config is text_config
+
     def test_hybrid_backbone_aliases_for_vllm(self):
         cfg = NeMoSpeechLMConfig(**_DEFAULT_CONFIG_KWARGS)
         assert cfg.is_hybrid is True

--- a/tests/collections/speechlm2/test_vllm_plugin.py
+++ b/tests/collections/speechlm2/test_vllm_plugin.py
@@ -705,6 +705,190 @@ class TestPluginRegistration:
         from_pretrained.assert_not_called()
 
 
+@pytest.mark.skipif(not _HAS_VLLM, reason="vLLM not installed")
+class TestMTPPlugin:
+    """Tests for NeMo SpeechLM MTP speculative-decoding support."""
+
+    class _HFConfigLike:
+        """Minimal stand-in for a HuggingFace PretrainedConfig."""
+
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+        def update(self, d):
+            for k, v in d.items():
+                setattr(self, k, v)
+
+    def test_mtp_patch_registers_model(self, monkeypatch):
+        """register() should add NeMoSpeechLMMTPModel to the model registry."""
+        from transformers import AutoConfig
+        from vllm.model_executor.models.registry import ModelRegistry
+
+        from nemo.collections.speechlm2.vllm.salm import register
+
+        monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
+
+        register()
+
+        assert "NeMoSpeechLMMTPModel" in ModelRegistry.get_supported_archs()
+
+    def test_mtp_patch_extends_mtp_model_types(self, monkeypatch):
+        """register() should add 'nemo_speechlm_mtp' to vLLM's MTPModelTypes Literal."""
+        from typing import get_args
+
+        import vllm.config.speculative as _spec_mod
+        from transformers import AutoConfig
+
+        from nemo.collections.speechlm2.vllm.salm import register
+
+        monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
+
+        register()
+
+        assert "nemo_speechlm_mtp" in get_args(_spec_mod.MTPModelTypes)
+
+    def test_patched_override_routes_nemo_mtp_config(self, monkeypatch):
+        """hf_config_override should rewrite nemo_speechlm configs with MTP heads."""
+        from transformers import AutoConfig
+        from vllm.config.speculative import SpeculativeConfig
+
+        from nemo.collections.speechlm2.vllm.salm import register
+
+        monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
+        register()
+
+        hf_cfg = self._HFConfigLike(
+            model_type="nemo_speechlm",
+            mtp={"num_nextn_predict_layers": 1, "use_repeated_layer": True},
+        )
+        result = SpeculativeConfig.hf_config_override(hf_cfg)
+
+        assert result.model_type == "nemo_speechlm_mtp"
+        assert result.architectures == ["NeMoSpeechLMMTPModel"]
+        assert result.n_predict == 1
+        assert result.num_nextn_predict_layers == 1
+
+    def test_patched_override_no_mtp_falls_through(self, monkeypatch):
+        """hf_config_override should not alter non-MTP configs."""
+        from transformers import AutoConfig
+        from vllm.config.speculative import SpeculativeConfig
+
+        from nemo.collections.speechlm2.vllm.salm import register
+
+        monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
+        original_calls = []
+        _orig = SpeculativeConfig.hf_config_override
+
+        def _recording_orig(cfg):
+            original_calls.append(cfg)
+            return cfg
+
+        monkeypatch.setattr(SpeculativeConfig, "hf_config_override", staticmethod(_recording_orig))
+        register()
+
+        hf_cfg = self._HFConfigLike(model_type="nemo_speechlm", mtp={"num_nextn_predict_layers": 0})
+        SpeculativeConfig.hf_config_override(hf_cfg)
+
+        assert len(original_calls) == 1
+
+    def test_patched_override_multi_head_without_repeated_layer_raises(self, monkeypatch):
+        """hf_config_override should raise for multi-head checkpoints without use_repeated_layer."""
+        from transformers import AutoConfig
+        from vllm.config.speculative import SpeculativeConfig
+
+        from nemo.collections.speechlm2.vllm.salm import register
+
+        monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
+        register()
+
+        hf_cfg = self._HFConfigLike(
+            model_type="nemo_speechlm",
+            mtp={"num_nextn_predict_layers": 3, "use_repeated_layer": False},
+        )
+        with pytest.raises(ValueError, match="use_repeated_layer"):
+            SpeculativeConfig.hf_config_override(hf_cfg)
+
+    def test_mtp_override_registration_is_idempotent(self, monkeypatch):
+        """register() should not repeatedly wrap the config override."""
+        from transformers import AutoConfig
+        from vllm.config.speculative import SpeculativeConfig
+
+        from nemo.collections.speechlm2.vllm.salm import register
+
+        monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
+        register()
+        first_override = SpeculativeConfig.hf_config_override
+        register()
+
+        assert SpeculativeConfig.hf_config_override is first_override
+
+    def test_embed_input_ids_text_only(self):
+        """embed_input_ids with no audio embeddings should return plain text embeddings."""
+        import torch
+
+        from nemo.collections.speechlm2.vllm.salm.mtp import NeMoSpeechLMMTP
+
+        m = object.__new__(NeMoSpeechLMMTP)
+        base_embeds = torch.arange(6, dtype=torch.float).reshape(3, 2)
+        m.model = SimpleNamespace(get_input_embeddings=lambda ids: base_embeds.clone())
+
+        result = m.embed_input_ids(torch.tensor([1, 2, 3]), multimodal_embeddings=None)
+
+        assert result.shape == (3, 2)
+        assert torch.equal(result, base_embeds)
+
+    def test_embed_input_ids_fuses_audio(self):
+        """embed_input_ids should replace placeholder positions with audio embeddings."""
+        import torch
+
+        from nemo.collections.speechlm2.vllm.salm.mtp import NeMoSpeechLMMTP
+
+        m = object.__new__(NeMoSpeechLMMTP)
+        base_embeds = torch.zeros(4, 2)
+        m.model = SimpleNamespace(get_input_embeddings=lambda ids: base_embeds.clone())
+
+        audio_feat = torch.ones(2, 2) * 9.0
+        is_audio = torch.tensor([False, True, True, False])
+        result = m.embed_input_ids(
+            torch.tensor([0, 1, 2, 3]),
+            multimodal_embeddings=[audio_feat],
+            is_multimodal=is_audio,
+        )
+
+        assert torch.equal(result[0], torch.zeros(2))
+        assert torch.equal(result[1], torch.ones(2) * 9.0)
+        assert torch.equal(result[2], torch.ones(2) * 9.0)
+        assert torch.equal(result[3], torch.zeros(2))
+
+    @pytest.mark.skipif(not _HAS_CONFIG, reason="NeMoSpeechLMConfig not available")
+    def test_mtp_hybrid_override_pattern_from_config(self):
+        """mtp_hybrid_override_pattern should read hybrid_override_pattern from mtp config dict."""
+        cfg = NeMoSpeechLMConfig(
+            **_DEFAULT_CONFIG_KWARGS,
+            mtp={"num_nextn_predict_layers": 1, "hybrid_override_pattern": "M*M"},
+        )
+        assert cfg.mtp_hybrid_override_pattern == "M*M"
+
+    @pytest.mark.skipif(not _HAS_CONFIG, reason="NeMoSpeechLMConfig not available")
+    def test_mtp_hybrid_override_pattern_default_all_attention(self):
+        """mtp_hybrid_override_pattern should default to '*' (all-attention) when absent."""
+        cfg = NeMoSpeechLMConfig(**_DEFAULT_CONFIG_KWARGS)
+        assert cfg.mtp_hybrid_override_pattern == "*"
+
+    @pytest.mark.skipif(not _HAS_CONFIG, reason="NeMoSpeechLMConfig not available")
+    def test_image_token_index_is_base_vocab_size(self):
+        """image_token_index should equal the backbone base vocab size (before padding)."""
+        import importlib
+
+        config_mod = importlib.import_module("nemo.collections.speechlm2.vllm.salm.config")
+        extra_rows = config_mod._SPEECHLM_EMBED_EXTRA_ROWS
+
+        cfg = NeMoSpeechLMConfig(**_DEFAULT_CONFIG_KWARGS)
+        base_vocab = cfg.text_config.vocab_size - extra_rows
+        assert cfg.image_token_index == base_vocab
+
+
 class _FakeTokenizer:
     def __init__(self):
         self.added_special_tokens = None

--- a/tests/collections/speechlm2/test_vllm_plugin.py
+++ b/tests/collections/speechlm2/test_vllm_plugin.py
@@ -36,6 +36,11 @@ except (ImportError, RuntimeError):
     _HAS_CONFIG = False
 
 _HAS_VLLM = importlib.util.find_spec("vllm") is not None
+if _HAS_VLLM:
+    import vllm.config.speculative as _spec_mod
+
+    SpeculativeConfig = _spec_mod.SpeculativeConfig
+
 _DEFAULT_CONFIG_KWARGS = {
     "pretrained_llm": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
     "pretrained_asr": "nvidia/canary-1b-v2",
@@ -761,7 +766,6 @@ class TestMTPPlugin:
         """register() should add 'nemo_speechlm_mtp' to vLLM's MTPModelTypes Literal."""
         from typing import get_args
 
-        import vllm.config.speculative as _spec_mod
         from transformers import AutoConfig
 
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
@@ -773,8 +777,6 @@ class TestMTPPlugin:
     def test_patched_override_routes_nemo_mtp_config(self, monkeypatch):
         """hf_config_override should rewrite nemo_speechlm configs with MTP heads."""
         from transformers import AutoConfig
-        from vllm.config.speculative import SpeculativeConfig
-
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         register()
 
@@ -794,8 +796,6 @@ class TestMTPPlugin:
         import pickle
 
         from transformers import AutoConfig
-        from vllm.config.speculative import SpeculativeConfig
-
         import nemo.collections.speechlm2.vllm.salm as salm_module
 
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
@@ -821,8 +821,6 @@ class TestMTPPlugin:
 
     def test_patched_override_lazily_captures_native_hook_in_spawn_child(self, monkeypatch):
         """A fresh spawn import should delegate unrelated configs to vLLM's native hook."""
-        from vllm.config.speculative import SpeculativeConfig
-
         import nemo.collections.speechlm2.vllm.salm as salm_module
 
         original_calls = []
@@ -843,8 +841,6 @@ class TestMTPPlugin:
 
     def test_patched_override_rejects_missing_native_hook(self, monkeypatch):
         """A corrupted install must fail clearly instead of recursing into our override."""
-        from vllm.config.speculative import SpeculativeConfig
-
         import nemo.collections.speechlm2.vllm.salm as salm_module
 
         monkeypatch.setattr(salm_module, "_ORIGINAL_VLLM_HF_CONFIG_OVERRIDE", None)
@@ -860,8 +856,6 @@ class TestMTPPlugin:
     def test_patched_override_enabled_mtp_defaults_to_one_head(self, monkeypatch):
         """An enabled training block without an explicit depth constructs one head."""
         from transformers import AutoConfig
-        from vllm.config.speculative import SpeculativeConfig
-
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         register()
 
@@ -875,8 +869,6 @@ class TestMTPPlugin:
     def test_patched_override_repeated_layer_exposes_one_reusable_head(self, monkeypatch):
         """Repeated-layer training depth must not constrain inference-time K."""
         from transformers import AutoConfig
-        from vllm.config.speculative import SpeculativeConfig
-
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         register()
 
@@ -892,8 +884,6 @@ class TestMTPPlugin:
     def test_patched_override_no_mtp_falls_through(self, monkeypatch):
         """hf_config_override should not alter non-MTP configs."""
         from transformers import AutoConfig
-        from vllm.config.speculative import SpeculativeConfig
-
         import nemo.collections.speechlm2.vllm.salm as salm_module
 
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
@@ -915,8 +905,6 @@ class TestMTPPlugin:
     def test_patched_override_depth_without_enabled_flag_falls_through(self, monkeypatch):
         """A retained recipe depth must not enable a head that training did not construct."""
         from transformers import AutoConfig
-        from vllm.config.speculative import SpeculativeConfig
-
         import nemo.collections.speechlm2.vllm.salm as salm_module
 
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
@@ -942,8 +930,6 @@ class TestMTPPlugin:
     def test_patched_override_explicitly_disabled_mtp_falls_through(self, monkeypatch):
         """An exported recipe depth must not override mtp.enabled=false."""
         from transformers import AutoConfig
-        from vllm.config.speculative import SpeculativeConfig
-
         import nemo.collections.speechlm2.vllm.salm as salm_module
 
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
@@ -969,8 +955,6 @@ class TestMTPPlugin:
     def test_patched_override_multi_head_without_repeated_layer_raises(self, monkeypatch):
         """hf_config_override should raise for multi-head checkpoints without use_repeated_layer."""
         from transformers import AutoConfig
-        from vllm.config.speculative import SpeculativeConfig
-
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         register()
 
@@ -984,8 +968,6 @@ class TestMTPPlugin:
     def test_mtp_override_registration_is_idempotent(self, monkeypatch):
         """register() should not repeatedly wrap the config override."""
         from transformers import AutoConfig
-        from vllm.config.speculative import SpeculativeConfig
-
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         register()
         first_override = SpeculativeConfig.hf_config_override
@@ -996,8 +978,6 @@ class TestMTPPlugin:
     def test_mtp_override_reregistration_preserves_first_native_hook(self, monkeypatch):
         """A later wrapper that delegates to us must not become our fallback and recurse."""
         from transformers import AutoConfig
-        from vllm.config.speculative import SpeculativeConfig
-
         import nemo.collections.speechlm2.vllm.salm as salm_module
 
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))

--- a/tests/collections/speechlm2/test_vllm_plugin.py
+++ b/tests/collections/speechlm2/test_vllm_plugin.py
@@ -43,6 +43,11 @@ _DEFAULT_CONFIG_KWARGS = {
 }
 
 
+def _identity_hf_config_override(hf_config):
+    """Pickleable target override for vLLM's composed-override API."""
+    return hf_config
+
+
 @pytest.mark.skipif(not _HAS_CONFIG, reason="NeMoSpeechLMConfig not available")
 class TestNeMoSpeechLMConfig:
     """Tests for NeMoSpeechLMConfig."""
@@ -711,6 +716,15 @@ class TestMTPPlugin:
     """Tests for NeMo SpeechLM MTP speculative-decoding support."""
 
     @pytest.fixture(autouse=True)
+    def restore_original_override(self):
+        """Keep the process-local fallback hook isolated between tests."""
+        import nemo.collections.speechlm2.vllm.salm as salm_module
+
+        original_override = salm_module._ORIGINAL_VLLM_HF_CONFIG_OVERRIDE
+        yield
+        salm_module._ORIGINAL_VLLM_HF_CONFIG_OVERRIDE = original_override
+
+    @pytest.fixture(autouse=True)
     def mock_backbone_config(self, monkeypatch):
         """Keep registration tests independent of Hugging Face network access."""
         if not _HAS_CONFIG:
@@ -789,6 +803,76 @@ class TestMTPPlugin:
         assert result.n_predict == 1
         assert result.num_nextn_predict_layers == 1
 
+    def test_patched_override_is_pickleable_for_spawned_engine(self, monkeypatch):
+        """The callable retained on draft ModelConfig must survive multiprocessing spawn."""
+        import pickle
+
+        from transformers import AutoConfig
+        from vllm.config.speculative import SpeculativeConfig
+
+        import nemo.collections.speechlm2.vllm.salm as salm_module
+
+        from nemo.collections.speechlm2.vllm.salm import register
+
+        monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
+        register()
+
+        restored = pickle.loads(pickle.dumps(SpeculativeConfig.hf_config_override))
+        assert restored is salm_module._nemo_speechlm_mtp_hf_config_override
+
+        overrides = [restored]
+        if hasattr(SpeculativeConfig, "compose_draft_hf_overrides"):
+            composed = SpeculativeConfig.compose_draft_hf_overrides(_identity_hf_config_override)
+            assert composed is not SpeculativeConfig.hf_config_override
+            overrides.append(pickle.loads(pickle.dumps(composed)))
+
+        for override in overrides:
+            hf_cfg = self._HFConfigLike(
+                model_type="nemo_speechlm",
+                mtp={"enabled": True, "num_nextn_predict_layers": 4, "use_repeated_layer": True},
+            )
+            result = override(hf_cfg)
+            assert result.model_type == "nemo_speechlm_mtp"
+            assert result.n_predict == 1
+
+    def test_patched_override_lazily_captures_native_hook_in_spawn_child(self, monkeypatch):
+        """A fresh spawn import should delegate unrelated configs to vLLM's native hook."""
+        from vllm.config.speculative import SpeculativeConfig
+
+        import nemo.collections.speechlm2.vllm.salm as salm_module
+
+        original_calls = []
+
+        def _recording_native(cfg):
+            original_calls.append(cfg)
+            return cfg
+
+        monkeypatch.setattr(salm_module, "_ORIGINAL_VLLM_HF_CONFIG_OVERRIDE", None)
+        monkeypatch.setattr(SpeculativeConfig, "hf_config_override", staticmethod(_recording_native))
+
+        hf_cfg = self._HFConfigLike(model_type="unrelated")
+        result = salm_module._nemo_speechlm_mtp_hf_config_override(hf_cfg)
+
+        assert result is hf_cfg
+        assert original_calls == [hf_cfg]
+        assert salm_module._ORIGINAL_VLLM_HF_CONFIG_OVERRIDE is _recording_native
+
+    def test_patched_override_rejects_missing_native_hook(self, monkeypatch):
+        """A corrupted install must fail clearly instead of recursing into our override."""
+        from vllm.config.speculative import SpeculativeConfig
+
+        import nemo.collections.speechlm2.vllm.salm as salm_module
+
+        monkeypatch.setattr(salm_module, "_ORIGINAL_VLLM_HF_CONFIG_OVERRIDE", None)
+        monkeypatch.setattr(
+            SpeculativeConfig,
+            "hf_config_override",
+            staticmethod(salm_module._nemo_speechlm_mtp_hf_config_override),
+        )
+
+        with pytest.raises(RuntimeError, match="without preserving vLLM's original hook"):
+            salm_module._nemo_speechlm_mtp_hf_config_override(self._HFConfigLike(model_type="unrelated"))
+
     def test_patched_override_enabled_mtp_defaults_to_one_head(self, monkeypatch):
         """An enabled training block without an explicit depth constructs one head."""
         from transformers import AutoConfig
@@ -830,6 +914,8 @@ class TestMTPPlugin:
         from transformers import AutoConfig
         from vllm.config.speculative import SpeculativeConfig
 
+        import nemo.collections.speechlm2.vllm.salm as salm_module
+
         from nemo.collections.speechlm2.vllm.salm import register
 
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
@@ -839,6 +925,7 @@ class TestMTPPlugin:
             original_calls.append(cfg)
             return cfg
 
+        monkeypatch.setattr(salm_module, "_ORIGINAL_VLLM_HF_CONFIG_OVERRIDE", None)
         monkeypatch.setattr(SpeculativeConfig, "hf_config_override", staticmethod(_recording_orig))
         register()
 
@@ -852,6 +939,8 @@ class TestMTPPlugin:
         from transformers import AutoConfig
         from vllm.config.speculative import SpeculativeConfig
 
+        import nemo.collections.speechlm2.vllm.salm as salm_module
+
         from nemo.collections.speechlm2.vllm.salm import register
 
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
@@ -861,6 +950,7 @@ class TestMTPPlugin:
             original_calls.append(cfg)
             return cfg
 
+        monkeypatch.setattr(salm_module, "_ORIGINAL_VLLM_HF_CONFIG_OVERRIDE", None)
         monkeypatch.setattr(SpeculativeConfig, "hf_config_override", staticmethod(_recording_orig))
         register()
 
@@ -878,6 +968,8 @@ class TestMTPPlugin:
         from transformers import AutoConfig
         from vllm.config.speculative import SpeculativeConfig
 
+        import nemo.collections.speechlm2.vllm.salm as salm_module
+
         from nemo.collections.speechlm2.vllm.salm import register
 
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
@@ -887,6 +979,7 @@ class TestMTPPlugin:
             original_calls.append(cfg)
             return cfg
 
+        monkeypatch.setattr(salm_module, "_ORIGINAL_VLLM_HF_CONFIG_OVERRIDE", None)
         monkeypatch.setattr(SpeculativeConfig, "hf_config_override", staticmethod(_recording_orig))
         register()
 
@@ -929,6 +1022,40 @@ class TestMTPPlugin:
         register()
 
         assert SpeculativeConfig.hf_config_override is first_override
+
+    def test_mtp_override_reregistration_preserves_first_native_hook(self, monkeypatch):
+        """A later wrapper that delegates to us must not become our fallback and recurse."""
+        from transformers import AutoConfig
+        from vllm.config.speculative import SpeculativeConfig
+
+        import nemo.collections.speechlm2.vllm.salm as salm_module
+
+        from nemo.collections.speechlm2.vllm.salm import register
+
+        monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
+        native_calls = []
+
+        def _recording_native(cfg):
+            native_calls.append(cfg)
+            return cfg
+
+        monkeypatch.setattr(salm_module, "_ORIGINAL_VLLM_HF_CONFIG_OVERRIDE", None)
+        monkeypatch.setattr(SpeculativeConfig, "hf_config_override", staticmethod(_recording_native))
+        register()
+        first_override = SpeculativeConfig.hf_config_override
+
+        def _third_party_wrapper(cfg):
+            return first_override(cfg)
+
+        monkeypatch.setattr(SpeculativeConfig, "hf_config_override", staticmethod(_third_party_wrapper))
+        register()
+
+        hf_cfg = self._HFConfigLike(model_type="unrelated")
+        result = SpeculativeConfig.hf_config_override(hf_cfg)
+
+        assert result is hf_cfg
+        assert native_calls == [hf_cfg]
+        assert salm_module._ORIGINAL_VLLM_HF_CONFIG_OVERRIDE is _recording_native
 
     def test_embed_input_ids_text_only(self):
         """embed_input_ids with no audio embeddings should return plain text embeddings."""

--- a/tests/collections/speechlm2/test_vllm_plugin.py
+++ b/tests/collections/speechlm2/test_vllm_plugin.py
@@ -769,6 +769,25 @@ class TestMTPPlugin:
         assert result.n_predict == 1
         assert result.num_nextn_predict_layers == 1
 
+    def test_patched_override_repeated_layer_exposes_one_reusable_head(self, monkeypatch):
+        """Repeated-layer training depth must not constrain inference-time K."""
+        from transformers import AutoConfig
+        from vllm.config.speculative import SpeculativeConfig
+
+        from nemo.collections.speechlm2.vllm.salm import register
+
+        monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
+        register()
+
+        hf_cfg = self._HFConfigLike(
+            model_type="nemo_speechlm",
+            mtp={"num_nextn_predict_layers": 4, "use_repeated_layer": True},
+        )
+        result = SpeculativeConfig.hf_config_override(hf_cfg)
+
+        assert result.n_predict == 1
+        assert result.num_nextn_predict_layers == 1
+
     def test_patched_override_no_mtp_falls_through(self, monkeypatch):
         """hf_config_override should not alter non-MTP configs."""
         from transformers import AutoConfig
@@ -859,6 +878,39 @@ class TestMTPPlugin:
         assert torch.equal(result[1], torch.ones(2) * 9.0)
         assert torch.equal(result[2], torch.ones(2) * 9.0)
         assert torch.equal(result[3], torch.zeros(2))
+
+    def test_mtp_weight_remap_uses_vllm_embedding_alias(self):
+        """Exported SpeechLM embeddings must pass NemotronHMTP's name filter."""
+        import torch
+
+        from nemo.collections.speechlm2.vllm.salm.mtp import _remap_nemo_mtp_weights
+
+        tensor = torch.ones(2, 3)
+        remapped = dict(
+            _remap_nemo_mtp_weights(
+                [
+                    ("llm.model.embed_tokens.weight", tensor),
+                    ("llm.mtp.layers.0.enorm.weight", tensor),
+                    ("llm.lm_head.weight", tensor),
+                ]
+            )
+        )
+
+        assert set(remapped) == {
+            "backbone.embeddings.weight",
+            "mtp.layers.0.enorm.weight",
+            "lm_head.weight",
+        }
+        assert remapped["backbone.embeddings.weight"] is tensor
+
+        padded = dict(
+            _remap_nemo_mtp_weights(
+                [("llm.model.embed_tokens.weight", tensor), ("llm.lm_head.weight", tensor)],
+                target_vocab=5,
+            )
+        )
+        assert padded["backbone.embeddings.weight"].shape == (5, 3)
+        assert padded["lm_head.weight"].shape == (5, 3)
 
     @pytest.mark.skipif(not _HAS_CONFIG, reason="NeMoSpeechLMConfig not available")
     def test_mtp_hybrid_override_pattern_from_config(self):

--- a/tests/collections/speechlm2/test_vllm_plugin.py
+++ b/tests/collections/speechlm2/test_vllm_plugin.py
@@ -79,18 +79,11 @@ class TestNeMoSpeechLMConfig:
         assert cfg.pretrained_llm is None
         assert cfg.pretrained_asr is None
         assert cfg.audio_locator_tag is None
-        assert cfg.audio_token_index is None
         assert cfg.image_token_index is None
         assert cfg.prompt_format is None
         assert cfg.pretrained_weights is None
         assert cfg.llm_architectures == []
         assert cfg.get_text_config() is cfg.text_config
-
-    @pytest.mark.parametrize("field", ["audio_token_index", "image_token_index"])
-    def test_token_index_alone_is_not_default_construction(self, field):
-        """Checkpoint data must not be silently discarded by HF's no-arg path."""
-        with pytest.raises(ValueError, match="pretrained_llm"):
-            NeMoSpeechLMConfig(**{field: 42})
 
     def test_loads_text_config(self):
         """Config should load a text_config from the pretrained LLM."""
@@ -1280,8 +1273,8 @@ class TestMTPPlugin:
         assert cfg.mtp_hybrid_override_pattern == "*"
 
     @pytest.mark.skipif(not _HAS_CONFIG, reason="NeMoSpeechLMConfig not available")
-    def test_audio_token_index_legacy_fallback_is_base_vocab_size(self):
-        """Legacy exports should fall back to the backbone base vocab size."""
+    def test_image_token_index_is_unserialized_backbone_vocab_boundary(self):
+        """vLLM's compatibility property should identify the first padded row."""
         import importlib
 
         config_mod = importlib.import_module("nemo.collections.speechlm2.vllm.salm.config")
@@ -1289,39 +1282,13 @@ class TestMTPPlugin:
 
         cfg = NeMoSpeechLMConfig(**_DEFAULT_CONFIG_KWARGS)
         base_vocab = cfg.text_config.vocab_size - extra_rows
-        assert cfg.audio_token_index == base_vocab
         assert cfg.image_token_index == base_vocab
-
-    @pytest.mark.skipif(not _HAS_CONFIG, reason="NeMoSpeechLMConfig not available")
-    def test_audio_token_index_uses_exported_tokenizer_id(self):
-        """New exports should use the tokenizer's exact placeholder ID."""
-        cfg = NeMoSpeechLMConfig(**_DEFAULT_CONFIG_KWARGS, audio_token_index=42)
-        assert cfg.audio_token_index == 42
-        assert cfg.image_token_index == 42
-        assert cfg.to_dict()["audio_token_index"] == 42
+        # vLLM 0.26 copies the target value onto the draft config. The setter
+        # accepts that runtime-only assignment without adding serialized state.
+        cfg.image_token_index = base_vocab
+        assert cfg.image_token_index == base_vocab
+        assert "audio_token_index" not in cfg.to_dict()
         assert "image_token_index" not in cfg.to_dict()
-
-    @pytest.mark.skipif(not _HAS_CONFIG, reason="NeMoSpeechLMConfig not available")
-    def test_legacy_image_token_index_is_accepted_as_vllm_alias(self):
-        cfg = NeMoSpeechLMConfig(**_DEFAULT_CONFIG_KWARGS, image_token_index=42)
-        assert cfg.audio_token_index == 42
-        assert cfg.image_token_index == 42
-
-    @pytest.mark.skipif(not _HAS_CONFIG, reason="NeMoSpeechLMConfig not available")
-    @pytest.mark.parametrize("field", ["audio_token_index", "image_token_index"])
-    @pytest.mark.parametrize("token_index", [True, "42", -1, 131082])
-    def test_audio_token_index_rejects_invalid_type_or_range(self, field, token_index):
-        with pytest.raises(ValueError, match="audio_token_index"):
-            NeMoSpeechLMConfig(**_DEFAULT_CONFIG_KWARGS, **{field: token_index})
-
-    @pytest.mark.skipif(not _HAS_CONFIG, reason="NeMoSpeechLMConfig not available")
-    def test_conflicting_audio_and_legacy_image_token_indices_raise(self):
-        with pytest.raises(ValueError, match="conflicts"):
-            NeMoSpeechLMConfig(
-                **_DEFAULT_CONFIG_KWARGS,
-                audio_token_index=42,
-                image_token_index=43,
-            )
 
 
 class _FakeTokenizer:

--- a/tests/collections/speechlm2/test_vllm_plugin.py
+++ b/tests/collections/speechlm2/test_vllm_plugin.py
@@ -25,9 +25,11 @@ from types import SimpleNamespace
 import pytest
 
 try:
-    from nemo.collections.speechlm2.vllm.salm import config as _config_module
+    import nemo.collections.speechlm2.vllm.salm as _salm_module
+    import nemo.collections.speechlm2.vllm.salm.config as _config_module
 
     NeMoSpeechLMConfig = _config_module.NeMoSpeechLMConfig
+    register = _salm_module.register
 
     _HAS_CONFIG = True
 except (ImportError, RuntimeError):
@@ -648,8 +650,6 @@ class TestPluginRegistration:
         """register() should add nemo_speechlm to vLLM's config registry."""
         from transformers import AutoConfig
 
-        from nemo.collections.speechlm2.vllm.salm import register
-
         monkeypatch.setattr(
             AutoConfig, "from_pretrained", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError())
         )
@@ -668,8 +668,6 @@ class TestPluginRegistration:
         """
         from transformers import AutoConfig
 
-        from nemo.collections.speechlm2.vllm.salm import register
-
         monkeypatch.setattr(
             AutoConfig, "from_pretrained", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError())
         )
@@ -686,8 +684,6 @@ class TestPluginRegistration:
     def test_register_does_not_patch_fast_tokenizer(self, monkeypatch):
         from transformers import AutoConfig, PreTrainedTokenizerFast
 
-        from nemo.collections.speechlm2.vllm.salm import register
-
         monkeypatch.setattr(
             AutoConfig, "from_pretrained", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError())
         )
@@ -700,8 +696,6 @@ class TestPluginRegistration:
         from unittest.mock import Mock
 
         from transformers import AutoConfig
-
-        from nemo.collections.speechlm2.vllm.salm import register
 
         from_pretrained = Mock(side_effect=AssertionError("register() must not load remote backbone configs"))
         monkeypatch.setattr(AutoConfig, "from_pretrained", from_pretrained)
@@ -759,8 +753,6 @@ class TestMTPPlugin:
         from transformers import AutoConfig
         from vllm.model_executor.models.registry import ModelRegistry
 
-        from nemo.collections.speechlm2.vllm.salm import register
-
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
 
         register()
@@ -774,8 +766,6 @@ class TestMTPPlugin:
         import vllm.config.speculative as _spec_mod
         from transformers import AutoConfig
 
-        from nemo.collections.speechlm2.vllm.salm import register
-
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
 
         register()
@@ -786,8 +776,6 @@ class TestMTPPlugin:
         """hf_config_override should rewrite nemo_speechlm configs with MTP heads."""
         from transformers import AutoConfig
         from vllm.config.speculative import SpeculativeConfig
-
-        from nemo.collections.speechlm2.vllm.salm import register
 
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         register()
@@ -811,8 +799,6 @@ class TestMTPPlugin:
         from vllm.config.speculative import SpeculativeConfig
 
         import nemo.collections.speechlm2.vllm.salm as salm_module
-
-        from nemo.collections.speechlm2.vllm.salm import register
 
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         register()
@@ -878,8 +864,6 @@ class TestMTPPlugin:
         from transformers import AutoConfig
         from vllm.config.speculative import SpeculativeConfig
 
-        from nemo.collections.speechlm2.vllm.salm import register
-
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         register()
 
@@ -894,8 +878,6 @@ class TestMTPPlugin:
         """Repeated-layer training depth must not constrain inference-time K."""
         from transformers import AutoConfig
         from vllm.config.speculative import SpeculativeConfig
-
-        from nemo.collections.speechlm2.vllm.salm import register
 
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         register()
@@ -915,8 +897,6 @@ class TestMTPPlugin:
         from vllm.config.speculative import SpeculativeConfig
 
         import nemo.collections.speechlm2.vllm.salm as salm_module
-
-        from nemo.collections.speechlm2.vllm.salm import register
 
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         original_calls = []
@@ -940,8 +920,6 @@ class TestMTPPlugin:
         from vllm.config.speculative import SpeculativeConfig
 
         import nemo.collections.speechlm2.vllm.salm as salm_module
-
-        from nemo.collections.speechlm2.vllm.salm import register
 
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         original_calls = []
@@ -970,8 +948,6 @@ class TestMTPPlugin:
 
         import nemo.collections.speechlm2.vllm.salm as salm_module
 
-        from nemo.collections.speechlm2.vllm.salm import register
-
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         original_calls = []
 
@@ -997,8 +973,6 @@ class TestMTPPlugin:
         from transformers import AutoConfig
         from vllm.config.speculative import SpeculativeConfig
 
-        from nemo.collections.speechlm2.vllm.salm import register
-
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         register()
 
@@ -1014,8 +988,6 @@ class TestMTPPlugin:
         from transformers import AutoConfig
         from vllm.config.speculative import SpeculativeConfig
 
-        from nemo.collections.speechlm2.vllm.salm import register
-
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         register()
         first_override = SpeculativeConfig.hf_config_override
@@ -1029,8 +1001,6 @@ class TestMTPPlugin:
         from vllm.config.speculative import SpeculativeConfig
 
         import nemo.collections.speechlm2.vllm.salm as salm_module
-
-        from nemo.collections.speechlm2.vllm.salm import register
 
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         native_calls = []

--- a/tests/collections/speechlm2/test_vllm_plugin.py
+++ b/tests/collections/speechlm2/test_vllm_plugin.py
@@ -778,7 +778,6 @@ class TestMTPPlugin:
 
         monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError()))
         original_calls = []
-        _orig = SpeculativeConfig.hf_config_override
 
         def _recording_orig(cfg):
             original_calls.append(cfg)


### PR DESCRIPTION
- register the NeMo SpeechLM MTP draft model and route compatible repeated-layer checkpoints through vLLM speculative decoding
- fuse audio embeddings at placeholder positions for target and draft models
- load MTP weights while handling SpeechLM checkpoint prefixes and vocabulary padding
- make plugin registration idempotent and validate repeated-layer multi-head configurations
- add focused plugin tests for registration, config routing, embeddings, and MTP properties

> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?
Add MTP speculative decoding support for NeMo SpeechLM models served through vLLM.

**Collection**:  SpeechLM (`nemo.collections.speechlm2`)

# Changelog

- Register a NeMo SpeechLM MTP draft-model architecture with vLLM.
- Route SpeechLM checkpoints with MTP configuration through vLLM speculative decoding.
- Support repeated-layer, multi-head MTP checkpoints.
- Fuse audio embeddings into placeholder positions for both target and draft models.
- Load MTP checkpoint weights while handling SpeechLM prefixes and vocabulary padding.
- Reject incompatible multi-head checkpoints that were not trained with a repeated MTP layer.
- Make vLLM plugin registration idempotent.
- Add unit tests for registration, configuration routing, weight handling, and multimodal MTP embeddings.


# Usage

- You can potentially add a usage example below

```python
from nemo.collections.speechlm2.vllm.salm import register

register()
```

And then start vllm server:
```
vllm serve /path/to/speechlm-checkpoint \
  --trust-remote-code \
  --speculative-config '{"method":"mtp","num_speculative_tokens":4}'
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- 55 focused SpeechLM vLLM plugin tests.
- vLLM 0.23.0.
- A four-head repeated-layer MTP checkpoint.
- The complete 83,212-sample Open-ASR leaderboard.
- MTP and no-MTP WER remained equivalent within normal run-to-run variation.
