### PR TITLE
[TTS] Add codebook dropout in codec training

### DIFF
--- a/nemo/collections/tts/models/audio_codec.py
+++ b/nemo/collections/tts/models/audio_codec.py
@@ -39,11 +39,7 @@ from nemo.collections.tts.losses.audio_codec_loss import (
     SISDRLoss,
     TimeDomainLoss,
 )
-from nemo.collections.tts.modules.audio_codec_modules import (
-    GroupFiniteScalarQuantizer,
-    ResNetSpeakerEncoder,
-    default_precision,
-)
+from nemo.collections.tts.modules.audio_codec_modules import ResNetSpeakerEncoder, default_precision
 from nemo.collections.tts.modules.common import GaussianDropout
 from nemo.collections.tts.parts.utils.callbacks import LoggingCallback
 from nemo.collections.tts.parts.utils.helpers import get_batch_size, get_num_workers
@@ -101,6 +97,7 @@ class AudioCodecModel(ModelPT):
 
         if "vector_quantizer" in cfg:
             self.vector_quantizer = safe_instantiate(cfg.vector_quantizer)
+            self.codebook_dropout_rate = cfg.get("codebook_dropout_rate", 0.0)
 
             vq_output_types = list(self.vector_quantizer.output_types.keys())
 
@@ -110,13 +107,10 @@ class AudioCodecModel(ModelPT):
             else:
                 self.vector_quantizer_has_commit_loss = False
                 logging.info('Vector quantizer does not support commit loss.')
-
-            self.codebook_dropout_rate = cfg.get("codebook_dropout_rate", 0.0)
-            if self.codebook_dropout_rate and not isinstance(self.vector_quantizer, GroupFiniteScalarQuantizer):
-                raise ValueError("Codebook dropout only supported for GroupFiniteScalarQuantizer")
         else:
             logging.warning('Vector quantizer will not be used.')
             self.vector_quantizer = None
+            self.codebook_dropout_rate = 0.0
 
         # Decoder setup
         self.audio_decoder = safe_instantiate(cfg.audio_decoder)
@@ -466,7 +460,9 @@ class AudioCodecModel(ModelPT):
         encoded, encoded_len = self.encode_audio(audio=audio, audio_len=audio_len, sample_rate=sample_rate)
 
         if num_codebooks:
-            encoded = self._dropout_codebooks(encoded=encoded, num_codebooks=num_codebooks)
+            assert self.vector_quantizer is not None
+            num_codebooks_batch = num_codebooks * torch.ones([encoded.shape[0]])
+            encoded = self.vector_quantizer.dropout_codebooks(encoded=encoded, num_codebooks=num_codebooks_batch)
 
         # Apply quantizer to obtain discrete representation per frame
         tokens = self.quantize(encoded=encoded, encoded_len=encoded_len)
@@ -568,43 +564,15 @@ class AudioCodecModel(ModelPT):
         audio, audio_len = self.pad_audio(audio=audio, audio_len=audio_len, samples_per_frame=self.samples_per_frame)
         return audio, audio_len
 
-    def _dropout_codebooks(self, encoded, num_codebooks):
-        """Dropout encoder output so that only 'num_codebooks' are left as decoder_input.
-        This is done for FSQ by setting all embedding values in dimensions above (num_codebooks * codebook_dim) to 0.
-
-        Args:
-            encoded: encoder output (B, D, T)
-            num_codebooks: number of codebooks to keep. This can be an integer, or a 3-D tensor compatible with the
-                dimensions of the encoder output
-
-        Returns:
-            Encoder output with all codebooks above index 'num_codebooks' masked out
-        """
-        batch_size, embed_dim, num_frames = encoded.shape
-        emb_unmask_dim = self.vector_quantizer.codebook_dim_per_group * num_codebooks
-        # [B, D, T]
-        embed_indices = (
-            torch.arange(start=0, end=embed_dim, device=encoded.device)
-            .unsqueeze(0)
-            .unsqueeze(2)
-            .repeat(batch_size, 1, num_frames)
-        )
-        codebook_mask = embed_indices < emb_unmask_dim
-        out = encoded * codebook_mask
-        return out
-
     def _dropout_random_codebooks(self, encoded):
         """Dropout a random number of codebooks for each batch element"""
         batch_size = encoded.shape[0]
         # [B]
         apply_dropout = torch.rand(size=[batch_size], device=encoded.device) < self.codebook_dropout_rate
         # Select random integers in range (1, num_codebooks - 1)
-        num_codebooks_unmasked = torch.randint(
-            low=1, high=self.num_codebooks, size=[batch_size], device=encoded.device
-        )
-        num_codebooks_unmasked = torch.where(apply_dropout, num_codebooks_unmasked, self.num_codebooks)
-        num_codebooks_unmasked = rearrange(num_codebooks_unmasked, 'B -> B 1 1')
-        out = self._dropout_codebooks(encoded=encoded, num_codebooks=num_codebooks_unmasked)
+        num_codebooks = torch.randint(low=1, high=self.num_codebooks, size=[batch_size], device=encoded.device)
+        num_codebooks = torch.where(apply_dropout, num_codebooks, self.num_codebooks)
+        out = self.vector_quantizer.dropout_codebooks(encoded=encoded, num_codebooks=num_codebooks)
         return out
 
     def _process_batch(self, batch):

--- a/nemo/collections/tts/models/audio_codec.py
+++ b/nemo/collections/tts/models/audio_codec.py
@@ -39,7 +39,11 @@ from nemo.collections.tts.losses.audio_codec_loss import (
     SISDRLoss,
     TimeDomainLoss,
 )
-from nemo.collections.tts.modules.audio_codec_modules import ResNetSpeakerEncoder, default_precision
+from nemo.collections.tts.modules.audio_codec_modules import (
+    GroupFiniteScalarQuantizer,
+    ResNetSpeakerEncoder,
+    default_precision,
+)
 from nemo.collections.tts.modules.common import GaussianDropout
 from nemo.collections.tts.parts.utils.callbacks import LoggingCallback
 from nemo.collections.tts.parts.utils.helpers import get_batch_size, get_num_workers
@@ -107,6 +111,9 @@ class AudioCodecModel(ModelPT):
                 self.vector_quantizer_has_commit_loss = False
                 logging.info('Vector quantizer does not support commit loss.')
 
+            self.codebook_dropout_rate = cfg.get("codebook_dropout_rate", 0.0)
+            if self.codebook_dropout_rate and not isinstance(self.vector_quantizer, GroupFiniteScalarQuantizer):
+                raise ValueError("Codebook dropout only supported for GroupFiniteScalarQuantizer")
         else:
             logging.warning('Vector quantizer will not be used.')
             self.vector_quantizer = None
@@ -428,6 +435,7 @@ class AudioCodecModel(ModelPT):
             "audio": NeuralType(('B', 'T_audio'), AudioSignal()),
             "audio_len": NeuralType(tuple('B'), LengthsType()),
             "sample_rate": NeuralType(tuple(), IntType(), optional=True),
+            "num_codebooks": NeuralType(tuple(), IntType(), optional=True),
         },
         output_types={
             "tokens": NeuralType(('B', 'C', 'T_encoded'), TokenIndex()),
@@ -435,7 +443,11 @@ class AudioCodecModel(ModelPT):
         },
     )
     def encode(
-        self, audio: torch.Tensor, audio_len: torch.Tensor, sample_rate: Optional[int] = None
+        self,
+        audio: torch.Tensor,
+        audio_len: torch.Tensor,
+        sample_rate: Optional[int] = None,
+        num_codebooks: Optional[int] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Convert input time-domain audio signal into a discrete representation (tokens).
 
@@ -443,6 +455,8 @@ class AudioCodecModel(ModelPT):
             audio: input time-domain signal, shape `(batch, number of samples)`
             audio_len: valid length for each example in the batch, shape `(batch size,)`
             sample_rate: sample rate of input audio (int)
+            num_codebooks: number of codebooks to use for reconstructing audio.
+                Using fewer codebooks will only be accurate for codecs trained with FSQ codebook dropout.
 
         Returns:
             Tokens for each codebook for each frame, shape `(batch, number of codebooks, number of frames)`,
@@ -450,6 +464,10 @@ class AudioCodecModel(ModelPT):
         """
         # Apply encoder to obtain a continuous vector for each frame
         encoded, encoded_len = self.encode_audio(audio=audio, audio_len=audio_len, sample_rate=sample_rate)
+
+        if num_codebooks:
+            encoded = self._dropout_codebooks(encoded=encoded, num_codebooks=num_codebooks)
+
         # Apply quantizer to obtain discrete representation per frame
         tokens = self.quantize(encoded=encoded, encoded_len=encoded_len)
         return tokens, encoded_len
@@ -550,6 +568,45 @@ class AudioCodecModel(ModelPT):
         audio, audio_len = self.pad_audio(audio=audio, audio_len=audio_len, samples_per_frame=self.samples_per_frame)
         return audio, audio_len
 
+    def _dropout_codebooks(self, encoded, num_codebooks):
+        """Dropout encoder output so that only 'num_codebooks' are left as decoder_input.
+        This is done for FSQ by setting all embedding values in dimensions above (num_codebooks * codebook_dim) to 0.
+
+        Args:
+            encoded: encoder output (B, D, T)
+            num_codebooks: number of codebooks to keep. This can be an integer, or a 3-D tensor compatible with the
+                dimensions of the encoder output
+
+        Returns:
+            Encoder output with all codebooks above index 'num_codebooks' masked out
+        """
+        batch_size, embed_dim, num_frames = encoded.shape
+        emb_unmask_dim = self.vector_quantizer.codebook_dim_per_group * num_codebooks
+        # [B, D, T]
+        embed_indices = (
+            torch.arange(start=0, end=embed_dim, device=encoded.device)
+            .unsqueeze(0)
+            .unsqueeze(2)
+            .repeat(batch_size, 1, num_frames)
+        )
+        codebook_mask = embed_indices < emb_unmask_dim
+        out = encoded * codebook_mask
+        return out
+
+    def _dropout_random_codebooks(self, encoded):
+        """Dropout a random number of codebooks for each batch element"""
+        batch_size = encoded.shape[0]
+        # [B]
+        apply_dropout = torch.rand(size=[batch_size], device=encoded.device) < self.codebook_dropout_rate
+        # Select random integers in range (1, num_codebooks - 1)
+        num_codebooks_unmasked = torch.randint(
+            low=1, high=self.num_codebooks, size=[batch_size], device=encoded.device
+        )
+        num_codebooks_unmasked = torch.where(apply_dropout, num_codebooks_unmasked, self.num_codebooks)
+        num_codebooks_unmasked = rearrange(num_codebooks_unmasked, 'B -> B 1 1')
+        out = self._dropout_codebooks(encoded=encoded, num_codebooks=num_codebooks_unmasked)
+        return out
+
     def _process_batch(self, batch):
         # [B, T_audio]
         audio = batch.get("audio")
@@ -577,6 +634,9 @@ class AudioCodecModel(ModelPT):
             encoded = encoded.to(encoded.dtype)  # make sure encoded is converted to the right dtype
         else:
             commit_loss = 0.0
+
+        if self.training and self.codebook_dropout_rate:
+            encoded = self._dropout_random_codebooks(encoded)
 
         # [B, T]
         audio_gen, _ = self.audio_decoder(inputs=encoded, input_len=encoded_len)

--- a/nemo/collections/tts/models/audio_codec.py
+++ b/nemo/collections/tts/models/audio_codec.py
@@ -450,7 +450,7 @@ class AudioCodecModel(ModelPT):
             audio_len: valid length for each example in the batch, shape `(batch size,)`
             sample_rate: sample rate of input audio (int)
             num_codebooks: number of codebooks to use for reconstructing audio.
-                Using fewer codebooks will only be accurate for codecs trained with FSQ codebook dropout.
+                Using fewer codebooks will only be accurate for codecs trained with codebook dropout.
 
         Returns:
             Tokens for each codebook for each frame, shape `(batch, number of codebooks, number of frames)`,

--- a/nemo/collections/tts/modules/audio_codec_modules.py
+++ b/nemo/collections/tts/modules/audio_codec_modules.py
@@ -232,7 +232,7 @@ class SLMEncoder(NeuralModule):
         if self.resample is not None:
             audio = self.resample(audio)
 
-        audio = torch.nn.functional.pad(audio, (0, self.padding))
+        audio = torch.nn.functional.pad(audio, (0, self.padding)).float()
         feats = self.feature_extractor(audio.cpu(), sampling_rate=self.slm_sr, return_tensors="pt").data[
             'input_features'
         ]
@@ -243,6 +243,7 @@ class SLMEncoder(NeuralModule):
             slm_emb = out.hidden_states[self.hidden_layer] / self.scaling_factor
 
         slm_emb = rearrange(slm_emb, 'B T D -> B D T')
+        slm_emb = slm_emb.to(audio.dtype)
 
         return slm_emb
 

--- a/nemo/collections/tts/modules/audio_codec_modules.py
+++ b/nemo/collections/tts/modules/audio_codec_modules.py
@@ -29,6 +29,7 @@ from nemo.collections.audio.parts.utils.transforms import MelSpectrogram, Resamp
 from nemo.collections.common.parts.utils import ClampActivation, HalfSnake, Snake, mask_sequence_tensor
 from nemo.core.classes.common import typecheck
 from nemo.core.classes.module import NeuralModule
+from nemo.core.neural_types import IntType
 from nemo.core.neural_types.elements import (
     AudioSignal,
     EncodedRepresentation,
@@ -236,14 +237,13 @@ class SLMEncoder(NeuralModule):
         feats = self.feature_extractor(audio.cpu(), sampling_rate=self.slm_sr, return_tensors="pt").data[
             'input_features'
         ]
-        feats = feats.to(audio.device)
+        feats = feats.to(device=audio.device, dtype=audio.dtype)
 
         with torch.no_grad():
             out = self.semantic_model(feats)
             slm_emb = out.hidden_states[self.hidden_layer] / self.scaling_factor
 
         slm_emb = rearrange(slm_emb, 'B T D -> B D T')
-        slm_emb = slm_emb.to(audio.dtype)
 
         return slm_emb
 
@@ -1344,6 +1344,27 @@ class VectorQuantizerBase(NeuralModule, ABC):
     def decode(self, indices: torch.Tensor, input_len: torch.Tensor) -> torch.Tensor:
         pass
 
+    @typecheck(
+        input_types={
+            "encoded": NeuralType(('B', 'D', 'T'), EncodedRepresentation()),
+            "num_codebooks": NeuralType(tuple('B'), IntType(), optional=True),
+        },
+        output_types={
+            "outputs": NeuralType(('B', 'D', 'T'), EncodedRepresentation()),
+        },
+    )
+    def dropout_codebooks(self, encoded: torch.Tensor, num_codebooks: Optional[int]) -> torch.Tensor:
+        """Dropout encoder output so that only 'num_codebooks' are left as decoder_input.
+
+        Args:
+            encoded: encoder output (B, D, T)
+            num_codebooks: number of codebooks to keep (B)
+
+        Returns:
+            Encoder output with all codebooks above index 'num_codebooks' dropped out
+        """
+        raise NotImplementedError(f"Codebook dropout not implemented for {self.__class__.__name__}")
+
 
 class FiniteScalarQuantizer(VectorQuantizerBase):
     """This quantizer is based on the Finite Scalar Quantization (FSQ) method.
@@ -1685,6 +1706,39 @@ class GroupFiniteScalarQuantizer(VectorQuantizerBase):
         indices = torch.stack(indices, dim=1)
 
         return indices
+
+    @typecheck(
+        input_types={
+            "encoded": NeuralType(('B', 'D', 'T'), EncodedRepresentation()),
+            "num_codebooks": NeuralType(tuple('B'), IntType(), optional=True),
+        },
+        output_types={
+            "outputs": NeuralType(('B', 'D', 'T'), EncodedRepresentation()),
+        },
+    )
+    def dropout_codebooks(self, encoded: torch.Tensor, num_codebooks: torch.Tensor) -> torch.Tensor:
+        """Sets all embedding values in dimensions above (num_codebooks * codebook_dim) to 0.
+
+        Args:
+            encoded: encoder output (B, D, T)
+            num_codebooks: number of codebooks to keep (B)
+
+        Returns:
+            Encoder output with all codebooks above index 'num_codebooks' masked out
+        """
+        batch_size, embed_dim, num_frames = encoded.shape
+        # [B, D, T]
+        embed_indices = (
+            torch.arange(start=0, end=embed_dim, device=encoded.device)
+            .unsqueeze(0)
+            .unsqueeze(2)
+            .repeat(batch_size, 1, num_frames)
+        )
+        emb_unmask_dim = self.codebook_dim_per_group * num_codebooks
+        emb_unmask_dim = rearrange(emb_unmask_dim, 'B -> B 1 1')
+        codebook_mask = embed_indices < emb_unmask_dim
+        out = encoded * codebook_mask
+        return out
 
 
 class ResidualBlock(NeuralModule):

--- a/tests/collections/tts/models/test_audio_codec.py
+++ b/tests/collections/tts/models/test_audio_codec.py
@@ -147,3 +147,34 @@ class TestAudioCodecModel:
         output_audio, output_audio_len = acoustic_codec_model.decode(tokens=tokens, tokens_len=tokens_len)
         assert output_audio.shape[0] == batch_size
         assert output_audio.shape[1] == output_audio_len.max()
+
+    @pytest.mark.unit
+    def test_encode_with_dropout(self, codec_model):
+        batch_size = 4
+        audio = torch.randn(size=(batch_size, 20000))
+        audio_len = torch.randint(size=[batch_size], low=10000, high=20000)
+
+        tokens, tokens_len = codec_model.encode(
+            audio=audio,
+            audio_len=audio_len,
+            sample_rate=codec_model.sample_rate,
+        )
+
+        # Setting num_codebooks to the total number of codebooks should not modify the output
+        tokens_without_dropout, _ = codec_model.encode(
+            audio=audio,
+            audio_len=audio_len,
+            sample_rate=codec_model.sample_rate,
+            num_codebooks=codec_model.num_codebooks,
+        )
+        torch.testing.assert_close(actual=tokens_without_dropout, expected=tokens)
+
+        for i in range(1, codec_model.num_codebooks):
+            tokens_with_dropout, _ = codec_model.encode(
+                audio=audio, audio_len=audio_len, sample_rate=codec_model.sample_rate, num_codebooks=i
+            )
+            encoded = codec_model.dequantize(tokens=tokens_with_dropout, tokens_len=tokens_len)  # (B, D, T)
+            # Validate appropriate dimensions are zero
+            dropout_start_i = i * codec_model.vector_quantizer.codebook_dim
+            dropped_codes = encoded[:, dropout_start_i:, :]
+            torch.testing.assert_close(actual=dropped_codes, expected=torch.zeros_like(dropped_codes))

--- a/tests/collections/tts/modules/test_audio_codec_modules.py
+++ b/tests/collections/tts/modules/test_audio_codec_modules.py
@@ -435,7 +435,7 @@ class TestFiniteScalarQuantizer:
     @pytest.mark.unit
     @pytest.mark.parametrize('num_groups', [1, 2, 4])
     @pytest.mark.parametrize('num_levels_per_group', [[2, 3], [8, 5, 5]])
-    def test_group_fsq_eval(self, num_groups: int, num_levels_per_group: int):
+    def test_group_fsq_eval(self, num_groups: int, num_levels_per_group: list[int]):
         """Simple test to confirm that the group FSQ module can be instantiated and run,
         and that forward produces the same result as encode-decode.
         """
@@ -471,3 +471,30 @@ class TestFiniteScalarQuantizer:
                 torch.testing.assert_close(
                     indices, indices_fw_grouped[g], msg=f'example {i}: indices mismatch for group {g}'
                 )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize('num_groups', [2, 4, 7])
+    @pytest.mark.parametrize('num_levels_per_group', [[2, 3], [8, 5, 5]])
+    def test_group_fsq_dropout(self, num_groups: int, num_levels_per_group: list[int]):
+        """Tests that FSQ dropout correctly zeros out the correct encoder dimensions"""
+        gfsq = GroupFiniteScalarQuantizer(num_groups=num_groups, num_levels_per_group=num_levels_per_group)
+
+        inputs = torch.randn([self.batch_size, gfsq.codebook_dim, self.max_len])
+        input_len = torch.tensor([self.max_len] * self.batch_size, dtype=torch.int32)
+        encoded, _ = gfsq(inputs=inputs, input_len=input_len)  # (B, D, T)
+
+        # Should not dropout any input
+        encoded_without_dropout = gfsq.dropout_codebooks(encoded=encoded, num_codebooks=torch.tensor([num_groups]))
+        torch.testing.assert_close(actual=encoded_without_dropout, expected=encoded)
+
+        for i in range(num_groups):
+            # Dropout different number of codebooks for each batch element
+            codebooks_to_keep = list(range(i, i + self.batch_size))
+            encoded_with_dropout = gfsq.dropout_codebooks(
+                encoded=encoded, num_codebooks=torch.tensor(codebooks_to_keep)
+            )
+            # Validate appropriate dimensions are zero
+            for batch_i in range(self.batch_size):
+                dropout_start_i = codebooks_to_keep[batch_i] * len(num_levels_per_group)
+                dropped_codes = encoded_with_dropout[batch_i, dropout_start_i:, :]
+                torch.testing.assert_close(actual=dropped_codes, expected=torch.zeros_like(dropped_codes))


### PR DESCRIPTION
# What does this PR do ?

Adds optional codebook dropout during audio codec training.

Training with a dropout of ~10% enables an FSQ based codec to reconstruct audio with any number of codebooks (quality increasing with more codebooks) with only a very small drop in performance when decoding all codebooks. Higher dropout rates produce a significantly larger drop in overall performance.

**Collection**: [TTS]

# Changelog

- Add parameter for randomized codebook dropout during training
- Add parameter to `encode()` making it easy to do inference with fewer codebooks
- Add a typecast in `SLMEncoder` necessary to do semantic codec training in BF16

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation