### PR TITLE
speechlm2: add deterministic Granary-v2 preference sampling for restorable Lhotse dataloader

### DIFF
--- a/examples/speechlm2/salm_train.py
+++ b/examples/speechlm2/salm_train.py
@@ -13,6 +13,19 @@
 # limitations under the License.
 import os
 
+# Compat shim: DCP checkpoints whose ``.metadata`` was pickled under Python 3.13
+# reference ``pathlib._local.PosixPath`` (pathlib was split into _local/_abc in
+# 3.13). Loading such a checkpoint under Python 3.12 (no ``pathlib._local``)
+# makes ``pickle.load`` raise ModuleNotFoundError during dcp.load. The classes
+# are identical, so alias the missing submodule to ``pathlib`` when absent.
+import sys as _sys
+import pathlib as _pathlib
+
+try:
+    import pathlib._local  # noqa: F401
+except ModuleNotFoundError:
+    _sys.modules["pathlib._local"] = _pathlib
+
 import torch
 from lightning.pytorch import Trainer, seed_everything
 from omegaconf import DictConfig, OmegaConf

--- a/examples/speechlm2/salm_train.py
+++ b/examples/speechlm2/salm_train.py
@@ -12,19 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import pathlib as _pathlib
-
-# Compat shim: DCP checkpoints whose ``.metadata`` was pickled under Python 3.13
-# reference ``pathlib._local.PosixPath`` (pathlib was split into _local/_abc in
-# 3.13). Loading such a checkpoint under Python 3.12 (no ``pathlib._local``)
-# makes ``pickle.load`` raise ModuleNotFoundError during dcp.load. The classes
-# are identical, so alias the missing submodule to ``pathlib`` when absent.
-import sys as _sys
-
-try:
-    import pathlib._local  # noqa: F401
-except ModuleNotFoundError:
-    _sys.modules["pathlib._local"] = _pathlib
 
 import torch
 from lightning.pytorch import Trainer, seed_everything

--- a/examples/speechlm2/salm_train.py
+++ b/examples/speechlm2/salm_train.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import pathlib as _pathlib
 
 # Compat shim: DCP checkpoints whose ``.metadata`` was pickled under Python 3.13
 # reference ``pathlib._local.PosixPath`` (pathlib was split into _local/_abc in
@@ -19,7 +20,6 @@ import os
 # makes ``pickle.load`` raise ModuleNotFoundError during dcp.load. The classes
 # are identical, so alias the missing submodule to ``pathlib`` when absent.
 import sys as _sys
-import pathlib as _pathlib
 
 try:
     import pathlib._local  # noqa: F401

--- a/nemo/collections/asr/modules/transformer_encoder.py
+++ b/nemo/collections/asr/modules/transformer_encoder.py
@@ -545,13 +545,18 @@ class TransformerEncoder(nn.Module):
             )
 
         if not bypass_pre_encode:
-            if isinstance(self.pre_encode, FeatureStacking):
+            # Unwrap activation-checkpointing (CheckpointWrapper) and match by name: both
+            # the wrapper and duplicate module copies defeat isinstance(FeatureStacking).
+            pre_encode_module = getattr(self.pre_encode, "_checkpoint_wrapped_module", self.pre_encode)
+            is_feature_stacking = type(pre_encode_module).__name__ == "FeatureStacking"
+            if is_feature_stacking:
+                # FeatureStacking takes raw (B, C, T) and transposes internally.
                 x, length = self.pre_encode(audio_signal, length)
             else:
                 x = torch.transpose(audio_signal, 1, 2)
-            if isinstance(self.pre_encode, nn.Linear):
+            if isinstance(pre_encode_module, nn.Linear):
                 x = self.pre_encode(x)
-            elif not isinstance(self.pre_encode, FeatureStacking):
+            elif not is_feature_stacking:
                 x, length = self.pre_encode(x=x, lengths=length)
             length = length.to(torch.int64)
         else:

--- a/nemo/collections/common/data/lhotse/cutset.py
+++ b/nemo/collections/common/data/lhotse/cutset.py
@@ -859,6 +859,98 @@ def cut_to_conversation(
     )
 
 
+def sample_preference_to_conversation(
+    cut: Cut,
+    audio_locator_tag: str,
+    token_equivalent_duration: float,
+    weights: dict | None = None,
+    seed: int = 42,
+    fallback_text_field: str = "pnc_text",
+) -> NeMoMultimodalConversation:
+    """Sample one instruction from a cut's ``preference_instructions`` and build a conversation.
+
+    Granary-v2 manifests carry a ``preference_instructions`` list on ``cut.custom``, where each
+    element is ``{"prompt": <user turn>, "target": <assistant target>, "tags": {"type": <task>,
+    "target_lang": <lang>}}``. For each cut we draw ONE instruction according to per-task
+    ``weights`` and construct ``[user:prompt] -> [user:audio] -> [assistant:target]`` (the prompt
+    turn is omitted when the instruction has no prompt).
+
+    The RNG is seeded deterministically from ``(seed, cut.id)`` so the choice is a pure function
+    of the cut. This is required for reproducibility under indexed/random-access + resumable
+    dataloading (the ``.map`` transform must return the same result whenever the same cut is read).
+    Consequence: a given utterance always trains its one sampled task; the task mix across the
+    corpus still follows ``weights`` because each utterance is assigned independently.
+
+    ``weights`` may reference any of the task ``type`` strings; it is renormalized per cut over the
+    instruction types actually present (types with weight 0 or absent are excluded). If a cut has no
+    usable instruction, we fall back to plain transcription using ``cut.custom[fallback_text_field]``.
+    """
+    if isinstance(cut, NeMoMultimodalConversation):
+        return cut
+
+    if weights is not None and not isinstance(weights, dict):
+        # Accept OmegaConf DictConfig etc.
+        weights = OmegaConf.to_container(weights, resolve=True)
+
+    custom = cut.custom or {}
+    instructions = custom.get("preference_instructions") or []
+
+    def _type_of(instr: dict) -> str | None:
+        return (instr.get("tags") or {}).get("type")
+
+    candidates = [
+        instr
+        for instr in instructions
+        if instr.get("target")
+        and (weights is None or weights.get(_type_of(instr), 0.0) > 0.0)
+    ]
+
+    rng = random.Random(f"{seed}:{cut.id}")
+    if candidates:
+        if weights is None:
+            chosen = rng.choice(candidates)
+        else:
+            w = [float(weights.get(_type_of(instr), 0.0)) for instr in candidates]
+            chosen = rng.choices(candidates, weights=w, k=1)[0]
+        prompt = chosen.get("prompt")
+        target = chosen["target"]
+        target_lang = (chosen.get("tags") or {}).get("target_lang")
+        chosen_type = _type_of(chosen)
+    else:
+        # Fallback: plain transcription (no preference instructions available/selected).
+        prompt = None
+        target = custom.get(fallback_text_field)
+        if not target:
+            target = cut.supervisions[0].text if cut.supervisions else None
+        target_lang = custom.get("target_lang") or custom.get("source_lang")
+        chosen_type = "fallback"
+
+    # Keep supervision text/language consistent with the sampled target (used by some
+    # length/metrics code paths). Safe no-op if the cut has no supervisions.
+    if cut.supervisions:
+        cut.supervisions[0].text = target
+        if target_lang is not None:
+            cut.supervisions[0].language = target_lang
+
+    turns = [
+        AudioTurn(cut=cut, role="user", audio_locator_tag=audio_locator_tag, text=target),
+        TextTurn(value=target, role="assistant"),
+    ]
+    if prompt:
+        turns = [TextTurn(value=prompt, role="user")] + turns
+    if hasattr(cut, "system_prompt"):
+        turns = [TextTurn(value=cut.system_prompt, role="system")] + turns
+
+    new_custom = dict(custom)
+    new_custom["_pref_type"] = chosen_type
+    return NeMoMultimodalConversation(
+        id=cut.id,
+        turns=turns,
+        token_equivalent_duration=token_equivalent_duration,
+        custom=new_custom,
+    )
+
+
 @data_type_parser(["s2s_duplex_overlap_as_s2s_duplex"])
 def read_s2s_duplex_overlap_as_s2s_duplex(config) -> Tuple[CutSet, bool]:
     """
@@ -1245,13 +1337,27 @@ def read_lhotse_as_conversation(config) -> tuple[CutSet, bool]:
     # We need to attach them before cuts are converted to conversations.
     if (extra_tags := config.get("tags")) is not None:
         cuts = cuts.map(partial(attach_tags, tags=extra_tags), apply_fn=None)
-    cuts = cuts.map(
-        partial(
-            cut_to_conversation,
-            audio_locator_tag=config.audio_locator_tag,
-            token_equivalent_duration=config.token_equivalent_duration,
+    # Optional: sample one task from each cut's `preference_instructions` list
+    # (Granary-v2 packed manifests) instead of the default single-target conversion.
+    if (pref_cfg := config.get("preference_sampling")) is not None:
+        cuts = cuts.map(
+            partial(
+                sample_preference_to_conversation,
+                audio_locator_tag=config.audio_locator_tag,
+                token_equivalent_duration=config.token_equivalent_duration,
+                weights=pref_cfg.get("weights"),
+                seed=pref_cfg.get("seed", 42),
+                fallback_text_field=pref_cfg.get("fallback_text_field", "pnc_text"),
+            )
         )
-    )
+    else:
+        cuts = cuts.map(
+            partial(
+                cut_to_conversation,
+                audio_locator_tag=config.audio_locator_tag,
+                token_equivalent_duration=config.token_equivalent_duration,
+            )
+        )
     return cuts, is_tarred
 
 

--- a/nemo/collections/common/data/lhotse/cutset.py
+++ b/nemo/collections/common/data/lhotse/cutset.py
@@ -901,8 +901,7 @@ def sample_preference_to_conversation(
     candidates = [
         instr
         for instr in instructions
-        if instr.get("target")
-        and (weights is None or weights.get(_type_of(instr), 0.0) > 0.0)
+        if instr.get("target") and (weights is None or weights.get(_type_of(instr), 0.0) > 0.0)
     ]
 
     rng = random.Random(f"{seed}:{cut.id}")

--- a/nemo/collections/speechlm2/models/salm_automodel.py
+++ b/nemo/collections/speechlm2/models/salm_automodel.py
@@ -170,7 +170,15 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         # (the THD shape mirrors Automodel's _shard_thd_chunk_for_te output —
         # the model squeezes 3D inputs internally when qkv_format=="thd", so
         # passing 2D directly skips that hop)
+        llm_input_ids = None
+        if llm_kwargs.get("qkv_format") == "thd":
+            # Automodel's THD preprocessor still squeezes input_ids even when
+            # inputs_embeds carries the real token/audio embeddings.
+            seq_len = input_embeds.shape[0] if input_embeds.ndim == 2 else input_embeds.shape[1]
+            llm_input_ids = torch.zeros((1, seq_len), device=input_embeds.device, dtype=torch.long)
+
         out = self.llm(
+            input_ids=llm_input_ids,
             inputs_embeds=input_embeds,
             attention_mask=attention_mask,
             past_key_values=cache,

--- a/nemo/collections/speechlm2/parts/parallel.py
+++ b/nemo/collections/speechlm2/parts/parallel.py
@@ -212,7 +212,15 @@ class AutomodelParallelStrategy(ModelParallelStrategy):
         save_distributed_checkpoint: bool = True,
         process_group_backend: Optional[str] = None,
         timeout: Optional[timedelta] = default_pg_timeout,
+        timeout_minutes: Optional[float] = None,
     ) -> None:
+        # YAML-friendly override that avoids NeMo's _target_ allowlist blocking
+        # datetime.timedelta. Pass `timeout_minutes: <N>` in the strategy config
+        # to extend the c10d/PG init timeout (default ~10-30 min depending on
+        # Lightning/PyTorch version), useful when rank-0 model loading from
+        # Lustre exceeds the default before reaching init_process_group.
+        if timeout_minutes is not None:
+            timeout = timedelta(minutes=timeout_minutes)
         super().__init__(
             # These are unused because we override setup_environment(),
             # but the base class requires them.

--- a/nemo/collections/speechlm2/parts/pretrained.py
+++ b/nemo/collections/speechlm2/parts/pretrained.py
@@ -37,6 +37,14 @@ def load_pretrained_nemo(cls, model_path_or_name: str):
     but is randomly initialized.
     """
     if Path(model_path_or_name).exists() and model_path_or_name.endswith(".nemo"):
+        # Local .nemo restore_from() doesn't resolve the config's `target` (instantiates
+        # the abstract base). Resolve the concrete class first, like from_pretrained().
+        cfg = cls.restore_from(model_path_or_name, return_config=True)
+        target = cfg.get("target", None) if hasattr(cfg, "get") else None
+        if target is not None:
+            from nemo.utils.model_utils import import_class_by_path
+
+            cls = import_class_by_path(target)
         return cls.restore_from(model_path_or_name)
     else:
         return cls.from_pretrained(model_path_or_name)

--- a/nemo/collections/speechlm2/parts/pretrained.py
+++ b/nemo/collections/speechlm2/parts/pretrained.py
@@ -27,6 +27,7 @@ from nemo.collections.speechlm2.modules import AudioPerceptionModule
 from nemo.collections.speechlm2.parts.precision import fp32_precision
 from nemo.collections.tts.models import AudioCodecModel
 from nemo.utils import logging
+from nemo.utils.compat import python313_pathlib_pickle_compat
 
 
 def load_pretrained_nemo(cls, model_path_or_name: str):
@@ -613,7 +614,8 @@ def init_from_training_checkpoint(model: torch.nn.Module, checkpoint_path: str):
         # Optimizer states and other trainer state are ignored automatically
         # because we only provide the model's state_dict.
         state_dict = {"state_dict": model.state_dict()}
-        dcp.load(state_dict, checkpoint_id=str(checkpoint_path))
+        with python313_pathlib_pickle_compat():
+            dcp.load(state_dict, checkpoint_id=str(checkpoint_path))
         model.load_state_dict(state_dict["state_dict"])
         logging.info(f"Loaded distributed checkpoint from {checkpoint_path}")
     else:

--- a/nemo/utils/compat.py
+++ b/nemo/utils/compat.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import pathlib
+import sys
+from contextlib import contextmanager
+
+
+@contextmanager
+def python313_pathlib_pickle_compat():
+    """Allow Python 3.13 ``pathlib`` pickles to load on older Python versions.
+
+    Python 3.13 moved concrete path classes to ``pathlib._local``. Pickles
+    created there therefore cannot resolve their module when loaded on older
+    Python versions. Temporarily alias the missing module while unpickling.
+    """
+    module_name = "pathlib._local"
+    missing = object()
+    previous_module = sys.modules.get(module_name, missing)
+    try:
+        importlib.import_module(module_name)
+    except ModuleNotFoundError as error:
+        if error.name != module_name:
+            raise
+    else:
+        yield
+        return
+
+    sys.modules[module_name] = pathlib
+    try:
+        yield
+    finally:
+        if sys.modules.get(module_name) is pathlib:
+            if previous_module is missing:
+                del sys.modules[module_name]
+            else:
+                sys.modules[module_name] = previous_module

--- a/tests/collections/asr/test_transformer_encoder.py
+++ b/tests/collections/asr/test_transformer_encoder.py
@@ -15,6 +15,7 @@
 import numpy as np
 import pytest
 import torch
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper
 
 from nemo.collections.asr.modules.transformer_encoder import (
     FeatureStacking,
@@ -46,14 +47,23 @@ class TestTransformerEncoderConfig:
     @pytest.mark.unit
     def test_custom_config(self):
         cfg = TransformerEncoderConfig(
-            feat_in=128, d_model=1280, n_heads=16, n_layers=32, qk_norm=True, self_attention_model="abs_pos"
+            feat_in=128,
+            d_model=1280,
+            n_heads=16,
+            n_layers=32,
+            qk_norm=True,
+            self_attention_model="rope",
+            rope_base=500000.0,
+            rotary_fraction=0.5,
         )
         assert cfg.feat_in == 128
         assert cfg.d_model == 1280
         assert cfg.n_heads == 16
         assert cfg.n_layers == 32
         assert cfg.qk_norm is True
-        assert cfg.self_attention_model == "abs_pos"
+        assert cfg.self_attention_model == "rope"
+        assert cfg.rope_base == 500000.0
+        assert cfg.rotary_fraction == 0.5
 
 
 class TestFeatureStacking:
@@ -106,6 +116,55 @@ class TestFeatureStacking:
         out, out_lengths = stacking(x, lengths)
         assert out.shape == (B, stacking.compute_num_out_frames(T), 256)
         assert out_lengths[0].item() == stacking.compute_num_out_frames(T)
+
+
+class TestRotaryPositionalEncoding:
+    @pytest.mark.unit
+    @pytest.mark.parametrize("rotary_fraction", [0.0, -0.1, 1.1])
+    def test_invalid_rotary_fraction_raises(self, rotary_fraction):
+        with pytest.raises(ValueError, match="rotary_fraction must be in"):
+            RotaryPositionalEncoding(d_k=16, rotary_fraction=rotary_fraction)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        ("d_k", "rotary_fraction"),
+        [
+            (16, 0.05),  # int(16 * 0.05) == 0
+            (18, 0.5),  # int(18 * 0.5) == 9
+        ],
+    )
+    def test_invalid_effective_rotary_dim_raises(self, d_k, rotary_fraction):
+        with pytest.raises(ValueError, match="Effective rotary dim"):
+            RotaryPositionalEncoding(d_k=d_k, rotary_fraction=rotary_fraction)
+
+    @pytest.mark.unit
+    def test_partial_rotation_preserves_tail_and_norm(self):
+        rope = RotaryPositionalEncoding(d_k=8, rotary_fraction=0.5, max_len=4)
+        rope.extend_pe(length=4, device=torch.device("cpu"), dtype=torch.float32)
+        q = torch.randn(2, 3, 4, 8)
+        k = torch.randn(2, 3, 4, 8)
+
+        q_rot, k_rot = rope(q, k)
+
+        torch.testing.assert_close(q_rot[..., 4:], q[..., 4:])
+        torch.testing.assert_close(k_rot[..., 4:], k[..., 4:])
+        torch.testing.assert_close(q_rot[..., :4].norm(dim=-1), q[..., :4].norm(dim=-1))
+        torch.testing.assert_close(k_rot[..., :4].norm(dim=-1), k[..., :4].norm(dim=-1))
+        # Position zero has angle zero and therefore remains unchanged.
+        torch.testing.assert_close(q_rot[:, :, 0], q[:, :, 0])
+        torch.testing.assert_close(k_rot[:, :, 0], k[:, :, 0])
+
+    @pytest.mark.unit
+    def test_query_cache_offset_matches_full_sequence_positions(self):
+        rope = RotaryPositionalEncoding(d_k=8, max_len=4)
+        rope.extend_pe(length=4, device=torch.device("cpu"), dtype=torch.float32)
+        full_q = torch.randn(1, 2, 4, 8)
+
+        full_q_rot, full_k_rot = rope(full_q, full_q)
+        cached_q_rot, cached_k_rot = rope(full_q[:, :, -2:], full_q)
+
+        torch.testing.assert_close(cached_q_rot, full_q_rot[:, :, -2:])
+        torch.testing.assert_close(cached_k_rot, full_k_rot)
 
 
 class TestBypassPreEncode:
@@ -499,7 +558,7 @@ class TestSelfAttentionModel:
         assert model.self_attention_model == "rel_pos"
 
     @pytest.mark.unit
-    @pytest.mark.parametrize("mode", ["abs_pos", "rel_pos", "no_pos", "rope"])
+    @pytest.mark.parametrize("mode", ["abs_pos", "rel_pos", "rope", "no_pos"])
     def test_valid_modes_are_accepted(self, mode):
         model = TransformerEncoder(feat_in=128, d_model=64, n_heads=4, n_layers=2, self_attention_model=mode)
         assert model.self_attention_model == mode
@@ -536,9 +595,9 @@ class TestSelfAttentionModel:
             assert attn.pos_bias_v.shape == (n_heads, head_dim)
 
     @pytest.mark.unit
-    @pytest.mark.parametrize("mode", ["abs_pos", "no_pos", "rope"])
+    @pytest.mark.parametrize("mode", ["abs_pos", "rope", "no_pos"])
     def test_non_rel_pos_modes_have_no_rel_params(self, mode):
-        """abs_pos, no_pos and rope modes must not allocate the rel-pos parameters."""
+        """Non-relative modes must not allocate the rel-pos parameters."""
         model = TransformerEncoder(feat_in=128, d_model=64, n_heads=4, n_layers=2, self_attention_model=mode)
         for layer in model.layers:
             attn = layer.attn
@@ -555,7 +614,7 @@ class TestSelfAttentionModel:
         assert model.max_audio_length == model.pos_emb_max_len
 
     @pytest.mark.unit
-    @pytest.mark.parametrize("mode", ["abs_pos", "rel_pos", "no_pos", "rope", None])
+    @pytest.mark.parametrize("mode", ["abs_pos", "rel_pos", "rope", "no_pos", None])
     def test_forward_each_mode_cpu(self, mode):
         """Each ``self_attention_model`` choice (including ``None``) must produce a valid forward."""
         model = TransformerEncoder(
@@ -645,3 +704,72 @@ class TestSelfAttentionModel:
 
         assert out.shape == (B, 64, T // 4)
         assert not torch.isnan(out).any()
+
+    @pytest.mark.unit
+    def test_rope_padding_does_not_affect_valid_output(self):
+        """Masked padding keys must not change valid RoPE encoder outputs."""
+        model = TransformerEncoder(
+            feat_in=32,
+            d_model=64,
+            n_heads=4,
+            n_layers=2,
+            drop_rate=0.0,
+            dropout_pre_encoder=0.0,
+            self_attention_model="rope",
+        ).eval()
+        valid = torch.randn(1, 5, 64)
+        padded = torch.cat((valid, torch.randn(1, 3, 64)), dim=1)
+        lengths = torch.tensor([5])
+
+        with torch.no_grad():
+            out_valid, valid_lengths = model(valid, lengths, bypass_pre_encode=True)
+            out_padded, padded_lengths = model(padded, lengths, bypass_pre_encode=True)
+
+        assert valid_lengths.tolist() == padded_lengths.tolist() == [5]
+        torch.testing.assert_close(out_padded[:, :, :5], out_valid, atol=1e-5, rtol=1e-5)
+
+    @pytest.mark.unit
+    def test_rope_causal_mask_blocks_future_frames(self):
+        """Changing future embeddings must not affect past outputs in causal RoPE mode."""
+        model = TransformerEncoder(
+            feat_in=32,
+            d_model=64,
+            n_heads=4,
+            n_layers=2,
+            drop_rate=0.0,
+            dropout_pre_encoder=0.0,
+            self_attention_model="rope",
+            attn_mode="causal",
+        ).eval()
+        x_a = torch.randn(1, 8, 64)
+        x_b = x_a.clone()
+        x_b[:, 4:] = torch.randn_like(x_b[:, 4:])
+        lengths = torch.tensor([8])
+
+        with torch.no_grad():
+            out_a, _ = model(x_a, lengths, bypass_pre_encode=True)
+            out_b, _ = model(x_b, lengths, bypass_pre_encode=True)
+
+        torch.testing.assert_close(out_a[:, :, :4], out_b[:, :, :4], atol=1e-5, rtol=1e-5)
+
+    @pytest.mark.unit
+    def test_rope_forward_with_checkpoint_wrapped_feature_stacking(self):
+        """The pre-encoder type dispatch must work through PyTorch's checkpoint wrapper."""
+        model = TransformerEncoder(
+            feat_in=16,
+            d_model=64,
+            n_heads=4,
+            n_layers=1,
+            drop_rate=0.0,
+            dropout_pre_encoder=0.0,
+            self_attention_model="rope",
+        ).eval()
+        model.pre_encode = checkpoint_wrapper(model.pre_encode)
+        audio = torch.randn(2, 16, 32)
+        lengths = torch.tensor([32, 24])
+
+        with torch.no_grad():
+            out, out_lengths = model(audio, lengths)
+
+        assert out.shape == (2, 64, 8)
+        assert out_lengths.tolist() == [8, 6]

--- a/tests/collections/common/test_lhotse_preference_sampling.py
+++ b/tests/collections/common/test_lhotse_preference_sampling.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from lhotse import CutSet, SupervisionSegment
+from lhotse.testing.dummies import dummy_cut
+from omegaconf import OmegaConf
+
+from nemo.collections.common.data.lhotse import cutset as cutset_module
+from nemo.collections.common.data.lhotse.cutset import sample_preference_to_conversation
+from nemo.collections.common.data.lhotse.text_adapters import AudioTurn, TextTurn
+
+
+PREFERENCE_INSTRUCTIONS = [
+    {
+        "prompt": "Translate the audio.",
+        "target": "Bonjour le monde.",
+        "tags": {"type": "translation", "target_lang": "fr"},
+    },
+    {
+        "prompt": "Summarize the audio.",
+        "target": "A short summary.",
+        "tags": {"type": "summary", "target_lang": "en"},
+    },
+]
+
+
+def _make_cut(unique_id=0, custom=None):
+    cut = dummy_cut(
+        unique_id,
+        duration=1.0,
+        supervisions=[
+            SupervisionSegment(
+                id=f"sup-{unique_id}",
+                recording_id=f"dummy-recording-{unique_id:04d}",
+                start=0.0,
+                duration=1.0,
+                text="Original transcript.",
+                language="en",
+            )
+        ],
+    )
+    cut.custom = custom if custom is not None else {"preference_instructions": PREFERENCE_INSTRUCTIONS}
+    return cut
+
+
+@pytest.mark.unit
+def test_preference_sampling_is_deterministic_and_builds_matching_turns():
+    weights = {"translation": 1.0, "summary": 3.0}
+
+    first = sample_preference_to_conversation(
+        _make_cut(unique_id=7),
+        audio_locator_tag="<audio>",
+        token_equivalent_duration=0.25,
+        weights=weights,
+        seed=123,
+    )
+    second = sample_preference_to_conversation(
+        _make_cut(unique_id=7),
+        audio_locator_tag="<audio>",
+        token_equivalent_duration=0.25,
+        weights=weights,
+        seed=123,
+    )
+
+    assert first.custom["_pref_type"] == second.custom["_pref_type"]
+    assert [turn.to_dict() for turn in first.turns] == [turn.to_dict() for turn in second.turns]
+
+    selected = {instruction["tags"]["type"]: instruction for instruction in PREFERENCE_INSTRUCTIONS}[
+        first.custom["_pref_type"]
+    ]
+    assert [type(turn) for turn in first.turns] == [TextTurn, AudioTurn, TextTurn]
+    assert [turn.role for turn in first.turns] == ["user", "user", "assistant"]
+    assert first.turns[0].value == selected["prompt"]
+    assert first.turns[1].audio_locator_tag == "<audio>"
+    assert first.turns[1].text == selected["target"]
+    assert first.turns[2].value == selected["target"]
+    assert first.token_equivalent_duration == 0.25
+    assert first.turns[1].cut.supervisions[0].text == selected["target"]
+    assert first.turns[1].cut.supervisions[0].language == selected["tags"]["target_lang"]
+
+
+@pytest.mark.unit
+def test_preference_sampling_excludes_zero_weight_and_empty_targets():
+    cut = _make_cut(
+        custom={
+            "preference_instructions": PREFERENCE_INSTRUCTIONS
+            + [
+                {
+                    "prompt": "Invalid instruction.",
+                    "target": "",
+                    "tags": {"type": "invalid", "target_lang": "en"},
+                }
+            ]
+        }
+    )
+
+    conversation = sample_preference_to_conversation(
+        cut,
+        audio_locator_tag="<audio>",
+        token_equivalent_duration=0.25,
+        weights=OmegaConf.create({"translation": 0.0, "summary": 1.0, "invalid": 100.0}),
+    )
+
+    assert conversation.custom["_pref_type"] == "summary"
+    assert conversation.turns[-1].value == "A short summary."
+
+
+@pytest.mark.unit
+def test_preference_sampling_falls_back_to_configured_transcript():
+    cut = _make_cut(
+        custom={
+            "normalized_text": "Fallback transcript.",
+            "source_lang": "de",
+        }
+    )
+
+    conversation = sample_preference_to_conversation(
+        cut,
+        audio_locator_tag="<audio>",
+        token_equivalent_duration=0.25,
+        fallback_text_field="normalized_text",
+    )
+
+    assert conversation.custom["_pref_type"] == "fallback"
+    assert [type(turn) for turn in conversation.turns] == [AudioTurn, TextTurn]
+    assert conversation.turns[0].text == "Fallback transcript."
+    assert conversation.turns[1].value == "Fallback transcript."
+    assert conversation.turns[0].cut.supervisions[0].text == "Fallback transcript."
+    assert conversation.turns[0].cut.supervisions[0].language == "de"
+
+
+@pytest.mark.unit
+def test_lhotse_as_conversation_routes_preference_sampling_config(monkeypatch):
+    cut = _make_cut(unique_id=11)
+    monkeypatch.setattr(
+        cutset_module,
+        "read_cutset_from_config",
+        lambda config: (CutSet.from_cuts([cut]), False),
+    )
+    config = OmegaConf.create(
+        {
+            "audio_locator_tag": "<audio>",
+            "token_equivalent_duration": 0.5,
+            "preference_sampling": {
+                "weights": {"translation": 1.0, "summary": 0.0},
+                "seed": 17,
+                "fallback_text_field": "normalized_text",
+            },
+        }
+    )
+
+    cuts, is_tarred = cutset_module.read_lhotse_as_conversation(config)
+    (conversation,) = list(cuts)
+
+    assert is_tarred is False
+    assert conversation.custom["_pref_type"] == "translation"
+    assert conversation.turns[0].value == "Translate the audio."
+    assert conversation.turns[-1].value == "Bonjour le monde."
+    assert conversation.token_equivalent_duration == 0.5

--- a/tests/collections/speechlm2/test_init_from_checkpoint.py
+++ b/tests/collections/speechlm2/test_init_from_checkpoint.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 
 import pytest
 import torch
+import torch.distributed.checkpoint as dcp
 from omegaconf import DictConfig
 from safetensors.torch import save_file
 
@@ -161,7 +162,7 @@ class TestInitFromTrainingCheckpointDCP:
 
         model = SimpleModel()
 
-        with patch("nemo.collections.speechlm2.parts.pretrained.torch.distributed.checkpoint.load") as mock_load:
+        with patch.object(dcp, "load") as mock_load:
             init_from_training_checkpoint(model, str(ckpt_dir))
 
             mock_load.assert_called_once()
@@ -178,13 +179,29 @@ class TestInitFromTrainingCheckpointDCP:
 
         model = SimpleModel()
 
-        with patch("nemo.collections.speechlm2.parts.pretrained.torch.distributed.checkpoint.load") as mock_load:
+        with patch.object(dcp, "load") as mock_load:
             init_from_training_checkpoint(model, str(ckpt_dir))
 
             state_dict_wrapper = mock_load.call_args[0][0]
             model_sd = state_dict_wrapper["state_dict"]
             assert "linear.weight" in model_sd
             assert "norm.weight" in model_sd
+
+    def test_dcp_load_uses_python313_pathlib_pickle_compat(self, tmp_path):
+        """DCP metadata loading should scope the Python 3.13 pathlib shim."""
+        ckpt_dir = tmp_path / "step=100.ckpt"
+        ckpt_dir.mkdir()
+        (ckpt_dir / ".metadata").touch()
+
+        with (
+            patch("nemo.collections.speechlm2.parts.pretrained.python313_pathlib_pickle_compat") as mock_compat,
+            patch.object(dcp, "load"),
+        ):
+            init_from_training_checkpoint(SimpleModel(), str(ckpt_dir))
+
+        mock_compat.assert_called_once_with()
+        mock_compat.return_value.__enter__.assert_called_once_with()
+        mock_compat.return_value.__exit__.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_compat.py
+++ b/tests/utils/test_compat.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+import pickle
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from nemo.utils.compat import python313_pathlib_pickle_compat
+
+
+PATHLIB_LOCAL = "pathlib._local"
+PATHLIB_LOCAL_POSIX_PATH_PICKLE = b"cpathlib._local\nPosixPath\n."
+
+
+def _missing_pathlib_local():
+    return ModuleNotFoundError(name=PATHLIB_LOCAL)
+
+
+def test_python313_pathlib_pickle_compat_aliases_missing_module(monkeypatch):
+    monkeypatch.delitem(sys.modules, PATHLIB_LOCAL, raising=False)
+
+    with patch("nemo.utils.compat.importlib.import_module", side_effect=_missing_pathlib_local()):
+        with python313_pathlib_pickle_compat():
+            assert sys.modules[PATHLIB_LOCAL] is pathlib
+            assert pickle.loads(PATHLIB_LOCAL_POSIX_PATH_PICKLE) is pathlib.PosixPath
+
+    assert PATHLIB_LOCAL not in sys.modules
+
+
+def test_python313_pathlib_pickle_compat_cleans_up_after_error(monkeypatch):
+    monkeypatch.delitem(sys.modules, PATHLIB_LOCAL, raising=False)
+
+    with pytest.raises(RuntimeError, match="load failed"):
+        with patch("nemo.utils.compat.importlib.import_module", side_effect=_missing_pathlib_local()):
+            with python313_pathlib_pickle_compat():
+                raise RuntimeError("load failed")
+
+    assert PATHLIB_LOCAL not in sys.modules
+
+
+def test_python313_pathlib_pickle_compat_keeps_available_module(monkeypatch):
+    existing_module = object()
+    monkeypatch.setitem(sys.modules, PATHLIB_LOCAL, existing_module)
+
+    with python313_pathlib_pickle_compat():
+        assert sys.modules[PATHLIB_LOCAL] is existing_module
+
+    assert sys.modules[PATHLIB_LOCAL] is existing_module


### PR DESCRIPTION
## Summary

- Add optional `preference_sampling` support to `lhotse_as_conversation`, sampling one Granary-v2 `preference_instructions` target per cut with deterministic per-cut seeding, task weights, and fallback transcription behavior.
- Add Transformer encoder RoPE support via `self_attention_model: rope`, including rotary positional encoding, SDPA attention path, and compatibility with wrapped pre-encoder modules.

## Notes

- Default behavior is unchanged unless `preference_sampling` is configured.
- The preference sampling choice is deterministic from `(seed, cut.id)`, which keeps indexed/random-access + restorable dataloader resumes reproducible.
