### PR TITLE
Support multi-system TTS comparison reports

### DIFF
--- a/scripts/tts_comparison_report/README.md
+++ b/scripts/tts_comparison_report/README.md
@@ -2,7 +2,8 @@
 
 This tool generates HTML comparison reports for TTS evaluation buckets and uploads them to S3.
 
-The `generate_report` script compares two evaluation buckets produced by `magpietts_inference` and generates:
+The `generate_report` script compares a baseline with one or more candidate evaluation buckets produced by
+`magpietts_inference` and generates:
 1. an HTML evaluation report with aggregated and per-benchmark metrics;
 2. an optional HTML audio comparison report with side-by-side audio samples.
 
@@ -48,7 +49,7 @@ experiment_root/
     └── benchmark_3
 ```
 
-In both cases, `--baseline_path` and `--candidate_path` should point to the experiment root. 
+In both cases, `--baseline_path` and each `--candidate_path` should point to an experiment root.
 If evaluation artifacts are stored directly inside the experiment root, set `--results_subdir` 
 to an empty string. If evaluation artifacts are stored under a dedicated subdirectory, 
 set `--results_subdir` to that subdirectory name.
@@ -110,6 +111,10 @@ python scripts/tts_comparison_report/generate_report.py \
 
 If the evaluation artifacts are stored in a non-default results subdirectory, 
 use `--results_subdir`.
+
+For more than two systems, repeat `--candidate_name` and `--candidate_path` for each additional candidate.
+Use `--s3_prefix` to override the generated S3 directory name, or `--local_output_dir` to create the report
+locally without uploading.
 
 To generate both the evaluation report and the audio comparison report, use `--audio_report`.
 You can also use `--audio_report_benchmarks` and `--samples_per_benchmark` 
@@ -178,7 +183,7 @@ only artifacts from repetition `0`.
 the experiment root that contains evaluation outputs such as metrics and generated audio. 
 If evaluation artifacts are stored directly inside the experiment root, `--results_subdir` 
 should be set to an empty string.
-- Both generated reports are HTML reports uploaded to S3-compatible object storage.
+- Reports are uploaded to S3-compatible object storage unless `--local_output_dir` is used.
 - If the audio report is enabled, the evaluation report includes a link to the audio report.
 - Audio files referenced by the audio report are uploaded separately and linked through presigned URLs.
 - Box plot images are also uploaded to S3 and embedded into the evaluation report via presigned URLs.

--- a/scripts/tts_comparison_report/generate_report.py
+++ b/scripts/tts_comparison_report/generate_report.py
@@ -64,14 +64,16 @@ def _create_argparser() -> ArgumentParser:
     parser.add_argument(
         "--candidate_name",
         type=str,
+        action="append",
         required=True,
-        help="Name of the candidate model that will be used in report.",
+        help="Name of a candidate model used in the report. Repeat with --candidate_path to compare more systems.",
     )
     parser.add_argument(
         "--candidate_path",
         type=str,
+        action="append",
         required=True,
-        help="Path to the generated evaluation bucket for the candidate model.",
+        help="Path to a candidate evaluation bucket. Repeat with --candidate_name to compare more systems.",
     )
     parser.add_argument(
         "--benchmarks",
@@ -82,20 +84,32 @@ def _create_argparser() -> ArgumentParser:
     parser.add_argument(
         "--s3_endpoint",
         type=str,
-        required=True,
-        help="S3 endpoint URL used for uploading the audio report.",
+        default=None,
+        help="S3 endpoint URL. Required unless --local_output_dir is used.",
     )
     parser.add_argument(
         "--s3_bucket",
         type=str,
-        required=True,
-        help="Name of the S3 bucket where the audio report HTML and audio files will be uploaded.",
+        default=None,
+        help="S3 bucket for report artifacts. Required unless --local_output_dir is used.",
     )
     parser.add_argument(
         "--s3_region",
         type=str,
-        required=True,
-        help="AWS region name for the S3 client.",
+        default=None,
+        help="AWS region name. Required unless --local_output_dir is used.",
+    )
+    parser.add_argument(
+        "--s3_prefix",
+        type=str,
+        default=None,
+        help="Override the generated S3 directory/key prefix, for example 'codec-comparison-aug-2026'.",
+    )
+    parser.add_argument(
+        "--local_output_dir",
+        type=str,
+        default=None,
+        help="Write a complete local HTML preview and assets here instead of uploading to S3.",
     )
     parser.add_argument(
         "--remote_hostname",
@@ -170,12 +184,23 @@ def _validate_audio_report_benchmarks(
             raise ValueError(f"Benchmark name for audio report '{name}' is not included in evaluation benchmarks.")
 
 
+def _validate_candidate_args(candidate_names: list[str], candidate_paths: list[str]) -> None:
+    if len(candidate_names) != len(candidate_paths):
+        raise ValueError(
+            "Each '--candidate_name' must have a matching '--candidate_path' "
+            f"({len(candidate_names)} names and {len(candidate_paths)} paths were provided)."
+        )
+
+    if len(set(candidate_names)) != len(candidate_names):
+        raise ValueError("Candidate names must be unique.")
+
+
 def main() -> None:
-    """Parse CLI arguments, generate comparison reports, and upload them to S3.
+    """Parse CLI arguments, generate comparison reports, and publish their artifacts.
 
     This function serves as the command-line entry point for the report
-    generation workflow. It validates user input, initializes storage and S3
-    clients, runs the report orchestrator, and logs the resulting report URLs.
+    generation workflow. It validates user input, initializes storage and the
+    selected destination, runs the report orchestrator, and logs the results.
 
     Raises:
         ValueError: If required environment variables are missing or CLI
@@ -191,7 +216,9 @@ def main() -> None:
     bucket_structure = BucketStructure()
     bucket_structure.eval_output_subdir = args.results_subdir
     baseline_path = Path(args.baseline_path).resolve()
-    candidate_path = Path(args.candidate_path).resolve()
+    _validate_candidate_args(args.candidate_name, args.candidate_path)
+    candidate_paths = [Path(path).resolve() for path in args.candidate_path]
+    local_output_dir = Path(args.local_output_dir).resolve() if args.local_output_dir is not None else None
     task_id = args.task_id
 
     storage: BaseStorage
@@ -202,25 +229,41 @@ def main() -> None:
     audio_report_url: Optional[str] = None
     audio_report_benchmarks: Optional[list[str]] = None
 
-    s3_key_id = os.getenv(_S3_ACCESS_KEY_ID)
-    s3_secret_key = os.getenv(_S3_SECRET_ACCESS_KEY)
+    if local_output_dir is not None:
+        if args.s3_prefix is not None:
+            raise ValueError("'--s3_prefix' cannot be used with '--local_output_dir'.")
+    else:
+        s3_args = {
+            "--s3_endpoint": args.s3_endpoint,
+            "--s3_bucket": args.s3_bucket,
+            "--s3_region": args.s3_region,
+        }
+        missing_s3_args = [name for name, value in s3_args.items() if value is None]
+        if missing_s3_args:
+            raise ValueError(f"Missing required S3 arguments: {', '.join(missing_s3_args)}.")
 
-    if s3_key_id is None or s3_secret_key is None:
-        raise ValueError(
-            f"Environment variables '{_S3_ACCESS_KEY_ID}' and '{_S3_SECRET_ACCESS_KEY}' "
-            "must be set for uploading reports to S3."
+        assert args.s3_endpoint is not None
+        assert args.s3_bucket is not None
+        assert args.s3_region is not None
+
+        s3_key_id = os.getenv(_S3_ACCESS_KEY_ID)
+        s3_secret_key = os.getenv(_S3_SECRET_ACCESS_KEY)
+        if s3_key_id is None or s3_secret_key is None:
+            raise ValueError(
+                f"Environment variables '{_S3_ACCESS_KEY_ID}' and '{_S3_SECRET_ACCESS_KEY}' "
+                "must be set for uploading reports to S3."
+            )
+
+        s3_cfg = S3Config(
+            bucket=args.s3_bucket,
+            endpoint_url=args.s3_endpoint,
+            region_name=args.s3_region,
         )
-
-    s3_cfg = S3Config(
-        bucket=args.s3_bucket,
-        endpoint_url=args.s3_endpoint,
-        region_name=args.s3_region,
-    )
-    s3_client = S3Client(
-        cfg=s3_cfg,
-        aws_access_key_id=s3_key_id,
-        aws_secret_access_key=s3_secret_key,
-    )
+        s3_client = S3Client(
+            cfg=s3_cfg,
+            aws_access_key_id=s3_key_id,
+            aws_secret_access_key=s3_secret_key,
+        )
 
     benchmarks = _get_benchmarks_list(args.benchmarks)
     _validate_benchmarks(benchmarks)
@@ -235,13 +278,18 @@ def main() -> None:
     if task_id == DUMMY_TASK_ID:
         logger.warning("\nWARNING: It is recommended to assign the evaluation report to a specific ticket!")
 
-    if baseline_path == candidate_path:
-        logger.warning(
-            "\nWARNING: Baseline and candidate paths are identical. "
-            "Comparison report is not meaningful in this case!"
-        )
+    if args.baseline_name in args.candidate_name:
+        raise ValueError("Baseline and candidate names must be unique.")
 
-    logger.info(f"\nComparing baseline '{args.baseline_name}' against candidate '{args.candidate_name}'")
+    for candidate_path in candidate_paths:
+        if baseline_path == candidate_path:
+            logger.warning(
+                "\nWARNING: Baseline and candidate paths are identical. "
+                "Comparison report is not meaningful in this case!"
+            )
+
+    candidates_str = ", ".join(f"'{name}'" for name in args.candidate_name)
+    logger.info(f"\nComparing baseline '{args.baseline_name}' against candidates {candidates_str}")
 
     try:
         if args.remote_hostname is not None or args.remote_username is not None:
@@ -279,17 +327,19 @@ def main() -> None:
             s3_client=s3_client,
             renderer=renderer,
             logger=logger,
+            local_output_dir=local_output_dir,
         )
         eval_report_url, audio_report_url = orchestrator.run(
             baseline_name=args.baseline_name,
             candidate_name=args.candidate_name,
             baseline_path=baseline_path,
-            candidate_path=candidate_path,
+            candidate_path=candidate_paths,
             benchmarks=benchmarks,
             generate_audio_report=args.audio_report,
             audio_report_benchmarks=audio_report_benchmarks,
             samples_per_benchmark=args.samples_per_benchmark,
             task_id=task_id,
+            s3_prefix_override=args.s3_prefix,
         )
 
     finally:
@@ -303,17 +353,21 @@ def main() -> None:
             s3_client.close()
 
     if eval_report_url is None:
-        raise RuntimeError("Failed to generate evaluation report and upload it to S3.")
+        raise RuntimeError("Failed to generate evaluation report.")
 
     if args.audio_report and audio_report_url is None:
-        raise RuntimeError("Failed to upload audio report to S3 and create URL.")
+        raise RuntimeError("Failed to generate audio report.")
 
-    if audio_report_url is not None:
-        logger.info(f"\nAudio report is available at:\n{audio_report_url}")
-
-    logger.info(f"\nEvaluation report is available at:\n{eval_report_url}")
-
-    logger.info("\nSave the links and open in your browser!\n")
+    if local_output_dir is not None:
+        if audio_report_url is not None:
+            logger.info(f"\nLocal audio report:\n{local_output_dir / audio_report_url}")
+        logger.info(f"\nLocal evaluation report:\n{local_output_dir / eval_report_url}")
+        logger.info("\nServe the output directory over HTTP to inspect the complete preview.\n")
+    else:
+        if audio_report_url is not None:
+            logger.info(f"\nAudio report is available at:\n{audio_report_url}")
+        logger.info(f"\nEvaluation report is available at:\n{eval_report_url}")
+        logger.info("\nSave the links and open in your browser!\n")
 
 
 if __name__ == "__main__":

--- a/scripts/tts_comparison_report/reporting/components/audio_report.py
+++ b/scripts/tts_comparison_report/reporting/components/audio_report.py
@@ -20,67 +20,67 @@ from scripts.tts_comparison_report.reporting.models import AudioPair, BucketData
 _RNG = random.Random(SEED)
 
 
+def _as_bucket_list(
+    bucket_baseline: BucketData,
+    bucket_candidate: BucketData | list[BucketData],
+) -> list[BucketData]:
+    candidates = bucket_candidate if isinstance(bucket_candidate, list) else [bucket_candidate]
+    return [bucket_baseline, *candidates]
+
+
 def _collect_audio_pairs(
     benchmark_name: str,
     bucket_baseline: BucketData,
-    bucket_candidate: BucketData,
+    bucket_candidate: BucketData | list[BucketData],
     bucket_structure: BucketStructure,
 ) -> list[AudioPair]:
-    baseline_paths = bucket_baseline.get_benchmark_audio_paths(benchmark_name)
-    candidate_paths = bucket_candidate.get_benchmark_audio_paths(benchmark_name)
-    baseline_meta = bucket_baseline.get_benchmark_sample_meta(benchmark_name, bucket_structure)
-    candidate_meta = bucket_candidate.get_benchmark_sample_meta(benchmark_name, bucket_structure)
+    buckets = _as_bucket_list(bucket_baseline, bucket_candidate)
+    audio_paths = [bucket.get_benchmark_audio_paths(benchmark_name) for bucket in buckets]
+    sample_meta = [bucket.get_benchmark_sample_meta(benchmark_name, bucket_structure) for bucket in buckets]
+    expected_names = set(audio_paths[0])
+
+    for bucket, paths in zip(buckets[1:], audio_paths[1:]):
+        if set(paths) != expected_names:
+            raise ValueError(f"Audio sample sets differ for benchmark '{benchmark_name}' in system '{bucket.name}'.")
+
     pairs = []
 
-    if set(baseline_paths) != set(candidate_paths):
-        raise ValueError(f"Audio sample sets differ for benchmark '{benchmark_name}'.")
-
-    for name in baseline_paths:
-        if name not in candidate_paths or name not in baseline_meta or name not in candidate_meta:
+    for name in sorted(expected_names):
+        if any(name not in paths or name not in metadata for paths, metadata in zip(audio_paths, sample_meta)):
             raise ValueError(
                 f"Missing matched sample '{name}' in audio paths or metadata for benchmark '{benchmark_name}'."
             )
 
-        if baseline_meta[name].sample_id != candidate_meta[name].sample_id:
-            raise ValueError(
-                f"Sample id mismatch for '{name}' in benchmark '{benchmark_name}'. "
-                "Probably you use different versions of buckets."
+        expected_sample_id = sample_meta[0][name].sample_id
+        for bucket, metadata in zip(buckets[1:], sample_meta[1:]):
+            if metadata[name].sample_id != expected_sample_id:
+                raise ValueError(
+                    f"Sample id mismatch for '{name}' in benchmark '{benchmark_name}' and system '{bucket.name}'. "
+                    "Probably you use different versions of buckets."
+                )
+
+        system_paths = {bucket.name: paths[name] for bucket, paths in zip(buckets, audio_paths)}
+        pairs.append(
+            AudioPair(
+                context_path=sample_meta[0][name].context_path,
+                baseline_path=audio_paths[0][name],
+                candidate_path=audio_paths[1][name],
+                text=sample_meta[0][name].gt_text,
+                system_paths=system_paths,
             )
-
-        pair = AudioPair(
-            context_path=baseline_meta[name].context_path,
-            baseline_path=baseline_paths[name],
-            candidate_path=candidate_paths[name],
-            text=baseline_meta[name].gt_text,
         )
-        pairs.append(pair)
-
-    pairs.sort(key=lambda p: p.baseline_path.stem)
 
     return pairs
 
 
 def prepare_audio_pairs(
     bucket_baseline: BucketData,
-    bucket_candidate: BucketData,
+    bucket_candidate: BucketData | list[BucketData],
     bucket_structure: BucketStructure,
     used_benchmarks: list[str],
     samples_per_benchmark: int,
 ) -> dict[str, list[AudioPair]]:
-    """Prepare audio pairs for the selected benchmarks.
-
-    Args:
-        bucket_baseline: Baseline bucket data.
-        bucket_candidate: Candidate bucket data.
-        used_benchmarks: Benchmark names to include in the audio report.
-        samples_per_benchmark: Maximum number of audio pairs to sample per benchmark.
-
-    Returns:
-        Mapping from benchmark name to sampled baseline/candidate audio pairs.
-
-    Raises:
-        ValueError: If benchmark audio sets or sample metadata are inconsistent.
-    """
+    """Prepare matched audio samples for every system and selected benchmark."""
     pairs = {}
 
     for benchmark_name in used_benchmarks:

--- a/scripts/tts_comparison_report/reporting/components/boxplots.py
+++ b/scripts/tts_comparison_report/reporting/components/boxplots.py
@@ -18,7 +18,6 @@ from typing import Optional
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
-from matplotlib.patches import PathPatch
 from scripts.tts_comparison_report.reporting.metrics import DistributionMetricSpec, DistributionMetricsRegistry
 from scripts.tts_comparison_report.reporting.models import BucketData, StatTestResult, Winner
 
@@ -51,20 +50,39 @@ class BoxPlotsConfig:
     outlier_alpha: float = 0.5
 
 
+def _as_bucket_list(
+    bucket_baseline: BucketData,
+    bucket_candidate: BucketData | list[BucketData],
+) -> list[BucketData]:
+    candidates = bucket_candidate if isinstance(bucket_candidate, list) else [bucket_candidate]
+    return [bucket_baseline, *candidates]
+
+
+def _winning_systems(metric_name: str, stat_test_results: list[StatTestResult]) -> set[str]:
+    wins: dict[str, int] = {}
+
+    for result in stat_test_results:
+        if result.metric_name != metric_name or result.winner == Winner.tie:
+            continue
+        winner = result.baseline_name if result.winner == Winner.baseline else result.candidate_name
+        if winner is not None:
+            wins[winner] = wins.get(winner, 0) + 1
+
+    if not wins:
+        return set()
+
+    max_wins = max(wins.values())
+    return {name for name, count in wins.items() if count == max_wins}
+
+
 def _style_boxplot(
-    bp: dict[str, PathPatch],
-    metric: DistributionMetricSpec,
-    winner_lookup: dict[str, Winner],
+    bp: dict,
+    system_names: list[str],
+    winning_systems: set[str],
     cfg: BoxPlotsConfig,
 ) -> None:
-    for i, patch in enumerate(bp["boxes"]):
-        winner = winner_lookup[metric.report_name]
-
-        if (i == 0 and winner == Winner.baseline) or (i == 1 and winner == Winner.candidate):
-            color = cfg.winner_model_color
-        else:
-            color = cfg.default_model_color
-
+    for system_name, patch in zip(system_names, bp["boxes"]):
+        color = cfg.winner_model_color if system_name in winning_systems else cfg.default_model_color
         patch.set_facecolor(color)
         patch.set_alpha(cfg.box_alpha)
         patch.set_edgecolor(color)
@@ -73,12 +91,11 @@ def _style_boxplot(
 
 def _add_mean_ci_labels(
     ax: Axes,
-    baseline: np.ndarray,
-    candidate: np.ndarray,
+    values_by_system: list[np.ndarray],
     metric: DistributionMetricSpec,
     cfg: BoxPlotsConfig,
 ) -> None:
-    for x, values in [(1, baseline), (2, candidate)]:
+    for x, values in enumerate(values_by_system, start=1):
         mean, median = values.mean(), np.median(values)
         sem = values.std(ddof=1) / np.sqrt(len(values)) if len(values) > 1 else 0.0
         ci95 = 1.96 * sem
@@ -101,13 +118,15 @@ def _add_mean_ci_labels(
 def _configure_boxplot_axis(
     ax: Axes,
     metric: DistributionMetricSpec,
-    baseline_name: str,
-    candidate_name: str,
+    system_names: list[str],
     cfg: BoxPlotsConfig,
 ) -> None:
+    positions = list(range(1, len(system_names) + 1))
     ax.set_title(metric.report_name, fontsize=cfg.fontsize_title)
-    ax.set_xticks([1, 2])
-    ax.set_xticklabels([baseline_name, candidate_name])
+    ax.set_xticks(positions)
+    ax.set_xticklabels(
+        system_names, rotation=20 if len(system_names) > 3 else 0, ha="right" if len(system_names) > 3 else "center"
+    )
     ax.tick_params(axis="x", labelsize=cfg.fontsize)
     ax.tick_params(axis="y", labelsize=cfg.fontsize)
     ax.grid(True, axis="y", linestyle="dotted", alpha=cfg.grid_alpha)
@@ -123,32 +142,20 @@ def _configure_boxplot_axis(
 
 def prepare_boxplots(
     bucket_baseline: BucketData,
-    bucket_candidate: BucketData,
+    bucket_candidate: BucketData | list[BucketData],
     stat_test_results: list[StatTestResult],
     cfg: BoxPlotsConfig,
     benchmark_name: Optional[str] = None,
 ) -> BytesIO:
-    """Create an in-memory box plot figure for summary or benchmark-level metrics.
-
-    Args:
-        bucket_baseline: Baseline bucket data.
-        bucket_candidate: Candidate bucket data.
-        stat_test_results: Statistical test results used to highlight the winning model.
-        cfg: Plot styling and layout configuration.
-        benchmark_name: Benchmark name. If omitted, metric samples are aggregated
-            across all benchmarks.
-
-    Returns:
-        PNG image stored in an in-memory bytes buffer.
-    """
-    baseline_name = bucket_baseline.name
-    candidate_name = bucket_candidate.name
-    winner_lookup = {res.metric_name: res.winner for res in stat_test_results}
-    num_rows = sum(m.add_to_box_plot for m in DistributionMetricsRegistry)
+    """Create an in-memory box plot figure containing every compared system."""
+    buckets = _as_bucket_list(bucket_baseline, bucket_candidate)
+    system_names = [bucket.name for bucket in buckets]
+    num_rows = sum(metric.add_to_box_plot for metric in DistributionMetricsRegistry)
     fig_height = max(2.0 * num_rows, 4.5)
+    fig_width = max(6.0, 1.6 * len(buckets))
 
     with plt.rc_context({"font.family": cfg.font_family, "font.sans-serif": cfg.font_list}):
-        fig, axs = plt.subplots(num_rows, 1, figsize=(6, fig_height), squeeze=False)
+        fig, axs = plt.subplots(num_rows, 1, figsize=(fig_width, fig_height), squeeze=False)
         axs = axs.flatten()
         plot_idx = 0
 
@@ -156,23 +163,16 @@ def prepare_boxplots(
             if not metric.add_to_box_plot:
                 continue
 
-            baseline = bucket_baseline.get_metric_samples(
-                metric_name=metric.key,
-                benchmark_name=benchmark_name,
-            )
-            candidate = bucket_candidate.get_metric_samples(
-                metric_name=metric.key,
-                benchmark_name=benchmark_name,
-            )
-            baseline = np.asarray(baseline, dtype=float)
-            candidate = np.asarray(candidate, dtype=float)
-
+            values_by_system = [
+                np.asarray(bucket.get_metric_samples(metric.key, benchmark_name), dtype=float) for bucket in buckets
+            ]
+            positions = list(range(1, len(buckets) + 1))
             ax = axs[plot_idx]
             plot_idx += 1
 
             bp = ax.boxplot(
-                [baseline, candidate],
-                positions=[1, 2],
+                values_by_system,
+                positions=positions,
                 widths=cfg.widths,
                 patch_artist=True,
                 showmeans=True,
@@ -183,21 +183,10 @@ def prepare_boxplots(
                     "markeredgecolor": cfg.mean_marker_color,
                     "markersize": cfg.mean_marker_size,
                 },
-                medianprops={
-                    "color": cfg.median_color,
-                    "linewidth": cfg.linewidth,
-                },
-                whiskerprops={
-                    "color": cfg.whisker_color,
-                    "linewidth": cfg.linewidth,
-                },
-                capprops={
-                    "color": cfg.cap_color,
-                    "linewidth": cfg.linewidth,
-                },
-                boxprops={
-                    "linewidth": cfg.linewidth,
-                },
+                medianprops={"color": cfg.median_color, "linewidth": cfg.linewidth},
+                whiskerprops={"color": cfg.whisker_color, "linewidth": cfg.linewidth},
+                capprops={"color": cfg.cap_color, "linewidth": cfg.linewidth},
+                boxprops={"linewidth": cfg.linewidth},
                 flierprops={
                     "marker": cfg.outlier_marker,
                     "markerfacecolor": cfg.outlier_color,
@@ -207,9 +196,9 @@ def prepare_boxplots(
                 },
             )
 
-            _style_boxplot(bp, metric, winner_lookup, cfg)
-            _add_mean_ci_labels(ax, baseline, candidate, metric, cfg)
-            _configure_boxplot_axis(ax, metric, baseline_name, candidate_name, cfg)
+            _style_boxplot(bp, system_names, _winning_systems(metric.report_name, stat_test_results), cfg)
+            _add_mean_ci_labels(ax, values_by_system, metric, cfg)
+            _configure_boxplot_axis(ax, metric, system_names, cfg)
 
         fig.tight_layout(rect=[0, 0, 1, 0.985])
 
@@ -217,5 +206,4 @@ def prepare_boxplots(
     fig.savefig(buffer, format="png", dpi=300, bbox_inches="tight")
     plt.close(fig)
     buffer.seek(0)
-
     return buffer

--- a/scripts/tts_comparison_report/reporting/components/eval_report.py
+++ b/scripts/tts_comparison_report/reporting/components/eval_report.py
@@ -24,41 +24,42 @@ from scripts.tts_comparison_report.reporting.components.stat_tests import (
 from scripts.tts_comparison_report.reporting.models import BucketData, EvalArtifacts, EvalResult, ModelConfiguration
 
 
+def _as_bucket_list(
+    bucket_baseline: BucketData,
+    bucket_candidate: BucketData | list[BucketData],
+) -> list[BucketData]:
+    candidates = bucket_candidate if isinstance(bucket_candidate, list) else [bucket_candidate]
+    return [bucket_baseline, *candidates]
+
+
 def prepare_eval_artifacts(
     bucket_baseline: BucketData,
-    bucket_candidate: BucketData,
+    bucket_candidate: BucketData | list[BucketData],
     box_plots_cfg: BoxPlotsConfig,
 ) -> EvalArtifacts:
-    """Prepare summary and benchmark-level evaluation artifacts for report rendering.
-
-    Args:
-        bucket_baseline: Baseline bucket data.
-        bucket_candidate: Candidate bucket data.
-        box_plots_cfg: Configuration used to generate benchmark and summary box plots.
-
-    Returns:
-        Evaluation artifacts containing configuration metadata, summary results,
-        and per-benchmark results.
-    """
+    """Prepare summary and benchmark-level artifacts for all compared systems."""
+    buckets = _as_bucket_list(bucket_baseline, bucket_candidate)
+    candidates = buckets[1:]
     baseline_name = bucket_baseline.name
-    candidate_name = bucket_candidate.name
-    is_self_comparison = bucket_baseline.path == bucket_candidate.path
+    candidate_name = candidates[0].name
+    is_self_comparison = len({bucket.path for bucket in buckets}) == 1
+    include_comparison = len(buckets) > 2
 
-    metrics_table_row = prepare_summary_metrics_table_rows(bucket_baseline, bucket_candidate)
-    stat_test_results = run_stat_tests(bucket_baseline, bucket_candidate)
-    stat_test_table_row = prepare_stat_tests_table_rows(baseline_name, candidate_name, stat_test_results)
-    stat_tests_analysis_info = prepare_stat_tests_analysis_info(baseline_name, candidate_name, stat_test_results)
-
-    box_plots = prepare_boxplots(
-        bucket_baseline=bucket_baseline,
-        bucket_candidate=bucket_candidate,
-        stat_test_results=stat_test_results,
-        cfg=box_plots_cfg,
+    metrics_table_row = prepare_summary_metrics_table_rows(bucket_baseline, candidates)
+    stat_test_results = run_stat_tests(bucket_baseline, candidates)
+    stat_test_table_row = prepare_stat_tests_table_rows(
+        baseline_name,
+        candidate_name,
+        stat_test_results,
+        include_comparison=include_comparison,
     )
+    stat_tests_analysis_info = prepare_stat_tests_analysis_info(baseline_name, candidate_name, stat_test_results)
+    box_plots = prepare_boxplots(bucket_baseline, candidates, stat_test_results, box_plots_cfg)
 
     configuration = ModelConfiguration(
         baseline=bucket_baseline.configuration_str,
-        candidate=bucket_candidate.configuration_str,
+        candidate=candidates[0].configuration_str,
+        systems={bucket.name: bucket.configuration_str for bucket in buckets},
     )
     summary = EvalResult(
         metrics_table_row=metrics_table_row,
@@ -69,19 +70,22 @@ def prepare_eval_artifacts(
     benchmarks = {}
 
     for benchmark_name in bucket_baseline.benchmarks:
-        metrics_table_row = prepare_benchmark_metrics_table_rows(benchmark_name, bucket_baseline, bucket_candidate)
-        stat_test_results = run_stat_tests(bucket_baseline, bucket_candidate, benchmark_name)
-        stat_test_table_row = prepare_stat_tests_table_rows(baseline_name, candidate_name, stat_test_results)
+        metrics_table_row = prepare_benchmark_metrics_table_rows(benchmark_name, bucket_baseline, candidates)
+        stat_test_results = run_stat_tests(bucket_baseline, candidates, benchmark_name)
+        stat_test_table_row = prepare_stat_tests_table_rows(
+            baseline_name,
+            candidate_name,
+            stat_test_results,
+            include_comparison=include_comparison,
+        )
         stat_tests_analysis_info = prepare_stat_tests_analysis_info(baseline_name, candidate_name, stat_test_results)
-
         box_plots = prepare_boxplots(
-            bucket_baseline=bucket_baseline,
-            bucket_candidate=bucket_candidate,
-            stat_test_results=stat_test_results,
-            cfg=box_plots_cfg,
+            bucket_baseline,
+            candidates,
+            stat_test_results,
+            box_plots_cfg,
             benchmark_name=benchmark_name,
         )
-
         benchmarks[benchmark_name] = EvalResult(
             metrics_table_row=metrics_table_row,
             stat_test_table_row=stat_test_table_row,

--- a/scripts/tts_comparison_report/reporting/components/metrics_table.py
+++ b/scripts/tts_comparison_report/reporting/components/metrics_table.py
@@ -12,143 +12,114 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import html
-from typing import Optional
 
 import numpy as np
 from scripts.tts_comparison_report.reporting.metrics import MetricSpec, MetricsRegistry
 from scripts.tts_comparison_report.reporting.models import BucketData
 
 
-def _metric_comparator(
-    a: float,
-    b: float,
-    lower_is_better: Optional[bool],
-) -> Optional[bool]:
-    if lower_is_better is None:
-        return None
-
-    if lower_is_better:
-        # If the values ​​are equal, the baseline wins.
-        return a <= b
-
-    return a >= b
+def _as_bucket_list(
+    bucket_baseline: BucketData,
+    bucket_candidate: BucketData | list[BucketData],
+) -> list[BucketData]:
+    candidates = bucket_candidate if isinstance(bucket_candidate, list) else [bucket_candidate]
+    return [bucket_baseline, *candidates]
 
 
 def _format_metric_values(
-    a: float,
-    b: float,
+    values: list[float],
     metric: MetricSpec,
-) -> tuple[str, str]:
-    a, b = metric.multiplier * a, metric.multiplier * b
-    a_is_better = _metric_comparator(a, b, metric.lower_is_better)
-    a, b = round(a, metric.round_digits), round(b, metric.round_digits)
-    a_str, b_str = f"{a}{metric.units}", f"{b}{metric.units}"
+) -> list[str]:
+    scaled_values = [metric.multiplier * value for value in values]
+    best_value = None
 
-    a_str = html.escape(a_str)
-    b_str = html.escape(b_str)
+    if metric.lower_is_better is True:
+        best_value = min(scaled_values)
+    elif metric.lower_is_better is False:
+        best_value = max(scaled_values)
 
-    if metric.lower_is_better is not None:
-        if a_is_better:
-            a_str = f"<strong>{a_str}</strong>"
-        else:
-            b_str = f"<strong>{b_str}</strong>"
+    best_indices = set()
+    if best_value is not None:
+        best_indices = {index for index, value in enumerate(scaled_values) if value == best_value}
+        if len(scaled_values) == 2 and len(best_indices) == 2:
+            best_indices = {0}
 
-    return a_str, b_str
+    output = []
+    for index, value in enumerate(scaled_values):
+        value_str = html.escape(f"{round(value, metric.round_digits)}{metric.units}")
+        if index in best_indices:
+            value_str = f"<strong>{value_str}</strong>"
+        output.append(value_str)
+
+    return output
 
 
 def prepare_benchmark_metrics_table_rows(
     benchmark_name: str,
     bucket_baseline: BucketData,
-    bucket_candidate: BucketData,
+    bucket_candidate: BucketData | list[BucketData],
 ) -> list[list[str]]:
-    """Prepare formatted metric rows for one benchmark comparison table.
-
-    Args:
-        benchmark_name: Name of the benchmark to render.
-        bucket_baseline: Baseline bucket data.
-        bucket_candidate: Candidate bucket data.
-
-    Returns:
-        Table rows containing metric names and formatted baseline/candidate values.
-
-    Raises:
-        ValueError: If a required metric is missing for the benchmark.
-    """
+    """Prepare formatted metric rows for one benchmark across all systems."""
+    buckets = _as_bucket_list(bucket_baseline, bucket_candidate)
     rows = []
 
     for metric in MetricsRegistry:
-        a = bucket_baseline.get_metric_avg_value(
-            metric_name=metric.key,
-            benchmark_name=benchmark_name,
-        )
-        b = bucket_candidate.get_metric_avg_value(
-            metric_name=metric.key,
-            benchmark_name=benchmark_name,
-        )
+        values = [
+            bucket.get_metric_avg_value(
+                metric_name=metric.key,
+                benchmark_name=benchmark_name,
+            )
+            for bucket in buckets
+        ]
 
-        if a is None or b is None:
+        if any(value is None for value in values):
             if metric.optional:
                 continue
             raise ValueError(f"Unknown metric '{metric.key}' for benchmark '{benchmark_name}'.")
 
-        a_str, b_str = _format_metric_values(a, b, metric)
-
-        rows.append([html.escape(metric.report_name), a_str, b_str])
+        formatted_values = _format_metric_values([float(value) for value in values], metric)
+        rows.append([html.escape(metric.report_name), *formatted_values])
 
     return rows
 
 
 def prepare_summary_metrics_table_rows(
     bucket_baseline: BucketData,
-    bucket_candidate: BucketData,
+    bucket_candidate: BucketData | list[BucketData],
 ) -> list[list[str]]:
-    """Prepare formatted metric rows for the summary comparison table.
-
-    Args:
-        bucket_baseline: Baseline bucket data.
-        bucket_candidate: Candidate bucket data.
-
-    Returns:
-        Table rows containing metric names and formatted macro-averaged
-        baseline/candidate values.
-
-    Raises:
-        ValueError: If a required metric is missing for any benchmark included
-            in the summary.
-    """
+    """Prepare macro-averaged metric rows across all benchmarks and systems."""
+    buckets = _as_bucket_list(bucket_baseline, bucket_candidate)
     rows = []
 
     for metric in MetricsRegistry:
         if not metric.include_in_summary:
             continue
 
-        a_vals, b_vals = [], []
+        system_values: list[list[float]] = [[] for _ in buckets]
         skip = False
 
         for benchmark_name in bucket_baseline.benchmarks:
-            a = bucket_baseline.get_metric_avg_value(
-                metric_name=metric.key,
-                benchmark_name=benchmark_name,
-            )
-            b = bucket_candidate.get_metric_avg_value(
-                metric_name=metric.key,
-                benchmark_name=benchmark_name,
-            )
+            values = [
+                bucket.get_metric_avg_value(
+                    metric_name=metric.key,
+                    benchmark_name=benchmark_name,
+                )
+                for bucket in buckets
+            ]
 
-            if a is None or b is None:
+            if any(value is None for value in values):
                 if metric.optional:
                     skip = True
                     break
                 raise ValueError(f"Unknown metric '{metric.key}' for benchmark '{benchmark_name}'.")
 
-            a_vals.append(a)
-            b_vals.append(b)
+            for system_index, value in enumerate(values):
+                system_values[system_index].append(float(value))
 
         if skip:
             continue
 
-        avg_a, avg_b = np.mean(a_vals), np.mean(b_vals)
-        a_str, b_str = _format_metric_values(avg_a, avg_b, metric)
-        rows.append([html.escape(metric.report_name), a_str, b_str])
+        averages = [float(np.mean(values)) for values in system_values]
+        rows.append([html.escape(metric.report_name), *_format_metric_values(averages, metric)])
 
     return rows

--- a/scripts/tts_comparison_report/reporting/components/stat_tests.py
+++ b/scripts/tts_comparison_report/reporting/components/stat_tests.py
@@ -14,6 +14,7 @@
 import html
 import warnings
 from enum import Enum
+from itertools import combinations
 from typing import Optional
 
 from scipy.stats import mannwhitneyu
@@ -29,6 +30,14 @@ class _Alternative(str, Enum):
     two_sided = "two-sided"
     greater = "greater"
     less = "less"
+
+
+def _as_bucket_list(
+    bucket_baseline: BucketData,
+    bucket_candidate: BucketData | list[BucketData],
+) -> list[BucketData]:
+    candidates = bucket_candidate if isinstance(bucket_candidate, list) else [bucket_candidate]
+    return [bucket_baseline, *candidates]
 
 
 def _run_single_stat_test(
@@ -49,7 +58,6 @@ def _run_single_stat_test(
             stacklevel=2,
         )
 
-    # First test whether distributions differ at all, then determine direction.
     p_val_two_sided = mannwhitneyu(baseline, candidate, alternative="two-sided", method="auto").pvalue
 
     if p_val_two_sided >= _SIGNIFICANCE_LEVEL:
@@ -59,15 +67,13 @@ def _run_single_stat_test(
 
     if p_val < _SIGNIFICANCE_LEVEL:
         winner = Winner.baseline if lower_is_better else Winner.candidate
-        p_val = round(p_val, P_VAL_ROUND_DIGITS)
-        return winner, _Alternative.less, p_val
+        return winner, _Alternative.less, round(p_val, P_VAL_ROUND_DIGITS)
 
     p_val = mannwhitneyu(baseline, candidate, alternative="greater", method="auto").pvalue
 
     if p_val < _SIGNIFICANCE_LEVEL:
         winner = Winner.candidate if lower_is_better else Winner.baseline
-        p_val = round(p_val, P_VAL_ROUND_DIGITS)
-        return winner, _Alternative.greater, p_val
+        return winner, _Alternative.greater, round(p_val, P_VAL_ROUND_DIGITS)
 
     return Winner.tie, _Alternative.two_sided, round(p_val_two_sided, P_VAL_ROUND_DIGITS)
 
@@ -86,38 +92,30 @@ def _map_winner_to_name(
 
 def run_stat_tests(
     bucket_baseline: BucketData,
-    bucket_candidate: BucketData,
+    bucket_candidate: BucketData | list[BucketData],
     benchmark_name: Optional[str] = None,
 ) -> list[StatTestResult]:
-    """Run statistical tests for all distribution metrics.
-
-    Args:
-        bucket_baseline: Baseline bucket data.
-        bucket_candidate: Candidate bucket data.
-        benchmark_name: Benchmark name. If omitted, metric samples are aggregated
-            across all benchmarks.
-
-    Returns:
-        List of StatTestResult instances for configured distribution metrics.
-
-    Raises:
-        ValueError: If metric samples are missing or benchmark data is invalid.
-    """
+    """Run every configured distribution test for all pairs of systems."""
+    buckets = _as_bucket_list(bucket_baseline, bucket_candidate)
     results = []
 
-    for metric in DistributionMetricsRegistry:
-        winner, alternative, p_value = _run_single_stat_test(
-            baseline=bucket_baseline.get_metric_samples(metric.key, benchmark_name),
-            candidate=bucket_candidate.get_metric_samples(metric.key, benchmark_name),
-            lower_is_better=metric.lower_is_better,
-        )
-        result = StatTestResult(
-            metric_name=metric.report_name,
-            winner=winner,
-            alternative=alternative.value,
-            p_value=p_value,
-        )
-        results.append(result)
+    for first_bucket, second_bucket in combinations(buckets, 2):
+        for metric in DistributionMetricsRegistry:
+            winner, alternative, p_value = _run_single_stat_test(
+                baseline=first_bucket.get_metric_samples(metric.key, benchmark_name),
+                candidate=second_bucket.get_metric_samples(metric.key, benchmark_name),
+                lower_is_better=metric.lower_is_better,
+            )
+            results.append(
+                StatTestResult(
+                    metric_name=metric.report_name,
+                    winner=winner,
+                    alternative=alternative.value,
+                    p_value=p_value,
+                    baseline_name=first_bucket.name,
+                    candidate_name=second_bucket.name,
+                )
+            )
 
     return results
 
@@ -126,30 +124,24 @@ def prepare_stat_tests_table_rows(
     baseline_name: str,
     candidate_name: str,
     stat_test_results: list[StatTestResult],
+    include_comparison: bool = False,
 ) -> list[list[str]]:
-    """Prepare formatted rows for a statistical test results table.
-
-    Args:
-        baseline_name: Name of the baseline model used in the reports.
-        candidate_name: Name of the candidate model used in the reports.
-        stat_test_results: Statistical test results to format.
-
-    Returns:
-        Table rows containing metric name, winner, alternative hypothesis,
-        and p-value.
-    """
+    """Prepare statistical-test table rows, optionally identifying each system pair."""
     rows = []
 
-    for res in stat_test_results:
-        winner = _map_winner_to_name(res.winner, baseline_name, candidate_name)
-        rows.append(
-            [
-                html.escape(res.metric_name),
-                html.escape(winner),
-                html.escape(res.alternative),
-                html.escape(str(res.p_value)),
-            ]
-        )
+    for result in stat_test_results:
+        first_name = result.baseline_name or baseline_name
+        second_name = result.candidate_name or candidate_name
+        winner = _map_winner_to_name(result.winner, first_name, second_name)
+        row = [
+            html.escape(result.metric_name),
+            html.escape(winner),
+            html.escape(result.alternative),
+            html.escape(str(result.p_value)),
+        ]
+        if include_comparison:
+            row.insert(1, html.escape(f"{first_name} vs {second_name}"))
+        rows.append(row)
 
     return rows
 
@@ -159,33 +151,39 @@ def prepare_stat_tests_analysis_info(
     candidate_name: str,
     stat_test_results: list[StatTestResult],
 ) -> StatTestAnalysisInfo:
-    """Prepare summary information for the statistical test analysis section.
+    """Summarize significant wins, preserving the original two-system behavior."""
+    comparison_pairs = {
+        (result.baseline_name or baseline_name, result.candidate_name or candidate_name)
+        for result in stat_test_results
+    }
+    if len(comparison_pairs) <= 1:
+        baseline_wins = [result.metric_name for result in stat_test_results if result.winner == Winner.baseline]
+        candidate_wins = [result.metric_name for result in stat_test_results if result.winner == Winner.candidate]
+        if not baseline_wins and not candidate_wins:
+            return StatTestAnalysisInfo(winner=None, advantages=None)
 
-    Args:
-        baseline_name: Name of the baseline model used in the reports.
-        candidate_name: Name of the candidate model used in the reports.
-        stat_test_results: Statistical test results to summarize.
+        winner, wins = (
+            (baseline_name, baseline_wins)
+            if len(baseline_wins) >= len(candidate_wins)
+            else (candidate_name, candidate_wins)
+        )
+        return StatTestAnalysisInfo(winner=winner, advantages=", ".join(wins))
 
-    Returns:
-        Instance of StatTestAnalysisInfo containing the overall winner and its
-        key advantages. If no statistically significant wins are present, both
-        fields are set to `None`.
-    """
-    a_wins, b_wins = [], []
+    wins: dict[str, list[str]] = {}
+    for result in stat_test_results:
+        first_name = result.baseline_name or baseline_name
+        second_name = result.candidate_name or candidate_name
+        winner = _map_winner_to_name(result.winner, first_name, second_name)
+        if result.winner == Winner.tie:
+            continue
+        loser = second_name if winner == first_name else first_name
+        wins.setdefault(winner, []).append(f"{result.metric_name} over {loser}")
 
-    for res in stat_test_results:
-        if res.winner == Winner.baseline:
-            a_wins.append(res.metric_name)
-        elif res.winner == Winner.candidate:
-            b_wins.append(res.metric_name)
+    if not wins:
+        return StatTestAnalysisInfo(winner=None, advantages=None)
 
-    if not a_wins and not b_wins:
-        winner, advantages = None, None
-    else:
-        winner, wins = (baseline_name, a_wins) if len(a_wins) >= len(b_wins) else (candidate_name, b_wins)
-        advantages = ", ".join(wins)
-
-    return StatTestAnalysisInfo(
-        winner=winner,
-        advantages=advantages,
-    )
+    max_wins = max(len(metrics) for metrics in wins.values())
+    leaders = sorted(name for name, metrics in wins.items() if len(metrics) == max_wins)
+    winner = ", ".join(leaders)
+    advantages = "; ".join(f"{name}: {', '.join(wins[name])}" for name in leaders)
+    return StatTestAnalysisInfo(winner=winner, advantages=advantages)

--- a/scripts/tts_comparison_report/reporting/helpers.py
+++ b/scripts/tts_comparison_report/reporting/helpers.py
@@ -57,24 +57,32 @@ def make_task_info(task_id: str) -> TaskInfo:
 
 def generate_s3_prefix(
     baseline_path: Path,
-    candidate_path: Path,
+    candidate_path: Path | list[Path],
     task_info: TaskInfo,
     expiration_info: ExpirationInfo,
+    override: str | None = None,
 ) -> str:
     """Generate the S3 prefix used to store report artifacts.
 
     Args:
         baseline_path: Path to the baseline bucket root.
-        candidate_path: Path to the candidate bucket root.
+        candidate_path: Path or paths to candidate bucket roots.
         task_info: Task metadata.
         expiration_info: Expiration metadata.
+        override: Optional explicit S3 key prefix.
 
     Returns:
         S3 key prefix for uploaded report artifacts.
     """
-    parts = [
-        task_info.task_id,
-        f"{baseline_path.stem}_vs_{candidate_path.stem}",
-        expiration_info.path_str,
-    ]
+    if override is not None:
+        prefix = override.strip("/")
+        if not prefix:
+            raise ValueError("S3 prefix override must not be empty.")
+        if any(part in {".", ".."} for part in prefix.split("/")):
+            raise ValueError("S3 prefix override must not contain relative path components.")
+        return prefix
+
+    candidate_paths = candidate_path if isinstance(candidate_path, list) else [candidate_path]
+    comparison_name = "_vs_".join([baseline_path.stem, *(path.stem for path in candidate_paths)])
+    parts = [task_info.task_id, comparison_name, expiration_info.path_str]
     return "-".join(parts)

--- a/scripts/tts_comparison_report/reporting/models.py
+++ b/scripts/tts_comparison_report/reporting/models.py
@@ -567,6 +567,8 @@ class StatTestResult:
     winner: Winner
     alternative: str
     p_value: float
+    baseline_name: Optional[str] = None
+    candidate_name: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -589,10 +591,11 @@ class EvalResult:
 
 @dataclass(frozen=True)
 class ModelConfiguration:
-    """Configuration strings associated with the baseline and candidate models."""
+    """Configuration strings associated with all compared systems."""
 
-    baseline: str
-    candidate: str
+    baseline: Optional[str]
+    candidate: Optional[str]
+    systems: dict[str, Optional[str]] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -615,19 +618,21 @@ class UploadedBoxPlotsInfo:
 
 @dataclass(frozen=True)
 class AudioPair:
-    """Matched context, baseline, and candidate audio files for one sample."""
+    """Matched context and generated audio files for one sample."""
 
     context_path: Path
     baseline_path: Path
     candidate_path: Path
     text: str
+    system_paths: dict[str, Path] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
 class UploadedAudioPairInfo:
-    """Uploaded context, baseline, and candidate audio URLs for one sample."""
+    """Uploaded context and generated audio URLs for one sample."""
 
     context_url: str
     baseline_url: str
     candidate_url: str
     text: str
+    system_urls: dict[str, str] = field(default_factory=dict)

--- a/scripts/tts_comparison_report/reporting/orchestrator.py
+++ b/scripts/tts_comparison_report/reporting/orchestrator.py
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import shutil
 from io import BytesIO
 from logging import Logger
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TypeVar
 
 from scripts.tts_comparison_report.reporting.components import (
     BoxPlotsConfig,
@@ -44,98 +45,137 @@ from scripts.tts_comparison_report.reporting.s3_client import S3Client
 from scripts.tts_comparison_report.reporting.storage import BaseStorage
 from tqdm import tqdm
 
+_T = TypeVar("_T")
+
 
 class Orchestrator:
-    """Coordinate loading, processing, rendering, and uploading of comparison reports."""
+    """Coordinate loading, processing, rendering, and publishing comparison reports."""
 
     def __init__(
         self,
         bucket_structure: BucketStructure,
         storage: BaseStorage,
-        s3_client: S3Client,
+        s3_client: Optional[S3Client],
         renderer: Renderer,
         logger: Optional[Logger] = None,
+        local_output_dir: Optional[Path] = None,
     ) -> None:
         self.bucket_structure = bucket_structure
         self.storage = storage
         self.s3_client = s3_client
         self.renderer = renderer
         self.logger = logger
+        self.local_output_dir = local_output_dir.resolve() if local_output_dir is not None else None
+        self.show_pbar = logger is not None
 
-        self.show_pbar = True if logger is not None else False
+        if (self.s3_client is None) == (self.local_output_dir is None):
+            raise ValueError("Configure exactly one report destination: S3 or a local output directory.")
 
     def _log_info(self, msg: str) -> None:
         if self.logger is not None:
             self.logger.info(msg)
 
+    def _expiration_comment(self, expiration_info: ExpirationInfo) -> str:
+        if self.local_output_dir is not None:
+            return "Local preview; audio and images are served from this directory."
+        return f"This report will expire at {expiration_info.user_str}"
+
+    @staticmethod
+    def _normalize_candidates(candidate: _T | list[_T]) -> list[_T]:
+        return candidate if isinstance(candidate, list) else [candidate]
+
     def _load_buckets(
         self,
         baseline_name: str,
-        candidate_name: str,
+        candidate_name: str | list[str],
         baseline_path: Path,
-        candidate_path: Path,
+        candidate_path: Path | list[Path],
         benchmark_names: tuple[str, ...],
         check_audio: bool,
-    ) -> tuple[BucketData, BucketData]:
-        self._log_info(f"\nLoading metadata for {baseline_name}...")
-        bucket_baseline = BucketData.from_storage(
-            bucket_name=baseline_name,
-            bucket_path=baseline_path,
-            bucket_structure=self.bucket_structure,
-            benchmark_names=benchmark_names,
-            check_audio=check_audio,
-            storage=self.storage,
-        )
-        self._log_info(f"Loading metadata for {candidate_name}...")
-        bucket_candidate = BucketData.from_storage(
-            bucket_name=candidate_name,
-            bucket_path=candidate_path,
-            bucket_structure=self.bucket_structure,
-            benchmark_names=benchmark_names,
-            check_audio=check_audio,
-            storage=self.storage,
-        )
+    ) -> list[BucketData]:
+        candidate_names = self._normalize_candidates(candidate_name)
+        candidate_paths = self._normalize_candidates(candidate_path)
+        if not candidate_names:
+            raise ValueError("At least one candidate system is required.")
+        if len(candidate_names) != len(candidate_paths):
+            raise ValueError("Candidate names and paths must have the same length.")
 
-        baseline_set = set(bucket_baseline.benchmarks.keys())
-        candidate_set = set(bucket_candidate.benchmarks.keys())
+        names = [baseline_name, *candidate_names]
+        paths = [baseline_path, *candidate_paths]
+        if len(set(names)) != len(names):
+            raise ValueError("System names must be unique.")
 
-        if baseline_set != candidate_set:
-            raise ValueError(f"Benchmark sets differ: '{baseline_set}' vs '{candidate_set}'.")
+        buckets = []
+        for name, path in zip(names, paths):
+            self._log_info(f"\nLoading metadata for {name}...")
+            buckets.append(
+                BucketData.from_storage(
+                    bucket_name=name,
+                    bucket_path=path,
+                    bucket_structure=self.bucket_structure,
+                    benchmark_names=benchmark_names,
+                    check_audio=check_audio,
+                    storage=self.storage,
+                )
+            )
 
-        self._log_info(f"\nLoading metric data for {baseline_name}:")
-        bucket_baseline.load_metrics(storage=self.storage, show_pbar=self.show_pbar)
+        reference_set = set(buckets[0].benchmarks)
+        for bucket in buckets[1:]:
+            benchmark_set = set(bucket.benchmarks)
+            if benchmark_set != reference_set:
+                raise ValueError(
+                    f"Benchmark sets differ for '{buckets[0].name}' and '{bucket.name}': "
+                    f"'{reference_set}' vs '{benchmark_set}'."
+                )
 
-        self._log_info(f"\nLoading metric data for {candidate_name}:")
-        bucket_candidate.load_metrics(storage=self.storage, show_pbar=self.show_pbar)
+        for bucket in buckets:
+            self._log_info(f"\nLoading metric data for {bucket.name}:")
+            bucket.load_metrics(storage=self.storage, show_pbar=self.show_pbar)
 
-        return bucket_baseline, bucket_candidate
+        return buckets
 
-    def _upload_audio_file(
-        self,
-        path: Path,
-        key: str,
-    ) -> str:
-        with self.storage.open_file(path) as f:
-            url = self.s3_client.upload_fileobj(
-                fileobj=f,
+    @staticmethod
+    def _artifact_key(prefix: str, relative_key: str) -> str:
+        return f"{prefix}/{relative_key}" if prefix else relative_key
+
+    def _local_artifact_path(self, key: str) -> Path:
+        if self.local_output_dir is None:
+            raise RuntimeError("Local output directory is not configured.")
+        target = (self.local_output_dir / key).resolve()
+        if not target.is_relative_to(self.local_output_dir):
+            raise ValueError(f"Local artifact path escapes output directory: '{key}'.")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        return target
+
+    def _upload_audio_file(self, path: Path, key: str) -> str:
+        with self.storage.open_file(path) as fileobj:
+            if self.local_output_dir is not None:
+                with self._local_artifact_path(key).open("wb") as output:
+                    shutil.copyfileobj(fileobj, output)
+                return key
+
+            if self.s3_client is None:
+                raise RuntimeError("S3 client is not configured.")
+            return self.s3_client.upload_fileobj(
+                fileobj=fileobj,
                 key=key,
                 expires_in=S3_LINK_EXPIRES_IN,
                 content_type="audio/wav",
             )
-        return url
 
-    def _upload_png_image(
-        self,
-        image: BytesIO,
-        key: str,
-    ) -> str:
-        url = self.s3_client.upload_bytes(
+    def _upload_png_image(self, image: BytesIO, key: str) -> str:
+        if self.local_output_dir is not None:
+            self._local_artifact_path(key).write_bytes(image.getvalue())
+            return key
+
+        if self.s3_client is None:
+            raise RuntimeError("S3 client is not configured.")
+        return self.s3_client.upload_bytes(
             data=image.getvalue(),
             key=key,
             expires_in=S3_LINK_EXPIRES_IN,
             content_type="image/png",
         )
-        return url
 
     def _upload_audio(
         self,
@@ -143,34 +183,43 @@ class Orchestrator:
         audio_pairs: dict[str, list[AudioPair]],
         s3_prefix: str,
     ) -> dict[str, list[UploadedAudioPairInfo]]:
-        total = sum(len(v) for v in audio_pairs.values())
+        total = sum(len(values) for values in audio_pairs.values())
         pbar = tqdm(total=total, ncols=TQDM_NCOLS) if self.show_pbar else None
         uploaded_info = {}
 
         for benchmark_name in used_benchmarks:
             benchmark_info = []
 
-            for i, pair in enumerate(audio_pairs[benchmark_name]):
+            for sample_index, pair in enumerate(audio_pairs[benchmark_name]):
                 context_url = self._upload_audio_file(
-                    path=pair.context_path,
-                    key=f"{s3_prefix}/{S3_AUDIO_DIR}/context_{benchmark_name}_{i}.wav",
+                    pair.context_path,
+                    self._artifact_key(s3_prefix, f"{S3_AUDIO_DIR}/context_{benchmark_name}_{sample_index}.wav"),
                 )
-                baseline_url = self._upload_audio_file(
-                    path=pair.baseline_path,
-                    key=f"{s3_prefix}/{S3_AUDIO_DIR}/baseline_{benchmark_name}_{i}.wav",
-                )
-                candidate_url = self._upload_audio_file(
-                    path=pair.candidate_path,
-                    key=f"{s3_prefix}/{S3_AUDIO_DIR}/candidate_{benchmark_name}_{i}.wav",
-                )
-                pair_info = UploadedAudioPairInfo(
-                    context_url=context_url,
-                    baseline_url=baseline_url,
-                    candidate_url=candidate_url,
-                    text=pair.text,
-                )
-                benchmark_info.append(pair_info)
+                system_urls = {}
+                system_items = list(pair.system_paths.items())
+                for system_index, (system_name, system_path) in enumerate(system_items):
+                    if len(system_items) == 2:
+                        artifact_name = ("baseline", "candidate")[system_index]
+                    else:
+                        artifact_name = f"system_{system_index}"
+                    system_urls[system_name] = self._upload_audio_file(
+                        system_path,
+                        self._artifact_key(
+                            s3_prefix,
+                            f"{S3_AUDIO_DIR}/{artifact_name}_{benchmark_name}_{sample_index}.wav",
+                        ),
+                    )
 
+                urls = list(system_urls.values())
+                benchmark_info.append(
+                    UploadedAudioPairInfo(
+                        context_url=context_url,
+                        baseline_url=urls[0],
+                        candidate_url=urls[1],
+                        text=pair.text,
+                        system_urls=system_urls,
+                    )
+                )
                 if pbar:
                     pbar.update(1)
 
@@ -178,102 +227,84 @@ class Orchestrator:
 
         if pbar:
             pbar.close()
-
         return uploaded_info
 
-    def _upload_boxplots(
-        self,
-        eval_artifacts: EvalArtifacts,
-        s3_prefix: str,
-    ) -> UploadedBoxPlotsInfo:
+    def _upload_boxplots(self, eval_artifacts: EvalArtifacts, s3_prefix: str) -> UploadedBoxPlotsInfo:
         name_prefix = "box_plot"
         pbar = tqdm(total=len(eval_artifacts.benchmarks) + 1, ncols=TQDM_NCOLS) if self.show_pbar else None
-
         summary_url = self._upload_png_image(
-            image=eval_artifacts.summary.box_plots,
-            key=f"{s3_prefix}/{S3_IMAGES_DIR}/{name_prefix}_summary.png",
+            eval_artifacts.summary.box_plots,
+            self._artifact_key(s3_prefix, f"{S3_IMAGES_DIR}/{name_prefix}_summary.png"),
         )
         if pbar:
             pbar.update(1)
 
         benchmark_urls = {}
-
         for benchmark_name, benchmark_result in eval_artifacts.benchmarks.items():
             benchmark_urls[benchmark_name] = self._upload_png_image(
-                image=benchmark_result.box_plots,
-                key=f"{s3_prefix}/{S3_IMAGES_DIR}/{name_prefix}_{benchmark_name}.png",
+                benchmark_result.box_plots,
+                self._artifact_key(s3_prefix, f"{S3_IMAGES_DIR}/{name_prefix}_{benchmark_name}.png"),
             )
             if pbar:
                 pbar.update(1)
 
         if pbar:
             pbar.close()
+        return UploadedBoxPlotsInfo(summary_url=summary_url, benchmark_urls=benchmark_urls)
 
-        return UploadedBoxPlotsInfo(
-            summary_url=summary_url,
-            benchmark_urls=benchmark_urls,
-        )
+    def _upload_report(self, report: str, s3_prefix: str, report_name: str) -> str:
+        key = self._artifact_key(s3_prefix, f"{report_name}.html")
+        if self.local_output_dir is not None:
+            self._local_artifact_path(key).write_text(report, encoding="utf-8")
+            return key
 
-    def _upload_report(
-        self,
-        report: str,
-        s3_prefix: str,
-        report_name: str,
-    ) -> str:
-        report_url = self.s3_client.upload_bytes(
+        if self.s3_client is None:
+            raise RuntimeError("S3 client is not configured.")
+        return self.s3_client.upload_bytes(
             data=report.encode("utf-8"),
-            key=f"{s3_prefix}/{report_name}.html",
+            key=key,
             expires_in=S3_LINK_EXPIRES_IN,
             content_type="text/html; charset=utf-8",
         )
-        return report_url
 
     def _render_audio_report(
         self,
-        baseline_name: str,
-        candidate_name: str,
+        system_names: list[str],
         used_benchmarks: list[str],
         uploaded_audio_info: dict[str, list[UploadedAudioPairInfo]],
         task_info: TaskInfo,
         expiration_info: ExpirationInfo,
     ) -> str:
-        expiration_comment = f"This report will expire at {expiration_info.user_str}"
-
         header_block = self.renderer.render(
             name=TemplateName.audio_report_header,
-            baseline_name=baseline_name,
-            candidate_name=candidate_name,
-            expiration_comment=expiration_comment,
+            system_names=system_names,
+            expiration_comment=self._expiration_comment(expiration_info),
         )
         benchmark_blocks, benchmark_section_info = [], []
 
         for benchmark_name in used_benchmarks:
-            pair_blocks = []
-
-            for pair in uploaded_audio_info[benchmark_name]:
-                block = self.renderer.render(
+            pair_blocks = [
+                self.renderer.render(
                     name=TemplateName.audio_report_pair,
                     context_url=pair.context_url,
-                    baseline_url=pair.baseline_url,
-                    candidate_url=pair.candidate_url,
+                    system_urls=pair.system_urls,
                     text=pair.text,
                 )
-                pair_blocks.append(block)
-
-            block = self.renderer.render(
-                name=TemplateName.audio_report_block,
-                title=benchmark_name,
-                section_id=benchmark_name,
-                baseline_name=baseline_name,
-                candidate_name=candidate_name,
-                pair_blocks=pair_blocks,
+                for pair in uploaded_audio_info[benchmark_name]
+            ]
+            benchmark_blocks.append(
+                self.renderer.render(
+                    name=TemplateName.audio_report_block,
+                    title=benchmark_name,
+                    section_id=benchmark_name,
+                    system_names=system_names,
+                    column_count=len(system_names) + 1,
+                    pair_blocks=pair_blocks,
+                )
             )
-            benchmark_blocks.append(block)
-            benchmark_language = BENCHMARK_META[benchmark_name]
-            name_info = f"{benchmark_name} ({benchmark_language})"
-            benchmark_section_info.append((benchmark_name, name_info))
+            benchmark_section_info.append((benchmark_name, f"{benchmark_name} ({BENCHMARK_META[benchmark_name]})"))
 
-        report = self.renderer.render(
+        return self.renderer.render(
             name=TemplateName.audio_report,
             jira_id=task_info.jira_id,
             jira_url=task_info.jira_url,
@@ -282,49 +313,46 @@ class Orchestrator:
             benchmark_section_info=benchmark_section_info,
         )
 
-        return report
-
     def _render_eval_report(
         self,
-        baseline_name: str,
-        candidate_name: str,
+        system_names: list[str],
         eval_artifacts: EvalArtifacts,
         uploaded_box_plots_info: UploadedBoxPlotsInfo,
         task_info: TaskInfo,
         expiration_info: ExpirationInfo,
         audio_report_url: Optional[str],
     ) -> str:
-        expiration_comment = f"This report will expire at {expiration_info.user_str}"
+        include_comparison = len(system_names) > 2
+        stat_headers = ["Metric", "Winner", "Alternative", "p-value"]
+        if include_comparison:
+            stat_headers.insert(1, "Comparison")
 
         configuration_block = self.renderer.render(
             name=TemplateName.eval_report_configuration,
-            baseline_name=baseline_name,
-            baseline_configuration=eval_artifacts.configuration.baseline,
-            candidate_name=candidate_name,
-            candidate_configuration=eval_artifacts.configuration.candidate,
+            configurations=eval_artifacts.configuration.systems,
         )
         header_block = self.renderer.render(
             name=TemplateName.eval_report_header,
-            baseline_name=baseline_name,
-            candidate_name=candidate_name,
-            expiration_comment=expiration_comment,
+            system_names=system_names,
+            expiration_comment=self._expiration_comment(expiration_info),
         )
         metrics_table = self.renderer.render(
             name=TemplateName.eval_report_table,
             title="Metrics (macro-average across benchmarks)",
-            headers=["Metric", baseline_name, candidate_name],
+            headers=["Metric", *system_names],
             rows=eval_artifacts.summary.metrics_table_row,
         )
         stat_tests_table = self.renderer.render(
             name=TemplateName.eval_report_table,
             title="Statistical Tests (pooled filewise across benchmarks)",
-            headers=["Metric", "Winner", "Alternative", "p-value"],
+            headers=stat_headers,
             rows=eval_artifacts.summary.stat_test_table_row,
         )
         stat_tests_analysis = self.renderer.render(
             name=TemplateName.eval_report_stat_analysis,
             winner=eval_artifacts.summary.stat_tests_analysis_info.winner,
             advantages=eval_artifacts.summary.stat_tests_analysis_info.advantages,
+            multiple_systems=include_comparison,
         )
         image_block = self.renderer.render(
             name=TemplateName.eval_report_image,
@@ -340,44 +368,45 @@ class Orchestrator:
         )
         benchmark_blocks, benchmark_section_info = [], []
 
-        for benchmark_name in sorted(eval_artifacts.benchmarks.keys()):
+        for benchmark_name in sorted(eval_artifacts.benchmarks):
+            result = eval_artifacts.benchmarks[benchmark_name]
             metrics_table = self.renderer.render(
                 name=TemplateName.eval_report_table,
                 title="Metrics",
-                headers=["Metric", baseline_name, candidate_name],
-                rows=eval_artifacts.benchmarks[benchmark_name].metrics_table_row,
+                headers=["Metric", *system_names],
+                rows=result.metrics_table_row,
             )
             stat_tests_table = self.renderer.render(
                 name=TemplateName.eval_report_table,
                 title="Statistical Tests",
-                headers=["Metric", "Winner", "Alternative", "p-value"],
-                rows=eval_artifacts.benchmarks[benchmark_name].stat_test_table_row,
+                headers=stat_headers,
+                rows=result.stat_test_table_row,
             )
             stat_tests_analysis = self.renderer.render(
                 name=TemplateName.eval_report_stat_analysis,
-                winner=eval_artifacts.benchmarks[benchmark_name].stat_tests_analysis_info.winner,
-                advantages=eval_artifacts.benchmarks[benchmark_name].stat_tests_analysis_info.advantages,
+                winner=result.stat_tests_analysis_info.winner,
+                advantages=result.stat_tests_analysis_info.advantages,
+                multiple_systems=include_comparison,
             )
             image_block = self.renderer.render(
                 name=TemplateName.eval_report_image,
                 image_url=uploaded_box_plots_info.benchmark_urls[benchmark_name],
             )
-            block = self.renderer.render(
-                name=TemplateName.eval_report_block,
-                is_summary=False,
-                title=benchmark_name,
-                section_id=benchmark_name,
-                metrics_table=metrics_table,
-                stat_tests_table=stat_tests_table,
-                stat_tests_analysis=stat_tests_analysis,
-                image_block=image_block,
+            benchmark_blocks.append(
+                self.renderer.render(
+                    name=TemplateName.eval_report_block,
+                    is_summary=False,
+                    title=benchmark_name,
+                    section_id=benchmark_name,
+                    metrics_table=metrics_table,
+                    stat_tests_table=stat_tests_table,
+                    stat_tests_analysis=stat_tests_analysis,
+                    image_block=image_block,
+                )
             )
-            benchmark_blocks.append(block)
-            benchmark_language = BENCHMARK_META[benchmark_name]
-            name_info = f"{benchmark_name} ({benchmark_language})"
-            benchmark_section_info.append((benchmark_name, name_info))
+            benchmark_section_info.append((benchmark_name, f"{benchmark_name} ({BENCHMARK_META[benchmark_name]})"))
 
-        report = self.renderer.render(
+        return self.renderer.render(
             name=TemplateName.eval_report,
             is_self_comparison=eval_artifacts.is_self_comparison,
             jira_id=task_info.jira_id,
@@ -388,126 +417,97 @@ class Orchestrator:
             summary_block=summary_block,
             benchmark_blocks=benchmark_blocks,
             benchmark_section_info=benchmark_section_info,
+            multiple_systems=include_comparison,
         )
-        return report
 
     def run(
         self,
         baseline_name: str,
-        candidate_name: str,
+        candidate_name: str | list[str],
         baseline_path: Path,
-        candidate_path: Path,
+        candidate_path: Path | list[Path],
         benchmarks: list[str],
         generate_audio_report: bool,
         audio_report_benchmarks: Optional[list[str]],
         samples_per_benchmark: int,
         task_id: str,
+        s3_prefix_override: Optional[str] = None,
     ) -> tuple[str, Optional[str]]:
-        """Generate evaluation reports, upload report artifacts to S3, and return report URLs.
-
-        This method performs the full end-to-end comparison workflow:
-        it loads evaluation buckets, prepares summary and benchmark-level artifacts,
-        uploads plots and optional audio samples to S3, renders the final HTML
-        reports, uploads them, and returns their presigned URLs.
-
-        Args:
-            baseline_name: Name of the baseline model used in the reports.
-            candidate_name: Name of the candidate model used in the reports.
-            baseline_path: Path to the baseline evaluation bucket root.
-            candidate_path: Path to the candidate evaluation bucket root.
-            benchmarks: Benchmark names to include in the evaluation report.
-            generate_audio_report: Whether to generate the audio comparison report.
-            audio_report_benchmarks: Benchmark names to include in the audio report.
-            samples_per_benchmark: Number of audio pairs to sample per benchmark.
-            task_id: Task identifier used for report metadata and Jira linking.
-
-        Returns:
-            Tuple containing the evaluation report URL and the optional audio report URL.
-
-        Raises:
-            ValueError: If input configuration is inconsistent, required benchmarks
-                are missing, or report generation inputs are invalid.
-            FileNotFoundError: If required bucket artifacts are missing from storage.
-            TypeError: If loaded metric files have unexpected types.
-        """
+        """Generate N-system reports, publish all artifacts, and return their locations."""
         benchmark_names = tuple(sorted(benchmarks, key=len, reverse=True))
-
-        audio_report: Optional[str] = None
-        audio_report_url: Optional[str] = None
-
-        bucket_baseline, bucket_candidate = self._load_buckets(
-            baseline_name=baseline_name,
-            candidate_name=candidate_name,
-            baseline_path=baseline_path,
-            candidate_path=candidate_path,
-            benchmark_names=benchmark_names,
+        candidate_names = self._normalize_candidates(candidate_name)
+        candidate_paths = self._normalize_candidates(candidate_path)
+        system_names = [baseline_name, *candidate_names]
+        buckets = self._load_buckets(
+            baseline_name,
+            candidate_names,
+            baseline_path,
+            candidate_paths,
+            benchmark_names,
             check_audio=generate_audio_report,
         )
 
         task_info = make_task_info(task_id)
         expiration_info = make_expiration_info(S3_LINK_EXPIRES_IN)
-        s3_prefix = generate_s3_prefix(baseline_path, candidate_path, task_info, expiration_info)
+        if self.local_output_dir is not None:
+            self.local_output_dir.mkdir(parents=True, exist_ok=True)
+            artifact_prefix = ""
+        else:
+            artifact_prefix = generate_s3_prefix(
+                baseline_path,
+                candidate_paths,
+                task_info,
+                expiration_info,
+                override=s3_prefix_override,
+            )
         box_plots_cfg = BoxPlotsConfig()
+        bucket_baseline, candidate_buckets = buckets[0], buckets[1:]
 
         self._log_info("\nPreparing evaluation artifacts...")
-        eval_artifacts = prepare_eval_artifacts(
-            bucket_baseline=bucket_baseline,
-            bucket_candidate=bucket_candidate,
-            box_plots_cfg=box_plots_cfg,
-        )
-        self._log_info("\nUploading images to S3:")
-        uploaded_box_plots_info = self._upload_boxplots(
-            eval_artifacts=eval_artifacts,
-            s3_prefix=s3_prefix,
-        )
+        eval_artifacts = prepare_eval_artifacts(bucket_baseline, candidate_buckets, box_plots_cfg)
+        destination = "local preview" if self.local_output_dir is not None else "S3"
+        self._log_info(f"\nPublishing images to {destination}:")
+        uploaded_box_plots_info = self._upload_boxplots(eval_artifacts, artifact_prefix)
 
+        audio_report_url = None
         if generate_audio_report:
             if audio_report_benchmarks is None:
                 raise ValueError("Audio report benchmarks must be provided when audio report is enabled.")
-
             audio_pairs = prepare_audio_pairs(
-                bucket_baseline=bucket_baseline,
-                bucket_candidate=bucket_candidate,
-                bucket_structure=self.bucket_structure,
-                used_benchmarks=audio_report_benchmarks,
-                samples_per_benchmark=samples_per_benchmark,
+                bucket_baseline,
+                candidate_buckets,
+                self.bucket_structure,
+                audio_report_benchmarks,
+                samples_per_benchmark,
             )
-            self._log_info("\nUploading audio files to S3:")
-            uploaded_audio_info = self._upload_audio(
-                used_benchmarks=audio_report_benchmarks,
-                audio_pairs=audio_pairs,
-                s3_prefix=s3_prefix,
-            )
+            self._log_info(f"\nPublishing audio files to {destination}:")
+            uploaded_audio_info = self._upload_audio(audio_report_benchmarks, audio_pairs, artifact_prefix)
             self._log_info("\nPreparing audio report...")
             audio_report = self._render_audio_report(
-                baseline_name=baseline_name,
-                candidate_name=candidate_name,
-                used_benchmarks=audio_report_benchmarks,
-                uploaded_audio_info=uploaded_audio_info,
-                task_info=task_info,
-                expiration_info=expiration_info,
+                system_names,
+                audio_report_benchmarks,
+                uploaded_audio_info,
+                task_info,
+                expiration_info,
             )
-            audio_report_url = self._upload_report(
-                report=audio_report,
-                s3_prefix=s3_prefix,
-                report_name="audio_report",
-            )
+            audio_report_url = self._upload_report(audio_report, artifact_prefix, "audio_report")
 
         self._log_info("\nPreparing evaluation report...")
         eval_report = self._render_eval_report(
-            baseline_name=bucket_baseline.name,
-            candidate_name=bucket_candidate.name,
-            eval_artifacts=eval_artifacts,
-            uploaded_box_plots_info=uploaded_box_plots_info,
-            task_info=task_info,
-            expiration_info=expiration_info,
-            audio_report_url=audio_report_url,
+            system_names,
+            eval_artifacts,
+            uploaded_box_plots_info,
+            task_info,
+            expiration_info,
+            audio_report_url,
         )
-        eval_report_url = self._upload_report(
-            report=eval_report,
-            s3_prefix=s3_prefix,
-            report_name="eval_report",
-        )
-        self._log_info(f"\nUploaded artifacts to bucket '{self.s3_client.cfg.bucket}' with prefix '{s3_prefix}'.")
-
+        eval_report_url = self._upload_report(eval_report, artifact_prefix, "eval_report")
+        if self.local_output_dir is not None:
+            self._log_info(f"\nWrote local preview to '{self.local_output_dir}'.")
+        else:
+            if self.s3_client is None:
+                raise RuntimeError("S3 client is not configured.")
+            self._log_info(
+                f"\nUploaded artifacts to bucket '{self.s3_client.cfg.bucket}' with prefix '{artifact_prefix}'."
+            )
         return eval_report_url, audio_report_url

--- a/scripts/tts_comparison_report/templates/audio_report.jinja
+++ b/scripts/tts_comparison_report/templates/audio_report.jinja
@@ -160,6 +160,7 @@
       box-shadow: var(--card-shadow);
       padding: 20px 24px;
       margin-bottom: 24px;
+      overflow-x: auto;
     }
 
     .model-header-row {

--- a/scripts/tts_comparison_report/templates/audio_report_block.jinja
+++ b/scripts/tts_comparison_report/templates/audio_report_block.jinja
@@ -1,15 +1,10 @@
 <h2 id="{{ section_id }}"> {{ title }} </h2>
 <div class="card">
-  <div class="model-header-row">
-    <div class="model-header">
-      Context
-    </div>
-    <div class="model-header">
-      {{ baseline_name }}
-    </div>
-    <div class="model-header">
-      {{ candidate_name }}
-    </div>
+  <div class="model-header-row" style="grid-template-columns: repeat({{ column_count }}, minmax(180px, 1fr));">
+    <div class="model-header">Context</div>
+    {% for system_name in system_names %}
+    <div class="model-header">{{ system_name }}</div>
+    {% endfor %}
   </div>
 
 {% for block in pair_blocks %}

--- a/scripts/tts_comparison_report/templates/audio_report_header.jinja
+++ b/scripts/tts_comparison_report/templates/audio_report_header.jinja
@@ -1,7 +1,12 @@
 <h1>Audio Comparison Report</h1>
 <p class="subtitle">
-  Comparing baseline <strong class="strong-muted">{{ baseline_name }}</strong>
-  against candidate <strong class="strong-muted">{{ candidate_name }}</strong>
+  {% if system_names|length == 2 %}
+  Comparing baseline <strong class="strong-muted">{{ system_names[0] }}</strong>
+  against candidate <strong class="strong-muted">{{ system_names[1] }}</strong>
+  {% else %}
+  Comparing baseline <strong class="strong-muted">{{ system_names[0] }}</strong>
+  against candidates <strong class="strong-muted">{{ system_names[1:]|join(", ") }}</strong>
+  {% endif %}
 </p>
 <p class="expiration_comment">
   {{ expiration_comment }}

--- a/scripts/tts_comparison_report/templates/audio_report_pair.jinja
+++ b/scripts/tts_comparison_report/templates/audio_report_pair.jinja
@@ -1,20 +1,17 @@
 <div class="audio-pair-card">
-  <div class="audio-pair-row">
+  <div class="audio-pair-row" style="grid-template-columns: repeat({{ system_urls|length + 1 }}, minmax(180px, 1fr));">
     <div class="audio-cell">
       <audio controls preload="metadata">
       <source src="{{ context_url }}" type="audio/wav">
       </audio>
     </div>
+    {% for system_url in system_urls.values() %}
     <div class="audio-cell">
       <audio controls preload="metadata">
-      <source src="{{ baseline_url }}" type="audio/wav">
+      <source src="{{ system_url }}" type="audio/wav">
       </audio>
     </div>
-    <div class="audio-cell">
-      <audio controls preload="metadata">
-      <source src="{{ candidate_url }}" type="audio/wav">
-      </audio>
-    </div>
+    {% endfor %}
   </div>
   <p class="pair-comment">
     Text: {{ text }}

--- a/scripts/tts_comparison_report/templates/eval_report.jinja
+++ b/scripts/tts_comparison_report/templates/eval_report.jinja
@@ -363,16 +363,15 @@
             </li>
 
             <li>
-              In statistical tests, <strong>less</strong> means the baseline tends 
-              to have smaller values than the candidate, <strong>greater</strong> means 
-              the baseline tends to have larger values than the candidate, and
-              <strong>two-sided</strong> means the alternative hypothesis is that 
-              the two distributions differ without specifying direction.
+              Statistical tests are run for every pair of systems. <strong>Less</strong> means the first
+              system in the comparison tends to have smaller values, <strong>greater</strong> means it tends
+              to have larger values, and <strong>two-sided</strong> means the distributions differ without
+              specifying direction.
             </li>
 
             <li>
-              In box plots, the statistically better model is 
-              <strong class="strong-highlighted">highlighted by color</strong>. 
+              In box plots, systems with the most statistically significant pairwise wins are
+              <strong class="strong-highlighted">highlighted by color</strong>.
               Mean values and approximate 95% confidence intervals are also shown.
             </li>
           </ul>

--- a/scripts/tts_comparison_report/templates/eval_report_configuration.jinja
+++ b/scripts/tts_comparison_report/templates/eval_report_configuration.jinja
@@ -1,11 +1,8 @@
 <div class="card">
+  {% for system_name, configuration in configurations.items() %}
   <div class="sub-card">
-    <h4>{{ baseline_name }}</h4>
-    <p><span class="config-text">{{ baseline_configuration }}</span></p>
+    <h4>{{ system_name }}</h4>
+    <p><span class="config-text">{{ configuration }}</span></p>
   </div>
-
-  <div class="sub-card">
-    <h4>{{ candidate_name }}</h4>
-    <p><span class="config-text">{{ candidate_configuration }}</span></p>
-  </div>
+  {% endfor %}
 </div>

--- a/scripts/tts_comparison_report/templates/eval_report_header.jinja
+++ b/scripts/tts_comparison_report/templates/eval_report_header.jinja
@@ -1,8 +1,13 @@
 <h1>TTS Evaluation Comparison Report</h1>
 
 <p class="subtitle">
-  Comparing baseline <strong>{{ baseline_name }}</strong>
-  against candidate <strong>{{ candidate_name }}</strong>
+  {% if system_names|length == 2 %}
+  Comparing baseline <strong>{{ system_names[0] }}</strong>
+  against candidate <strong>{{ system_names[1] }}</strong>
+  {% else %}
+  Comparing baseline <strong>{{ system_names[0] }}</strong>
+  against candidates <strong>{{ system_names[1:]|join(", ") }}</strong>
+  {% endif %}
 </p>
 
 <p class="expiration_comment">

--- a/scripts/tts_comparison_report/templates/eval_report_stat_analysis.jinja
+++ b/scripts/tts_comparison_report/templates/eval_report_stat_analysis.jinja
@@ -1,7 +1,12 @@
 <div class="sub-card">
   <h4>Analysis of Statistical Tests</h4>
-  {% if winner is none %}
+  {% if winner is none and multiple_systems %}
+    <p>No statistically significant pairwise difference was observed.</p>
+  {% elif winner is none %}
     <p>No statistically significant difference was observed between these two models.</p>
+  {% elif multiple_systems %}
+    <p><strong>{{ winner }}</strong> recorded the most significant pairwise wins.
+    Significant advantages: {{ advantages }}.</p>
   {% else %}
     <p><strong>{{ winner }}</strong> performs best. 
     Key statistically significant advantages: {{ advantages }}.</p>

--- a/scripts/tts_comparison_report/templates/eval_report_table.jinja
+++ b/scripts/tts_comparison_report/templates/eval_report_table.jinja
@@ -1,7 +1,7 @@
 <div class="sub-card">
   <h4>{{ title }}</h4>
   <div class="table-wrap">
-    <table>
+    <table style="min-width: {{ [headers|length * 180, 720]|max }}px;">
       <thead>
         <tr>
         {% for header in headers %}

--- a/tests/collections/tts/test_tts_comparison_report.py
+++ b/tests/collections/tts/test_tts_comparison_report.py
@@ -1,0 +1,405 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.tts_comparison_report.generate_report import _create_argparser
+from scripts.tts_comparison_report.reporting.components.audio_report import prepare_audio_pairs
+from scripts.tts_comparison_report.reporting.components.boxplots import BoxPlotsConfig
+from scripts.tts_comparison_report.reporting.components.eval_report import prepare_eval_artifacts
+from scripts.tts_comparison_report.reporting.components.metrics_table import prepare_benchmark_metrics_table_rows
+from scripts.tts_comparison_report.reporting.components.stat_tests import (
+    prepare_stat_tests_analysis_info,
+    run_stat_tests,
+)
+from scripts.tts_comparison_report.reporting.constants import DUMMY_TASK_ID, TEMPLATES_DIR
+from scripts.tts_comparison_report.reporting.helpers import generate_s3_prefix
+from scripts.tts_comparison_report.reporting.models import (
+    AudioPair,
+    BenchmarkData,
+    BucketData,
+    BucketStructure,
+    ExpirationInfo,
+    StatTestResult,
+    TaskInfo,
+    Winner,
+)
+from scripts.tts_comparison_report.reporting.orchestrator import Orchestrator
+from scripts.tts_comparison_report.reporting.renderer import Renderer, TemplateName
+from scripts.tts_comparison_report.reporting.storage import LocalStorage
+
+
+pytestmark = pytest.mark.unit
+
+
+def _parse_args(*candidate_args: str):
+    return _create_argparser().parse_args(
+        [
+            "--baseline_name",
+            "baseline",
+            "--baseline_path",
+            "/eval/baseline",
+            *candidate_args,
+            "--s3_endpoint",
+            "https://s3.example.com",
+            "--s3_bucket",
+            "reports",
+            "--s3_region",
+            "local",
+        ]
+    )
+
+
+def _make_bucket(name: str, path: str, metric_offset: float = 0.0) -> BucketData:
+    filewise_metrics = []
+
+    for index in range(4):
+        sample_name = f"predicted_audio_{index}"
+        filewise_metrics.append(
+            {
+                "pred_audio_filepath": f"/generated/{sample_name}.wav",
+                "gt_text": f"sample {index}",
+                "gt_audio_filepath": f"/reference/gt_{index}.wav",
+                "context_audio_filepath": f"/reference/context_{index}.wav",
+                "cer": 0.01 * index + metric_offset,
+                "utmosv2": 4.0 - metric_offset,
+                "pred_context_ssim": 0.8 - metric_offset,
+            }
+        )
+
+    metrics = {
+        "wer_cumulative": 0.10 + metric_offset,
+        "cer_cumulative": 0.05 + metric_offset,
+        "wer_filewise_avg": 0.11 + metric_offset,
+        "cer_filewise_avg": 0.06 + metric_offset,
+        "utmosv2_avg": 4.0 - metric_offset,
+        "ssim_pred_gt_avg": 0.75 - metric_offset,
+        "ssim_pred_context_avg": 0.80 - metric_offset,
+        "total_gen_audio_seconds": 12.0,
+    }
+    benchmark = BenchmarkData(
+        name="libritts",
+        metrics=metrics,
+        filewise_metrics=filewise_metrics,
+        generated_audio_paths={
+            f"predicted_audio_{index}": Path(f"/{name}/predicted_audio_{index}.wav") for index in range(4)
+        },
+        context_audio_paths={
+            f"context_audio_{index}": Path(f"/reference/context_audio_{index}.wav") for index in range(4)
+        },
+    )
+    return BucketData(
+        name=name,
+        path=Path(path),
+        configuration_str=f"{name}-config",
+        benchmarks={"libritts": benchmark},
+    )
+
+
+def test_candidate_flags_remain_backward_compatible():
+    args = _parse_args("--candidate_name", "candidate", "--candidate_path", "/eval/candidate")
+
+    assert args.candidate_name == ["candidate"]
+    assert args.candidate_path == ["/eval/candidate"]
+
+
+def test_candidate_flags_are_repeatable_for_multiple_systems():
+    args = _parse_args(
+        "--candidate_name",
+        "candidate-a",
+        "--candidate_path",
+        "/eval/candidate-a",
+        "--candidate_name",
+        "candidate-b",
+        "--candidate_path",
+        "/eval/candidate-b",
+    )
+
+    assert args.candidate_name == ["candidate-a", "candidate-b"]
+    assert args.candidate_path == ["/eval/candidate-a", "/eval/candidate-b"]
+
+
+def test_metrics_table_contains_every_system():
+    baseline = _make_bucket("baseline", "/eval/baseline", 0.0)
+    candidate_a = _make_bucket("candidate-a", "/eval/candidate-a", 0.01)
+    candidate_b = _make_bucket("candidate-b", "/eval/candidate-b", -0.01)
+
+    rows = prepare_benchmark_metrics_table_rows("libritts", baseline, [candidate_a, candidate_b])
+
+    assert all(len(row) == 4 for row in rows)
+    cer_row = next(row for row in rows if row[0] == "CER (cumulative)")
+    assert cer_row == ["CER (cumulative)", "5.0%", "6.0%", "<strong>4.0%</strong>"]
+
+
+def test_statistics_cover_all_system_pairs():
+    buckets = [
+        _make_bucket("baseline", "/eval/baseline", 0.0),
+        _make_bucket("candidate-a", "/eval/candidate-a", 0.01),
+        _make_bucket("candidate-b", "/eval/candidate-b", -0.01),
+    ]
+
+    results = run_stat_tests(buckets[0], buckets[1:])
+
+    comparisons = {(result.baseline_name, result.candidate_name) for result in results}
+    assert comparisons == {
+        ("baseline", "candidate-a"),
+        ("baseline", "candidate-b"),
+        ("candidate-a", "candidate-b"),
+    }
+
+
+def test_audio_samples_contain_every_system():
+    buckets = [
+        _make_bucket("baseline", "/eval/baseline", 0.0),
+        _make_bucket("candidate-a", "/eval/candidate-a", 0.01),
+        _make_bucket("candidate-b", "/eval/candidate-b", -0.01),
+    ]
+
+    pairs = prepare_audio_pairs(
+        bucket_baseline=buckets[0],
+        bucket_candidate=buckets[1:],
+        bucket_structure=BucketStructure(),
+        used_benchmarks=["libritts"],
+        samples_per_benchmark=2,
+    )
+
+    assert len(pairs["libritts"]) == 2
+    assert all(list(pair.system_paths) == ["baseline", "candidate-a", "candidate-b"] for pair in pairs["libritts"])
+
+
+def test_eval_artifacts_and_audio_template_render_every_system():
+    buckets = [
+        _make_bucket("baseline", "/eval/baseline", 0.0),
+        _make_bucket("candidate-a", "/eval/candidate-a", 0.01),
+        _make_bucket("candidate-b", "/eval/candidate-b", -0.01),
+    ]
+
+    artifacts = prepare_eval_artifacts(buckets[0], buckets[1:], BoxPlotsConfig())
+
+    assert list(artifacts.configuration.systems) == ["baseline", "candidate-a", "candidate-b"]
+    assert all(len(row) == 5 for row in artifacts.summary.stat_test_table_row)
+    assert artifacts.summary.box_plots.getbuffer().nbytes > 0
+
+    renderer = Renderer(TEMPLATES_DIR)
+    rendered_pair = renderer.render(
+        TemplateName.audio_report_pair,
+        context_url="context.wav",
+        system_urls={"baseline": "baseline.wav", "candidate-a": "a.wav", "candidate-b": "b.wav"},
+        text="hello",
+    )
+    assert rendered_pair.count("<audio") == 4
+
+
+def test_two_system_artifacts_keep_original_table_shapes():
+    baseline = _make_bucket("baseline", "/eval/baseline", 0.0)
+    candidate = _make_bucket("candidate", "/eval/candidate", 0.01)
+
+    artifacts = prepare_eval_artifacts(baseline, candidate, BoxPlotsConfig())
+
+    assert all(len(row) == 3 for row in artifacts.summary.metrics_table_row)
+    assert all(len(row) == 4 for row in artifacts.summary.stat_test_table_row)
+
+
+def test_two_system_metric_ties_keep_original_baseline_highlight():
+    baseline = _make_bucket("baseline", "/eval/baseline", 0.0)
+    candidate = _make_bucket("candidate", "/eval/candidate", 0.0)
+
+    rows = prepare_benchmark_metrics_table_rows("libritts", baseline, candidate)
+
+    cer_row = next(row for row in rows if row[0] == "CER (cumulative)")
+    assert cer_row == ["CER (cumulative)", "<strong>5.0%</strong>", "5.0%"]
+
+
+def test_two_system_stat_summary_keeps_original_tie_breaking():
+    results = [
+        StatTestResult("CER", Winner.baseline, "less", 0.01, "baseline", "candidate"),
+        StatTestResult("UTMOS v2", Winner.candidate, "greater", 0.01, "baseline", "candidate"),
+    ]
+
+    analysis = prepare_stat_tests_analysis_info("baseline", "candidate", results)
+
+    assert analysis.winner == "baseline"
+    assert analysis.advantages == "CER"
+
+
+def test_two_system_audio_artifact_names_remain_backward_compatible(tmp_path: Path, monkeypatch):
+    orchestrator = Orchestrator(
+        bucket_structure=BucketStructure(),
+        storage=LocalStorage(),
+        s3_client=None,
+        renderer=Renderer(TEMPLATES_DIR),
+        local_output_dir=tmp_path,
+    )
+    uploaded_keys = []
+
+    def record_upload(_path: Path, key: str) -> str:
+        uploaded_keys.append(key)
+        return key
+
+    monkeypatch.setattr(orchestrator, "_upload_audio_file", record_upload)
+    pair = AudioPair(
+        context_path=Path("/context.wav"),
+        baseline_path=Path("/baseline.wav"),
+        candidate_path=Path("/candidate.wav"),
+        text="sample",
+        system_paths={
+            "baseline": Path("/baseline.wav"),
+            "candidate": Path("/candidate.wav"),
+        },
+    )
+
+    orchestrator._upload_audio(["libritts"], {"libritts": [pair]}, "report-prefix")
+
+    assert uploaded_keys == [
+        "report-prefix/audio/context_libritts_0.wav",
+        "report-prefix/audio/baseline_libritts_0.wav",
+        "report-prefix/audio/candidate_libritts_0.wav",
+    ]
+
+
+def test_parser_accepts_local_output_without_s3_arguments():
+    args = _create_argparser().parse_args(
+        [
+            "--baseline_name",
+            "baseline",
+            "--baseline_path",
+            "/eval/baseline",
+            "--candidate_name",
+            "candidate",
+            "--candidate_path",
+            "/eval/candidate",
+            "--local_output_dir",
+            "/tmp/report-preview",
+        ]
+    )
+
+    assert args.local_output_dir == "/tmp/report-preview"
+    assert args.s3_endpoint is None
+    assert args.s3_bucket is None
+    assert args.s3_region is None
+
+
+def test_s3_prefix_override_replaces_generated_directory_name():
+    task_info = TaskInfo(task_id="NMP-I-123", jira_id="NMP-I-123", jira_url="https://jira/NMP-I-123")
+    expiration_info = ExpirationInfo(timestamp=1, path_str="2027-01-01T00-00-00Z", user_str="2027-01-01")
+
+    default_prefix = generate_s3_prefix(
+        Path("/eval/baseline"),
+        Path("/eval/candidate"),
+        task_info,
+        expiration_info,
+    )
+    assert default_prefix == "NMP-I-123-baseline_vs_candidate-2027-01-01T00-00-00Z"
+
+    prefix = generate_s3_prefix(
+        Path("/eval/very-long-baseline-name"),
+        [Path("/eval/candidate-a"), Path("/eval/candidate-b"), Path("/eval/candidate-c")],
+        task_info,
+        expiration_info,
+        override="/codec-reports/four-way/",
+    )
+
+    assert prefix == "codec-reports/four-way"
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        generate_s3_prefix(Path("/a"), Path("/b"), task_info, expiration_info, override="///")
+
+    with pytest.raises(ValueError, match="relative path"):
+        generate_s3_prefix(Path("/a"), Path("/b"), task_info, expiration_info, override="reports/../run")
+
+
+def _write_evaluation_bucket(root: Path, name: str, metric_offset: float) -> None:
+    benchmark_dir = root / "results" / f"{name}_libritts"
+    audio_dir = benchmark_dir / "audio" / "repeat_0"
+    audio_dir.mkdir(parents=True)
+
+    metrics = {
+        "wer_cumulative": 0.10 + metric_offset,
+        "cer_cumulative": 0.05 + metric_offset,
+        "wer_filewise_avg": 0.11 + metric_offset,
+        "cer_filewise_avg": 0.06 + metric_offset,
+        "utmosv2_avg": 4.0 - metric_offset,
+        "ssim_pred_gt_avg": 0.75 - metric_offset,
+        "ssim_pred_context_avg": 0.80 - metric_offset,
+        "total_gen_audio_seconds": 12.0,
+    }
+    filewise_metrics = []
+    for index in range(4):
+        filewise_metrics.append(
+            {
+                "pred_audio_filepath": f"/generated/predicted_audio_{index}.wav",
+                "gt_text": f"sample {index}",
+                "gt_audio_filepath": f"/reference/gt_{index}.wav",
+                "context_audio_filepath": f"/reference/context_{index}.wav",
+                "cer": 0.01 * index + metric_offset,
+                "utmosv2": 4.0 - 0.01 * index - metric_offset,
+                "pred_context_ssim": 0.8 - 0.01 * index - metric_offset,
+            }
+        )
+        (audio_dir / f"predicted_audio_{index}.wav").write_bytes(b"RIFF-generated-" + name.encode())
+        (audio_dir / f"context_audio_{index}.wav").write_bytes(b"RIFF-context")
+
+    (benchmark_dir / "libritts_metrics_0.json").write_text(json.dumps(metrics), encoding="utf-8")
+    (benchmark_dir / "libritts_filewise_metrics_0.json").write_text(json.dumps(filewise_metrics), encoding="utf-8")
+
+
+def test_local_preview_writes_complete_report_with_relative_assets(tmp_path: Path):
+    systems = [
+        ("baseline", 0.0),
+        ("candidate-a", 0.01),
+        ("candidate-b", -0.01),
+    ]
+    bucket_paths = []
+    for name, offset in systems:
+        bucket_path = tmp_path / name
+        _write_evaluation_bucket(bucket_path, name, offset)
+        bucket_paths.append(bucket_path)
+
+    output_dir = tmp_path / "preview"
+    orchestrator = Orchestrator(
+        bucket_structure=BucketStructure(),
+        storage=LocalStorage(),
+        s3_client=None,
+        renderer=Renderer(TEMPLATES_DIR),
+        local_output_dir=output_dir,
+    )
+    eval_report_path, audio_report_path = orchestrator.run(
+        baseline_name="baseline",
+        candidate_name=["candidate-a", "candidate-b"],
+        baseline_path=bucket_paths[0],
+        candidate_path=bucket_paths[1:],
+        benchmarks=["libritts"],
+        generate_audio_report=True,
+        audio_report_benchmarks=["libritts"],
+        samples_per_benchmark=2,
+        task_id=DUMMY_TASK_ID,
+    )
+
+    assert eval_report_path == "eval_report.html"
+    assert audio_report_path == "audio_report.html"
+    assert (output_dir / eval_report_path).is_file()
+    assert (output_dir / audio_report_path).is_file()
+    assert (output_dir / "images" / "box_plot_summary.png").is_file()
+    assert (output_dir / "images" / "box_plot_libritts.png").is_file()
+    assert len(list((output_dir / "audio").glob("*.wav"))) == 8
+
+    eval_html = (output_dir / eval_report_path).read_text(encoding="utf-8")
+    audio_html = (output_dir / audio_report_path).read_text(encoding="utf-8")
+    assert 'href="audio_report.html"' in eval_html
+    assert 'src="images/box_plot_summary.png"' in eval_html
+    assert 'src="audio/context_libritts_' in audio_html
+    assert audio_html.count("<audio") == 8
+    assert "Local preview" in eval_html


### PR DESCRIPTION
## What changed

- allow `--candidate_name` and `--candidate_path` to be repeated for N-system comparisons
- render metrics, configurations, box plots, and matched audio for every system
- run the existing Mann–Whitney statistical procedure for every unordered system pair
- preserve the original two-system CLI, statistical summary behavior, generated prefix, and audio object names
- add optional S3 prefix override and complete local report output

## Why

The report generator was limited to one baseline and one candidate, which prevented side-by-side codec comparisons involving three or more systems.

## Validation

- `conda run -n nemotts pytest -q tests/collections/tts/test_tts_comparison_report.py` (13 passed)
- Black check
- isort check
- Python bytecode compilation
- `git diff --check`
