### PR TITLE
Fix multi-GPU deadlock in RNN-T validation (fuse_loss_wer)

### DIFF
--- a/nemo/collections/asr/modules/rnnt.py
+++ b/nemo/collections/asr/modules/rnnt.py
@@ -1595,10 +1595,13 @@ class RNNTJoint(rnnt_abstract.AbstractRNNTJoint, Exportable, AdapterModuleMixin)
                     sub_enc = sub_enc.detach()
                     sub_transcripts = sub_transcripts.detach()
 
-                    # Update WER on each process without syncing
-                    if self.training:
-                        original_sync = self.wer._to_sync
-                        self.wer._to_sync = False
+                    # Suppress per-sub-batch metric sync so that compute() does
+                    # not issue a collective.  Without this, ranks that receive
+                    # different local batch sizes iterate a different number of
+                    # times, leading to a collective count mismatch and a
+                    # deadlock during validation.  See #16003.
+                    original_sync = self.wer._to_sync
+                    self.wer._to_sync = False
 
                     self.wer.update(
                         predictions=sub_enc,
@@ -1609,12 +1612,10 @@ class RNNTJoint(rnnt_abstract.AbstractRNNTJoint, Exportable, AdapterModuleMixin)
 
                     hyp = self.wer.get_hypotheses() if keep_hypotheses else []
 
-                    # Sync and all_reduce on all processes, compute global WER
                     wer, wer_num, wer_denom = self.wer.compute()
                     self.wer.reset()
 
-                    if self.training:
-                        self.wer._to_sync = original_sync
+                    self.wer._to_sync = original_sync
 
                     wers.append(wer)
                     wer_nums.append(wer_num)
@@ -2147,7 +2148,10 @@ class SampledRNNTJoint(RNNTJoint):
                 sub_enc = sub_enc.detach()
                 sub_transcripts = sub_transcripts.detach()
 
-                # Update WER on each process without syncing
+                # Suppress per-sub-batch metric sync — see RNNTJoint and #16003.
+                original_sync = self.wer._to_sync
+                self.wer._to_sync = False
+
                 self.wer.update(
                     predictions=sub_enc,
                     predictions_lengths=sub_enc_lens,
@@ -2155,9 +2159,10 @@ class SampledRNNTJoint(RNNTJoint):
                     targets_lengths=sub_transcript_lens,
                 )
 
-                # Sync and all_reduce on all processes, compute global WER
                 wer, wer_num, wer_denom = self.wer.compute()
                 self.wer.reset()
+
+                self.wer._to_sync = original_sync
 
                 wers.append(wer)
                 wer_nums.append(wer_num)


### PR DESCRIPTION
Fixes #16003.

When `fuse_loss_wer=true`, validation on multiple GPUs with different local batch sizes deadlocks because `RNNTJoint.forward` triggers `wer.compute()` for each sub-batch.

This fixes it by removing the `if self.training:` guard around the sync suppression in `RNNTJoint.forward`. This makes sure `compute()` doesn't issue collectives per-sub-batch during validation either. The metric reduction will still happen correctly at the epoch level, exactly like it does during training.

Also added the same missing sync suppression to `SampledRNNTJoint.forward`.