### PR TITLE
fix: report manifest format mismatch instead of failing in the wrong parser

### DIFF
--- a/nemo/collections/common/data/lhotse/cutset.py
+++ b/nemo/collections/common/data/lhotse/cutset.py
@@ -14,6 +14,7 @@
 """Lhotse CutSet utilities and Parquet manifest support for NeMo."""
 
 import io
+import json
 import logging
 import random
 import re
@@ -31,7 +32,7 @@ from lhotse import CutSet, Features, MonoCut, Recording, SupervisionSegment
 from lhotse.array import Array, TemporalArray
 from lhotse.cut import Cut, MixedCut, PaddingCut
 from lhotse.lazy import LazyIteratorChain
-from lhotse.serialization import load_yaml
+from lhotse.serialization import load_yaml, open_best
 from lhotse.utils import fastcopy
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
@@ -1605,6 +1606,78 @@ def mux(
     return cuts
 
 
+# Every record of a NeMo non-tarred manifest carries an ``audio_filepath`` field, and Lhotse
+# manifests never use that field, so a single record is enough to tell the two formats apart.
+_NEMO_MANIFEST_FIELD = "audio_filepath"
+
+# Upper bound on how much of a manifest we read to detect its format. NeMo and Lhotse JSON Lines
+# records are small, so this is generous, and it keeps us from loading a huge single-line manifest.
+_MANIFEST_SNIFF_BYTES = 65536
+
+
+def _sniff_manifest_format(path: str) -> Union[str, None]:
+    """
+    Detect whether ``path`` holds a NeMo or a Lhotse manifest by looking at its first record.
+
+    Returns ``"nemo"``, ``"lhotse"``, or ``None`` when the format cannot be determined cheaply,
+    e.g. the path is unreadable, is a shard pattern, is empty, or does not hold JSON at all.
+    Callers must treat ``None`` as "no opinion" and keep their existing behaviour.
+    """
+    try:
+        with open_best(path, "r") as f:
+            head = f.read(_MANIFEST_SNIFF_BYTES)
+    except Exception:
+        return None
+    if not isinstance(head, str):
+        return None
+    truncated = len(head) >= _MANIFEST_SNIFF_BYTES
+    head = head.lstrip()
+    if not head:
+        return None
+    if head.startswith("["):
+        # Only Lhotse manifests are serialized as a JSON array. NeMo manifests are always JSON Lines.
+        return "lhotse"
+    first_line, newline_found, _ = head.partition("\n")
+    if not newline_found and truncated:
+        # The first record is longer than the sniffing window, so we cannot parse it.
+        return None
+    try:
+        record = json.loads(first_line)
+    except ValueError:
+        return None
+    if not isinstance(record, dict):
+        return None
+    return "nemo" if _NEMO_MANIFEST_FIELD in record else "lhotse"
+
+
+def _check_manifest_format(path: str, expected: str) -> None:
+    """
+    Raise an actionable error when ``path``'s extension and its contents disagree on the manifest format.
+
+    NeMo and Lhotse manifests are told apart by extension alone, so a NeMo manifest saved as
+    ``.jsonl`` (or a Lhotse manifest saved as ``.json``) is handed to the wrong parser and fails
+    deep inside it with an error that says nothing about the extension. See issue #14287.
+    """
+    detected = _sniff_manifest_format(path)
+    if detected is None or detected == expected:
+        return
+    convention = (
+        "NeMo and Lhotse manifests are told apart by their extension: use '.json' for NeMo "
+        "manifests and '.jsonl' or '.jsonl.gz' for Lhotse manifests."
+    )
+    if detected == "nemo":
+        raise ValueError(
+            f"Cannot read '{path}' as a Lhotse manifest: its extension says Lhotse, but its first record has an "
+            f"'{_NEMO_MANIFEST_FIELD}' field, which makes it a NeMo manifest. {convention} Rename the file so that "
+            f"it ends with '.json', or pass it as 'manifest_filepath' instead of 'cuts_path'."
+        )
+    raise ValueError(
+        f"Cannot read '{path}' as a NeMo manifest: its extension says NeMo, but its contents are a Lhotse manifest. "
+        f"{convention} Rename the file so that it ends with '.jsonl', or pass it as 'cuts_path' instead of "
+        f"'manifest_filepath'."
+    )
+
+
 def guess_parse_cutset(inp: Union[str, dict, omegaconf.DictConfig]) -> CutSet:
     """
     Utility function that supports opening a CutSet from:
@@ -1615,6 +1688,10 @@ def guess_parse_cutset(inp: Union[str, dict, omegaconf.DictConfig]) -> CutSet:
         :class:`nemo.collections.common.data.lhotse.dataloader.LhotseDataLoadingConfig`
 
     It's intended to be used in a generic context where we are not sure which way the user will specify the inputs.
+
+    String inputs are routed by extension. When the extension and the file contents disagree on the
+    manifest format, a :class:`ValueError` naming the extension convention is raised instead of
+    letting the wrong parser fail with an unrelated message.
     """
     from nemo.collections.common.data.lhotse.dataloader import make_structured_with_schema_warnings
 
@@ -1633,9 +1710,11 @@ def guess_parse_cutset(inp: Union[str, dict, omegaconf.DictConfig]) -> CutSet:
             config = make_structured_with_schema_warnings(OmegaConf.from_dotlist([f"input_cfg={inp}"]))
         elif inp.endswith(".jsonl") or inp.endswith(".jsonl.gz"):
             # Path to a Lhotse non-tarred manifest
+            _check_manifest_format(inp, expected="lhotse")
             config = make_structured_with_schema_warnings(OmegaConf.from_dotlist([f"cuts_path={inp}"]))
         else:
             # Assume anything else is a NeMo non-tarred manifest
+            _check_manifest_format(inp, expected="nemo")
             config = make_structured_with_schema_warnings(OmegaConf.from_dotlist([f"manifest_filepath={inp}"]))
         cuts, _ = read_cutset_from_config(config)
         return cuts

--- a/tests/collections/common/test_lhotse_dataloading.py
+++ b/tests/collections/common/test_lhotse_dataloading.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import gzip
+import json
 from collections import Counter
 from io import BytesIO
 from itertools import islice
@@ -31,6 +33,11 @@ from lhotse.testing.random import deterministic_rng
 from omegaconf import OmegaConf
 
 from nemo.collections.common.data.lhotse import get_lhotse_dataloader_from_config
+from nemo.collections.common.data.lhotse.cutset import (
+    _MANIFEST_SNIFF_BYTES,
+    _sniff_manifest_format,
+    guess_parse_cutset,
+)
 from nemo.collections.common.data.lhotse.text_adapters import SourceTargetTextExample, TextExample
 from nemo.collections.common.tokenizers.sentencepiece_tokenizer import SentencePieceTokenizer, create_spt_model
 from nemo.utils.dependency import is_module_available
@@ -3238,3 +3245,66 @@ def test_dataloader_reweight_temperature_mixed_leaf_and_group(
     nested_total = dataset_counts["N1"] + dataset_counts["N2"]
     assert dataset_counts["N1"] / nested_total == pytest.approx(0.5, abs=0.15)
     assert dataset_counts["N2"] / nested_total == pytest.approx(0.5, abs=0.15)
+
+
+class TestGuessParseCutsetManifestFormat:
+    """
+    ``guess_parse_cutset`` routes string inputs by extension: '.json' means a NeMo manifest and
+    '.jsonl' / '.jsonl.gz' mean a Lhotse manifest. When the extension and the contents disagree,
+    the input used to reach the wrong parser and fail with a message that never mentioned the
+    extension, e.g. "SupervisionSegment.__init__() got an unexpected keyword argument
+    'audio_filepath'" for a NeMo manifest named '.jsonl'. See issue #14287.
+    """
+
+    def test_reads_manifests_whose_extension_matches_their_contents(self, nemo_manifest_path: Path, cutset_path: Path):
+        assert len(list(guess_parse_cutset(str(nemo_manifest_path)))) == 10
+        assert len(list(guess_parse_cutset(str(cutset_path)))) == 10
+
+    @pytest.mark.parametrize("extension", [".jsonl", ".jsonl.gz"])
+    def test_rejects_nemo_manifest_with_lhotse_extension(
+        self, tmp_path: Path, nemo_manifest_path: Path, extension: str
+    ):
+        mislabeled = tmp_path / f"input_manifest{extension}"
+        payload = nemo_manifest_path.read_bytes()
+        if extension.endswith(".gz"):
+            payload = gzip.compress(payload)
+        mislabeled.write_bytes(payload)
+
+        with pytest.raises(ValueError, match="audio_filepath"):
+            guess_parse_cutset(str(mislabeled))
+
+    def test_rejects_lhotse_manifest_with_nemo_extension(self, tmp_path: Path, cutset_path: Path):
+        mislabeled = tmp_path / "cuts.json"
+        CutSet.from_file(cutset_path).to_file(mislabeled)
+
+        with pytest.raises(ValueError, match="contents are a Lhotse manifest"):
+            guess_parse_cutset(str(mislabeled))
+
+    def test_sniffing_detects_both_formats(self, nemo_manifest_path: Path, cutset_path: Path):
+        assert _sniff_manifest_format(str(nemo_manifest_path)) == "nemo"
+        assert _sniff_manifest_format(str(cutset_path)) == "lhotse"
+
+    @pytest.mark.parametrize(
+        "name,contents",
+        [
+            ("empty.jsonl", ""),
+            ("blank.jsonl", "\n\n"),
+            ("not_json.jsonl", "this is not json at all\n"),
+            ("scalar.jsonl", "42\n"),
+        ],
+    )
+    def test_sniffing_is_inconclusive_for_unparseable_manifests(self, tmp_path: Path, name: str, contents: str):
+        """An unrecognizable manifest must yield no opinion so that the existing behaviour is kept."""
+        path = tmp_path / name
+        path.write_text(contents)
+        assert _sniff_manifest_format(str(path)) is None
+
+    def test_sniffing_is_inconclusive_for_missing_and_templated_paths(self, tmp_path: Path):
+        assert _sniff_manifest_format(str(tmp_path / "does_not_exist.jsonl")) is None
+        assert _sniff_manifest_format(str(tmp_path / "shard_{0..3}.jsonl")) is None
+
+    def test_sniffing_is_inconclusive_when_first_record_exceeds_the_window(self, tmp_path: Path):
+        """A single record larger than the sniffing window cannot be parsed, so we must not guess."""
+        path = tmp_path / "huge_record.jsonl"
+        path.write_text(json.dumps({"audio_filepath": "a.wav", "pad": "x" * (2 * _MANIFEST_SNIFF_BYTES)}))
+        assert _sniff_manifest_format(str(path)) is None


### PR DESCRIPTION
# What does this PR do?

`guess_parse_cutset` routes a string input by extension: `.json` means a NeMo manifest and `.jsonl` or `.jsonl.gz` means a Lhotse manifest. Nothing checked that the file contents agreed with the extension, so a mislabeled manifest was handed to the wrong parser and failed deep inside it with an error that never mentioned the extension.

That is issue #14287. A NeMo manifest named `input_manifest.jsonl` reaches the Lhotse parser, which treats each record as a Lhotse object and dies with:

```
TypeError: SupervisionSegment.__init__() got an unexpected keyword argument 'audio_filepath'
```

Two people hit this independently on `examples/speechlm2/salm_generate.py` and neither could tell from the message that the filename was the problem. The mirror case has the same shape: a Lhotse manifest named `cuts.json` reaches the NeMo JSON Lines parser and dies with a bare `JSONDecodeError: Expecting value: line 2 column 1`.

This PR detects the format from the manifest's first record and raises a `ValueError` that names the convention and the fix, for both directions.

# Approach

Every record of a NeMo non-tarred manifest carries an `audio_filepath` field and Lhotse records never do, so one record is enough to tell the formats apart. A leading `[` means a JSON array, which only Lhotse uses. `_sniff_manifest_format` applies those two rules and `_check_manifest_format` raises when the result contradicts the extension.

Three properties keep this safe on the paths that already work:

Detection reads at most 64 KiB, so a large manifest serialized as a single line is not pulled into memory. A record longer than that window yields no opinion rather than a guess.

Detection returns `None`, meaning no opinion, for anything it cannot read or parse. Missing paths, shard patterns such as `shard_{0..3}.jsonl`, remote URIs, empty files and non-JSON files all fall into this bucket, and the caller keeps its existing behaviour untouched.

`open_best` is used for reading, so gzipped and remote manifests are sniffed the same way as plain local ones.

The check runs only in `guess_parse_cutset`, where the extension convention is applied. Configs that name `manifest_filepath` or `cuts_path` explicitly are unchanged, since there the user has already stated the format.

# Verification

Verified on CPU against `upstream/main` at `40ace43`.

Reverting only `cutset.py` to the base revision reproduces both reported failures, and restoring the fix turns both into the new actionable error:

```
FAIL-BEFORE  NeMo manifest named .jsonl   TypeError: SupervisionSegment.__init__() got an unexpected keyword argument 'audio_filepath'
FAIL-BEFORE  Lhotse manifest named .json  JSONDecodeError: Expecting value: line 2 column 1 (char 2)
PASS-AFTER   NeMo manifest named .jsonl   ValueError: Cannot read '...' as a Lhotse manifest: ... 'audio_filepath' field, which makes it a NeMo manifest ...
PASS-AFTER   Lhotse manifest named .json  ValueError: Cannot read '...' as a NeMo manifest: ... its contents are a Lhotse manifest ...
```

New tests in `TestGuessParseCutsetManifestFormat` cover both mismatch directions, `.jsonl` and `.jsonl.gz` for the mislabeled NeMo case, the three correctly named happy paths, and the inconclusive inputs that must keep the old behaviour. They fail at the base revision and pass with the fix, 11 passed.

The surrounding suite is unaffected:

```
pytest tests/collections/common/test_lhotse_dataloading.py -q -m "not pleasefixme" --cpu
78 passed, 1 skipped
```

`isort` 5.13.2 and `black` 24.10.0 at the versions pinned in `.pre-commit-config.yaml` report both changed files clean. `flake8 --config=.flake8` and `--config=.flake8.speech` report nothing new. The three findings that remain in the test file are present at the base revision and are untouched by this change.

# Issues

Fixes #14287

# PR Type

- [x] Bugfix
- [ ] New Feature
- [ ] Documentation
- [ ] Test

# Additional notes

Commit is signed off per CONTRIBUTING. As a community fork PR, `copy-pr-bot` will not start CI on its own, so a maintainer comment of `/ok to test <sha>` is needed to run it.
