### PR TITLE
feat(speechlm2): add optional MTP training modes

### DIFF
--- a/examples/speechlm2/conf/salm_automodel.yaml
+++ b/examples/speechlm2/conf/salm_automodel.yaml
@@ -32,6 +32,7 @@ model:
   # prevent_freeze_params when the broad LLM freeze pattern above is active.
   mtp:
     enabled: false
+    training_mode: joint  # joint preserves the recipe freeze policy; head_only trains only llm.mtp
     num_nextn_predict_layers: 1
     hybrid_override_pattern: "*"
     loss_scaling_factor: 0.1

--- a/examples/speechlm2/conf/salm_automodel.yaml
+++ b/examples/speechlm2/conf/salm_automodel.yaml
@@ -28,13 +28,18 @@ model:
   # Multi-Token Prediction is opt-in. Some LLM checkpoints include native MTP
   # weights; they are restored when enabled and skipped entirely when disabled.
   # For a base checkpoint without MTP weights, enabling this block initializes a
-  # fresh head after loading the backbone. Add "^llm\\.mtp\\..+$" to
+  # fresh head before Automodel parallelizes and loads the backbone weights. Add
+  # "^llm\\.mtp\\..+$" to
   # prevent_freeze_params when the broad LLM freeze pattern above is active.
   mtp:
     enabled: false
     training_mode: joint  # joint preserves the recipe freeze policy; head_only trains only llm.mtp
     num_nextn_predict_layers: 1
     hybrid_override_pattern: "*"
+    # Preserve a checkpoint-native MTP architecture by default. Set true to
+    # construct a fresh recipe-defined head instead; all checkpoint MTP tensors
+    # are skipped so they cannot partially initialize the replacement head.
+    replace_existing_head: false
     loss_scaling_factor: 0.1
     use_repeated_layer: false
 

--- a/examples/speechlm2/conf/salm_automodel.yaml
+++ b/examples/speechlm2/conf/salm_automodel.yaml
@@ -25,6 +25,18 @@ model:
     - "^perception\\.encoder(_multilayer\\.encoder)?\\..+$"
   prevent_freeze_params: []  # Use to make specific submodules trainable; overrides freeze_params
 
+  # Multi-Token Prediction is opt-in. Some LLM checkpoints include native MTP
+  # weights; they are restored when enabled and skipped entirely when disabled.
+  # For a base checkpoint without MTP weights, enabling this block initializes a
+  # fresh head after loading the backbone. Add "^llm\\.mtp\\..+$" to
+  # prevent_freeze_params when the broad LLM freeze pattern above is active.
+  mtp:
+    enabled: false
+    num_nextn_predict_layers: 1
+    hybrid_override_pattern: "*"
+    loss_scaling_factor: 0.1
+    use_repeated_layer: false
+
   prompt_format: nemotron-nano-v3
   audio_locator_tag: "<|audio|>"  # placeholder token for audio turn is expected
   # Split audios longer than this before the speech encoder forward, then concatenate

--- a/examples/speechlm2/salm_train.py
+++ b/examples/speechlm2/salm_train.py
@@ -27,16 +27,6 @@ if torch.cuda.is_available():
     torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
 
 
-def _should_pin_bf16_default_dtype(cfg: DictConfig) -> bool:
-    """Return whether compiled BF16 checkpoint recompute needs a stable default dtype."""
-    return (
-        cfg.trainer.get("precision") == "bf16-true"
-        and bool(cfg.model.get("use_nemo_automodel", False))
-        and bool(OmegaConf.select(cfg, "model.compile.enabled", default=False))
-        and bool(OmegaConf.select(cfg, "trainer.strategy.activation_checkpointing_llm", default=False))
-    )
-
-
 def _create_salm_dataset(tokenizer, data_cfg: DictConfig | dict) -> SALMDataset:
     """Build SALMDataset without forwarding unset options to legacy NeMo packages."""
     multispeaker_cfg = data_cfg.get("multispeaker_cfg", None)
@@ -53,15 +43,6 @@ def train(cfg):
         torch.distributed.init_process_group(backend="nccl")
     seed_everything(cfg.data.train_ds.seed)
     torch.set_float32_matmul_precision("medium")
-
-    # Under bf16-true, Lightning changes the default dtype only around the forward.
-    # A torch.compile-d LLM that is recomputed by activation checkpointing then sees
-    # fp32 during backward, invalidates its Dynamo global-state guard, and repeatedly
-    # recompiles. Pin the process default only for that exact combination; ordinary
-    # bf16-true and bf16-flash runs retain their precision plugin behavior.
-    if _should_pin_bf16_default_dtype(cfg):
-        torch.set_default_dtype(torch.bfloat16)
-
     trainer = Trainer(**resolve_trainer_cfg(cfg.trainer))
     log_dir = exp_manager(trainer, cfg.get("exp_manager", None))
     # Insert at position 0 so our ``on_train_batch_end`` runs BEFORE the
@@ -83,11 +64,6 @@ def train(cfg):
     dataset = _create_salm_dataset(model.tokenizer, cfg.data)
     datamodule = DataModule(cfg.data, tokenizer=model.tokenizer, dataset=dataset)
 
-    # Evaluation-only path: run the Lightning validation loop without any
-    # training (e.g. to measure MTP per-head teacher-forced agreement on a checkpoint
-    # loaded via model.init_from_checkpoint). configure_model() still loads the
-    # checkpoint weights for validate, so this exercises the val metrics on the
-    # restored model without touching its weights.
     if cfg.get("run_validate_only", False):
         trainer.validate(model, datamodule)
     else:

--- a/examples/speechlm2/salm_train.py
+++ b/examples/speechlm2/salm_train.py
@@ -82,7 +82,7 @@ def train(cfg):
     datamodule = DataModule(cfg.data, tokenizer=model.tokenizer, dataset=dataset)
 
     # Evaluation-only path: run the Lightning validation loop without any
-    # training (e.g. to measure MTP per-head token acceptance on a checkpoint
+    # training (e.g. to measure MTP per-head teacher-forced agreement on a checkpoint
     # loaded via model.init_from_checkpoint). configure_model() still loads the
     # checkpoint weights for validate, so this exercises the val metrics on the
     # restored model without touching its weights.

--- a/examples/speechlm2/salm_train.py
+++ b/examples/speechlm2/salm_train.py
@@ -43,6 +43,23 @@ def train(cfg):
         torch.distributed.init_process_group(backend="nccl")
     seed_everything(cfg.data.train_ds.seed)
     torch.set_float32_matmul_precision("medium")
+
+    # Pin the process-global default dtype to match bf16-true precision. Under
+    # bf16-true, the default dtype is bf16 around the forward, but activation-
+    # checkpoint recompute runs in backward where it has reverted to fp32. Any
+    # @torch.compile'd kernel whose Dynamo GLOBAL_STATE guard includes
+    # default_dtype (e.g. Automodel's Float32RMSNorm) is then traced under bf16
+    # in the forward and re-entered under fp32 in recompute -> it recompiles every
+    # step until Dynamo's recompile_limit (8) raises, killing training ~33 min in
+    # (2904 mtp4r-v2 BSHD recipe, 2026-06-29). Pinning the global default makes the
+    # forward and the recompute agree so the guard never flips. This protects all
+    # compiled kernels (not just RMSNorm) and is numerically inert: bf16-true
+    # already trains in bf16, and fp32-critical modules/buffers are created with an
+    # explicit dtype (RMSNorm upcasts via .float(); RoPE/A_log/router bias are
+    # explicitly fp32), so they are unaffected by the default.
+    if cfg.trainer.get("precision") == "bf16-true":
+        torch.set_default_dtype(torch.bfloat16)
+
     trainer = Trainer(**resolve_trainer_cfg(cfg.trainer))
     log_dir = exp_manager(trainer, cfg.get("exp_manager", None))
     # Insert at position 0 so our ``on_train_batch_end`` runs BEFORE the
@@ -64,7 +81,15 @@ def train(cfg):
     dataset = _create_salm_dataset(model.tokenizer, cfg.data)
     datamodule = DataModule(cfg.data, tokenizer=model.tokenizer, dataset=dataset)
 
-    trainer.fit(model, datamodule)
+    # Evaluation-only path: run the Lightning validation loop without any
+    # training (e.g. to measure MTP per-head token acceptance on a checkpoint
+    # loaded via model.init_from_checkpoint). configure_model() still loads the
+    # checkpoint weights for validate, so this exercises the val metrics on the
+    # restored model without touching its weights.
+    if cfg.get("run_validate_only", False):
+        trainer.validate(model, datamodule)
+    else:
+        trainer.fit(model, datamodule)
 
     if torch.distributed.is_initialized():
         torch.distributed.destroy_process_group()

--- a/examples/speechlm2/salm_train.py
+++ b/examples/speechlm2/salm_train.py
@@ -27,6 +27,16 @@ if torch.cuda.is_available():
     torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
 
 
+def _should_pin_bf16_default_dtype(cfg: DictConfig) -> bool:
+    """Return whether compiled BF16 checkpoint recompute needs a stable default dtype."""
+    return (
+        cfg.trainer.get("precision") == "bf16-true"
+        and bool(cfg.model.get("use_nemo_automodel", False))
+        and bool(OmegaConf.select(cfg, "model.compile.enabled", default=False))
+        and bool(OmegaConf.select(cfg, "trainer.strategy.activation_checkpointing_llm", default=False))
+    )
+
+
 def _create_salm_dataset(tokenizer, data_cfg: DictConfig | dict) -> SALMDataset:
     """Build SALMDataset without forwarding unset options to legacy NeMo packages."""
     multispeaker_cfg = data_cfg.get("multispeaker_cfg", None)
@@ -44,20 +54,12 @@ def train(cfg):
     seed_everything(cfg.data.train_ds.seed)
     torch.set_float32_matmul_precision("medium")
 
-    # Pin the process-global default dtype to match bf16-true precision. Under
-    # bf16-true, the default dtype is bf16 around the forward, but activation-
-    # checkpoint recompute runs in backward where it has reverted to fp32. Any
-    # @torch.compile'd kernel whose Dynamo GLOBAL_STATE guard includes
-    # default_dtype (e.g. Automodel's Float32RMSNorm) is then traced under bf16
-    # in the forward and re-entered under fp32 in recompute -> it recompiles every
-    # step until Dynamo's recompile_limit (8) raises, killing training ~33 min in
-    # (2904 mtp4r-v2 BSHD recipe, 2026-06-29). Pinning the global default makes the
-    # forward and the recompute agree so the guard never flips. This protects all
-    # compiled kernels (not just RMSNorm) and is numerically inert: bf16-true
-    # already trains in bf16, and fp32-critical modules/buffers are created with an
-    # explicit dtype (RMSNorm upcasts via .float(); RoPE/A_log/router bias are
-    # explicitly fp32), so they are unaffected by the default.
-    if cfg.trainer.get("precision") == "bf16-true":
+    # Under bf16-true, Lightning changes the default dtype only around the forward.
+    # A torch.compile-d LLM that is recomputed by activation checkpointing then sees
+    # fp32 during backward, invalidates its Dynamo global-state guard, and repeatedly
+    # recompiles. Pin the process default only for that exact combination; ordinary
+    # bf16-true and bf16-flash runs retain their precision plugin behavior.
+    if _should_pin_bf16_default_dtype(cfg):
         torch.set_default_dtype(torch.bfloat16)
 
     trainer = Trainer(**resolve_trainer_cfg(cfg.trainer))

--- a/nemo/collections/speechlm2/models/salm_automodel.py
+++ b/nemo/collections/speechlm2/models/salm_automodel.py
@@ -14,6 +14,7 @@
 import re
 import warnings
 from collections import defaultdict
+from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
 
@@ -488,7 +489,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             # seq_idx and masks cross-sequence targets.
             mtp_cu_seqlens = inputs.get("llm_kwargs", {}).get("cu_seqlens")
             with loss_parallel():
-                mtp_loss, mtp_loss_by_head, mtp_raw_loss_by_head = _calculate_mtp_loss_with_heads(
+                mtp_loss, mtp_raw_loss_by_head = _calculate_mtp_loss_with_heads(
                     self._mtp_loss_fn,
                     mtp_per_depth_h=mtp_h,
                     labels=inputs["target_ids"],
@@ -499,12 +500,9 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                     cu_seqlens=mtp_cu_seqlens,
                 )
             mtp_loss = dp_size * mtp_loss
-            mtp_loss_by_head = [dp_size * head_loss for head_loss in mtp_loss_by_head]
             mtp_raw_loss_by_head = [dp_size * head_loss for head_loss in mtp_raw_loss_by_head]
             loss = loss + mtp_loss
             mtp_metrics["mtp_loss"] = mtp_loss.detach()
-            for head_idx, head_loss in enumerate(mtp_loss_by_head, start=1):
-                mtp_metrics[f"mtp_loss/head_{head_idx}"] = head_loss.detach()
             for head_idx, head_loss in enumerate(mtp_raw_loss_by_head, start=1):
                 mtp_metrics[f"mtp_loss_unscaled/head_{head_idx}"] = head_loss.detach()
 
@@ -1342,11 +1340,65 @@ def _build_mtp_loss_fn() -> torch.nn.Module:
     return MaskedCrossEntropy(reduction="sum", fp32_upcast=False)
 
 
+def _resolve_mtp_seq_idx(
+    labels: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor | None = None,
+    seq_idx: torch.Tensor | None = None,
+) -> torch.Tensor | None:
+    """Resolve packed-sequence IDs and align them with the label layout."""
+    if seq_idx is None and cu_seqlens is not None:
+        cs = cu_seqlens
+        if cs.dim() == 2:
+            if cs.shape[0] != 1:
+                raise ValueError(f"MTP cu_seqlens must have shape [N+1] or [1, N+1], got {tuple(cs.shape)}")
+            cs = cs.squeeze(0)
+        if cs.dim() != 1:
+            raise ValueError(f"MTP cu_seqlens must have shape [N+1] or [1, N+1], got {tuple(cs.shape)}")
+        positions = torch.arange(labels.shape[-1], device=labels.device)
+        seq_idx = torch.searchsorted(cs[1:].contiguous(), positions, right=True)
+
+    if seq_idx is None:
+        return None
+    if seq_idx.dim() == 1 and labels.dim() == 2:
+        seq_idx = seq_idx.unsqueeze(0).expand(labels.shape[0], -1)
+    elif seq_idx.dim() == 2 and labels.dim() == 1 and seq_idx.shape[0] == 1:
+        seq_idx = seq_idx.squeeze(0)
+    if seq_idx.shape != labels.shape:
+        raise ValueError(f"MTP seq_idx shape {tuple(seq_idx.shape)} does not match labels shape {tuple(labels.shape)}")
+    return seq_idx
+
+
+def _iter_mtp_depth_targets(
+    labels: torch.Tensor,
+    num_depths: int,
+    *,
+    ignore_index: int = -100,
+    cu_seqlens: torch.Tensor | None = None,
+    seq_idx: torch.Tensor | None = None,
+) -> Iterator[torch.Tensor]:
+    """Yield shifted labels with trailing and packed-boundary positions masked."""
+    from nemo_automodel.components.models.common.mtp import roll_tensor
+
+    seq_idx = _resolve_mtp_seq_idx(labels, cu_seqlens=cu_seqlens, seq_idx=seq_idx)
+    cur_labels = labels
+    for depth in range(1, num_depths + 1):
+        cur_labels = roll_tensor(cur_labels, shifts=-1, dim=-1)
+        masked = cur_labels.clone()
+        n_invalid = min(depth, masked.shape[-1])
+        masked[..., -n_invalid:] = ignore_index
+
+        if seq_idx is not None:
+            rolled_seq_idx = roll_tensor(seq_idx, shifts=-depth, dim=-1)
+            masked = torch.where(rolled_seq_idx != seq_idx, torch.full_like(masked, ignore_index), masked)
+
+        yield masked
+
+
 def _calculate_mtp_loss_with_heads(
     loss_fn,
     *,
-    mtp_per_depth_h: list[torch.Tensor] | None = None,
-    mtp_per_depth_logits: list[torch.Tensor] | None = None,
+    mtp_per_depth_h: list[torch.Tensor],
     labels: torch.Tensor,
     model: torch.nn.Module,
     scaling_factor: float = 0.1,
@@ -1355,42 +1407,35 @@ def _calculate_mtp_loss_with_heads(
     ignore_index: int = -100,
     cu_seqlens: torch.Tensor | None = None,
     seq_idx: torch.Tensor | None = None,
-) -> tuple[torch.Tensor, list[torch.Tensor], list[torch.Tensor]]:
+) -> tuple[torch.Tensor, list[torch.Tensor]]:
     """Compute aggregate MTP loss and per-head losses for logging.
 
     This mirrors Automodel's ``calculate_mtp_loss`` but keeps the intermediate
     depth losses so Lightning/WandB can display each MTP head. Returned
-    ``head_losses`` are the weighted contributions that sum to ``total``;
-    returned ``raw_head_losses`` are normalized CE values before applying
+    ``raw_head_losses`` are normalized CE values before applying
     ``scaling_factor / D``. The caller applies the same DP correction used by
     the main training loss.
     """
     from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
     from nemo_automodel.components.loss.utils import _get_lm_head_module, calculate_loss
-    from nemo_automodel.components.models.common.mtp import roll_tensor
-
-    if (mtp_per_depth_h is None) == (mtp_per_depth_logits is None):
-        raise ValueError("Provide exactly one of mtp_per_depth_h or mtp_per_depth_logits")
-
-    mtp_outputs = mtp_per_depth_logits if mtp_per_depth_logits is not None else mtp_per_depth_h
 
     if labels.dim() == 1:
-        mtp_outputs = [h.squeeze(0) if (h.dim() == 3 and h.shape[0] == 1) else h for h in mtp_outputs]
+        mtp_per_depth_h = [h.squeeze(0) if (h.dim() == 3 and h.shape[0] == 1) else h for h in mtp_per_depth_h]
 
-    D = len(mtp_outputs)
-    cur_labels = labels
-    total = mtp_outputs[0].new_zeros(())
-    head_losses = []
+    D = len(mtp_per_depth_h)
+    head_scale = scaling_factor / D
+    total = mtp_per_depth_h[0].new_zeros(())
     raw_head_losses = []
+
+    lm_head = _get_lm_head_module(model)
+    if lm_head is None:
+        raise ValueError("lm_head module not found in model")
 
     # FusedLinearCrossEntropy consumes the shared LM-head weight directly. Materialize
     # a possibly sharded weight once and reuse it for every depth; gathering separately
     # inside calculate_loss retains one full vocabulary matrix per head for backward.
     lm_weight = None
-    if mtp_per_depth_h is not None and isinstance(loss_fn, FusedLinearCrossEntropy):
-        lm_head = _get_lm_head_module(model)
-        if lm_head is None:
-            raise ValueError("lm_head module not found in model")
+    if isinstance(loss_fn, FusedLinearCrossEntropy):
         lm_weight = lm_head.weight
         if isinstance(lm_weight, DTensor):
             materialize = getattr(loss_fn, "materialize_lm_weight", None)
@@ -1400,49 +1445,15 @@ def _calculate_mtp_loss_with_heads(
                 )
             lm_weight = materialize(lm_weight, grad_reduce_group=grad_reduce_group)
 
-    if seq_idx is None and cu_seqlens is not None:
-        cs = cu_seqlens
-        if cs.dim() == 2 and cs.shape[0] == 1:
-            cs = cs.squeeze(0)
-        if cs.dim() == 1:
-            total_len = labels.shape[-1]
-            positions = torch.arange(total_len, device=labels.device)
-            seq_idx = torch.searchsorted(cs[1:].contiguous(), positions, right=True)
-            if labels.dim() == 2:
-                seq_idx = seq_idx.unsqueeze(0).expand(labels.shape[0], -1)
-    elif seq_idx is not None:
-        if seq_idx.dim() == 1 and labels.dim() == 2:
-            seq_idx = seq_idx.unsqueeze(0).expand(labels.shape[0], -1)
-        elif seq_idx.dim() == 2 and labels.dim() == 1 and seq_idx.shape[0] == 1:
-            seq_idx = seq_idx.squeeze(0)
-        if seq_idx.shape != labels.shape:
-            raise ValueError(
-                f"_calculate_mtp_loss_with_heads: seq_idx.shape={tuple(seq_idx.shape)} does not "
-                f"match labels.shape={tuple(labels.shape)}"
-            )
-
-    for k, mtp_output in enumerate(mtp_outputs):
-        cur_labels = roll_tensor(cur_labels, shifts=-1, dim=-1)
-        masked = cur_labels.clone()
-        n_invalid = min(k + 1, masked.shape[-1])
-        masked[..., -n_invalid:] = ignore_index
-
-        if seq_idx is not None:
-            rolled_seq_idx = roll_tensor(seq_idx, shifts=-(k + 1), dim=-1)
-            cross_seq = rolled_seq_idx != seq_idx
-            masked = torch.where(cross_seq, torch.full_like(masked, ignore_index), masked)
-
-        if mtp_per_depth_logits is not None:
-            if isinstance(loss_fn, FusedLinearCrossEntropy):
-                raise ValueError("MTP logits are incompatible with FusedLinearCrossEntropy")
-            depth_loss = calculate_loss(
-                loss_fn,
-                logits=mtp_output,
-                labels=masked,
-                model=model,
-                num_label_tokens=num_label_tokens,
-            )
-        elif isinstance(loss_fn, FusedLinearCrossEntropy):
+    depth_targets = _iter_mtp_depth_targets(
+        labels,
+        D,
+        ignore_index=ignore_index,
+        cu_seqlens=cu_seqlens,
+        seq_idx=seq_idx,
+    )
+    for mtp_output, masked in zip(mtp_per_depth_h, depth_targets):
+        if isinstance(loss_fn, FusedLinearCrossEntropy):
             depth_loss = calculate_loss(
                 loss_fn,
                 hidden_states=mtp_output,
@@ -1453,23 +1464,17 @@ def _calculate_mtp_loss_with_heads(
                 grad_reduce_group=grad_reduce_group,
             )
         else:
-            lm_head = _get_lm_head_module(model)
-            if lm_head is None:
-                raise ValueError("lm_head module not found in model")
             depth_loss = calculate_loss(
                 loss_fn,
                 logits=lm_head(mtp_output),
                 labels=masked,
-                model=model,
                 num_label_tokens=num_label_tokens,
             )
 
         raw_head_losses.append(depth_loss)
-        head_loss = depth_loss * (scaling_factor / D)
-        head_losses.append(head_loss)
-        total = total + head_loss
+        total = total + depth_loss * head_scale
 
-    return total, head_losses, raw_head_losses
+    return total, raw_head_losses
 
 
 def _vocab_parallel_argmax(logits: torch.Tensor) -> torch.Tensor:
@@ -1523,31 +1528,18 @@ def _calculate_mtp_teacher_forced_agreement_with_heads(
     if lm_head is None:
         raise ValueError("lm_head module not found in model")
 
-    if seq_idx is None and cu_seqlens is not None:
-        cs = cu_seqlens
-        if cs.dim() == 2 and cs.shape[0] == 1:
-            cs = cs.squeeze(0)
-        if cs.dim() == 1:
-            positions = torch.arange(labels.shape[-1], device=labels.device)
-            seq_idx = torch.searchsorted(cs[1:].contiguous(), positions, right=True)
-            if labels.dim() == 2:
-                seq_idx = seq_idx.unsqueeze(0).expand(labels.shape[0], -1)
-
-    cur_labels = labels
     prefix_matches = torch.ones_like(labels, dtype=torch.bool)
     prefix_valid = torch.ones_like(labels, dtype=torch.bool)
     correct_by_head = []
     valid_by_head = []
-    for k, mtp_output in enumerate(mtp_outputs):
-        cur_labels = roll_tensor(cur_labels, shifts=-1, dim=-1)
-        masked = cur_labels.clone()
-        n_invalid = min(k + 1, masked.shape[-1])
-        masked[..., -n_invalid:] = ignore_index
-
-        if seq_idx is not None:
-            rolled_seq_idx = roll_tensor(seq_idx, shifts=-(k + 1), dim=-1)
-            masked = torch.where(rolled_seq_idx != seq_idx, torch.full_like(masked, ignore_index), masked)
-
+    depth_targets = _iter_mtp_depth_targets(
+        labels,
+        len(mtp_outputs),
+        ignore_index=ignore_index,
+        cu_seqlens=cu_seqlens,
+        seq_idx=seq_idx,
+    )
+    for k, (mtp_output, masked) in enumerate(zip(mtp_outputs, depth_targets)):
         logits = lm_head(mtp_output)
         preds = _vocab_parallel_argmax(logits)
         valid = masked != ignore_index

--- a/nemo/collections/speechlm2/models/salm_automodel.py
+++ b/nemo/collections/speechlm2/models/salm_automodel.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import warnings
 from collections import defaultdict
+from contextlib import contextmanager
 from typing import Any
 
 import torch
@@ -386,6 +387,12 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             nvte_fused_attn=nvte_fused_attn,
             device_capability=device_capability,
         )
+        mtp_cfg = self.cfg.get("mtp", None)
+        if cp_size > 1 and mtp_cfg is not None and bool(mtp_cfg.get("enabled", False)):
+            raise ValueError(
+                "SALMAutomodel MTP currently requires cp_size=1. Context parallelism uses an interleaved "
+                "THD partition, so rank-local labels cannot be rolled into correct next-token MTP targets yet."
+            )
 
     def training_step(self, dataloader_iter):
         # ``dataloader_iter`` signature → Lightning selects
@@ -567,10 +574,10 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             if lss_vals:
                 self.log("val_lss", torch.stack(lss_vals).mean(), on_epoch=True, sync_dist=True)
 
-        # Multi-Token Prediction acceptance metrics: per-head acceptance probability and the
-        # expected acceptance length (number of tokens a greedy verifier would accept, i.e. the
-        # always-accepted main-head token plus the cumulative product of each MTP head's accept
-        # probability). Per-head marginal rates approximate the conditional accept probabilities.
+        # Multi-Token Prediction acceptance metrics. Each accumulated per-head count is already
+        # a prefix count: depth k contributes only when the verifier matched every draft through
+        # depth k. Therefore the expected greedy acceptance length is one always-accepted target
+        # token plus the sum of the measured prefix-acceptance probabilities.
         if self._partial_val_mtp_correct:
             accept_lengths = []
             for name in self._partial_val_mtp_correct:
@@ -581,7 +588,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                 per_head = reduced[:D] / reduced[D:].clamp(min=1)
                 for head_idx, p in enumerate(per_head, start=1):
                     self.log(f"val_mtp_acc_{name}/head_{head_idx}", p, on_epoch=True, sync_dist=True)
-                accept_length = 1.0 + torch.cumprod(per_head, dim=0).sum()
+                accept_length = 1.0 + per_head.sum()
                 self.log(f"val_mtp_accept_length_{name}", accept_length, on_epoch=True, sync_dist=True)
                 accept_lengths.append(accept_length)
             if accept_lengths:
@@ -605,32 +612,15 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             if dataset_batch is None:
                 continue  # some dataset is exhausted
             inputs = self.prepare_inputs(dataset_batch)
-            # Enable the MTP heads under eval so we can measure per-head token
-            # acceptance during validation; the LLM gates them on self.training
-            # otherwise. Restored immediately so generation stays unaffected.
-            # ``hasattr`` (not ``getattr(..., None)``) so we can distinguish "LLM
-            # doesn't support eval-mode MTP" from the normal False default and warn
-            # once — otherwise the acceptance metrics silently never appear.
-            _mtp_eval_supported = hasattr(self.llm, "compute_mtp_in_eval")
-            if not _mtp_eval_supported and self._mtp_enabled and not getattr(self, "_warned_no_mtp_eval", False):
-                logging.warning(
-                    "MTP is enabled but the LLM has no `compute_mtp_in_eval` attribute, so validation "
-                    "will not report MTP acceptance metrics. Upgrade nemo_automodel to a revision that "
-                    "supports eval-mode MTP (the heads are gated on `self.training` otherwise)."
-                )
-                self._warned_no_mtp_eval = True
-            if _mtp_eval_supported:
-                _prev_mtp_eval = self.llm.compute_mtp_in_eval
-                self.llm.compute_mtp_in_eval = True
-            try:
+            # Enable MTP only around the validation forward. New Automodel revisions expose
+            # ``compute_mtp_in_eval``; the compatibility path for the currently pinned revision
+            # flips only the root module's gate while leaving every child in eval mode.
+            with _mtp_validation_forward(self.llm, enabled=self._mtp_enabled):
                 forward_outputs = self(
                     inputs["input_embeds"],
                     attention_mask=inputs["attention_mask"],
                     **inputs.get("llm_kwargs", {}),
                 )
-            finally:
-                if _mtp_eval_supported:
-                    self.llm.compute_mtp_in_eval = _prev_mtp_eval
             num_frames = (inputs["target_ids"] != -100).long().sum()
             with loss_parallel():
                 logits = forward_outputs["logits"]
@@ -641,14 +631,15 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                     ignore_index=-100,
                 )
 
+            if isinstance(logits, DTensor):
+                logits = logits.full_tensor()
             if self.lss_loss is not None and num_frames > 0:
-                if isinstance(logits, DTensor):
-                    logits = logits.full_tensor()
                 log_probs = torch.nn.functional.log_softmax(logits.float(), dim=-1)
                 lss_val = self.lss_loss(log_probs=log_probs, labels=inputs["target_ids"])
                 self._partial_val_lss[name].append(lss_val.detach())
 
-            preds = forward_outputs["logits"].argmax(dim=-1).view(-1)
+            verifier_predictions = logits.argmax(dim=-1)
+            preds = verifier_predictions.view(-1)
             refs = inputs["target_ids"].reshape(-1)
             preds = preds[refs != -100]
             refs = refs[refs != -100]
@@ -658,8 +649,8 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             self._partial_val_corrects[name].append(correct.detach().to(loss_sum.dtype))
             self._partial_val_num_frames[name].append(num_frames.detach().to(loss_sum.dtype))
 
-            # Multi-Token Prediction acceptance: per-head match rate of each MTP head's
-            # argmax against the token it predicts, accumulated for epoch-end reporting.
+            # Multi-Token Prediction acceptance: verifier-matched prefix rates for each
+            # depth, accumulated for epoch-end expected-length reporting.
             mtp_h = forward_outputs.get("mtp_per_depth_h", None)
             if mtp_h is not None:
                 mtp_cu_seqlens = inputs.get("llm_kwargs", {}).get("cu_seqlens")
@@ -667,6 +658,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                     mtp_per_depth_h=mtp_h,
                     labels=inputs["target_ids"],
                     model=self.llm,
+                    verifier_predictions=verifier_predictions,
                     cu_seqlens=mtp_cu_seqlens,
                 )
                 self._partial_val_mtp_correct[name].append(torch.stack(correct_by_head).detach().to(loss_sum.dtype))
@@ -1182,11 +1174,12 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             # boundaries (see training_step); the MTP sublayers already get the
             # THD context (qkv_format/cu_seqlens/seq_idx) from the model forward.
             self._mtp_loss_scaling_factor = float(mtp_cfg.get("loss_scaling_factor", 0.1))
-            # Same per-token loss class the Automodel recipe uses for MTP; reduction="sum"
-            # so calculate_mtp_loss can normalize by our global token count.
-            from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
+            # Fuse the shared LM projection with CE so each MTP depth does not materialize
+            # a full [tokens, vocab] logits tensor. reduction="sum" lets the helper
+            # normalize by the global labeled-token count.
+            from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
 
-            self._mtp_loss_fn = MaskedCrossEntropy(reduction="sum", fp32_upcast=False)
+            self._mtp_loss_fn = FusedLinearCrossEntropy(reduction="sum")
         else:
             # Some checkpoints (including Nemotron-3.5 Lightning) ship a native
             # MTP head in config.json. Explicitly override its depth to zero so
@@ -1201,6 +1194,11 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             trust_remote_code=self.cfg.get("trust_remote_code", False),
             **automodel_kwargs,
         )
+        if not mtp_requested:
+            # The constructor override suppresses a checkpoint-native MTP module but does
+            # not mutate the HF config. Keep the serialized config consistent with the
+            # actual state dict so conversion/reload does not recreate a missing head.
+            self.llm.config.num_nextn_predict_layers = 0
 
         # Build + attach the MTP head ourselves only when the checkpoint did not
         # provide one. Native checkpoint MTP modules were already sharded by
@@ -1356,6 +1354,19 @@ def _calculate_mtp_loss_with_heads(
     head_losses = []
     raw_head_losses = []
 
+    # FusedLinearCrossEntropy consumes the shared LM-head weight directly. Materialize
+    # a possibly sharded weight once and reuse it for every depth; gathering separately
+    # inside calculate_loss retains one full vocabulary matrix per head for backward.
+    lm_weight = None
+    if mtp_per_depth_h is not None and isinstance(loss_fn, FusedLinearCrossEntropy):
+        lm_head = _get_lm_head_module(model)
+        if lm_head is None:
+            raise ValueError("lm_head module not found in model")
+        lm_weight = lm_head.weight
+        if isinstance(lm_weight, DTensor):
+            materialize = getattr(loss_fn, "materialize_lm_weight", None)
+            lm_weight = materialize(lm_weight) if materialize is not None else lm_weight.full_tensor()
+
     if seq_idx is None and cu_seqlens is not None:
         cs = cu_seqlens
         if cs.dim() == 2 and cs.shape[0] == 1:
@@ -1404,6 +1415,7 @@ def _calculate_mtp_loss_with_heads(
                 hidden_states=mtp_output,
                 labels=masked,
                 model=model,
+                lm_weight=lm_weight,
                 num_label_tokens=num_label_tokens,
             )
         else:
@@ -1431,18 +1443,18 @@ def _calculate_mtp_acceptance_with_heads(
     mtp_per_depth_h: list[torch.Tensor],
     labels: torch.Tensor,
     model: torch.nn.Module,
+    verifier_predictions: torch.Tensor,
     ignore_index: int = -100,
     cu_seqlens: torch.Tensor | None = None,
     seq_idx: torch.Tensor | None = None,
 ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
     """Per-head MTP token-acceptance counts for validation.
 
-    For each MTP depth ``k`` the head's argmax prediction is compared against the
-    token ``k + 1`` steps ahead, using exactly the same rolled/masked targets as
-    ``_calculate_mtp_loss_with_heads`` (including cross-sequence masking under
-    packed THD). Returns ``(correct_by_head, valid_by_head)`` scalar tensors so
-    the epoch end can report per-head acceptance probability and expected
-    acceptance length without repeating the forward pass.
+    For each MTP depth ``k`` the head's argmax prediction is compared with the
+    verifier's prediction for the same future position. Counts are prefix-based:
+    depth ``k`` is accepted only when every draft through ``k`` matches. The same
+    rolled/masked labels as the MTP loss define eligible validation positions,
+    including cross-sequence masking under packed THD.
     """
     from nemo_automodel.components.loss.utils import _get_lm_head_module
     from nemo_automodel.components.models.common.mtp import roll_tensor
@@ -1450,6 +1462,13 @@ def _calculate_mtp_acceptance_with_heads(
     mtp_outputs = mtp_per_depth_h
     if labels.dim() == 1:
         mtp_outputs = [h.squeeze(0) if (h.dim() == 3 and h.shape[0] == 1) else h for h in mtp_outputs]
+        if verifier_predictions.dim() == 2 and verifier_predictions.shape[0] == 1:
+            verifier_predictions = verifier_predictions.squeeze(0)
+    if verifier_predictions.shape != labels.shape:
+        raise ValueError(
+            f"verifier_predictions.shape={tuple(verifier_predictions.shape)} does not "
+            f"match labels.shape={tuple(labels.shape)}"
+        )
 
     lm_head = _get_lm_head_module(model)
     if lm_head is None:
@@ -1466,6 +1485,8 @@ def _calculate_mtp_acceptance_with_heads(
                 seq_idx = seq_idx.unsqueeze(0).expand(labels.shape[0], -1)
 
     cur_labels = labels
+    prefix_matches = torch.ones_like(labels, dtype=torch.bool)
+    prefix_valid = torch.ones_like(labels, dtype=torch.bool)
     correct_by_head = []
     valid_by_head = []
     for k, mtp_output in enumerate(mtp_outputs):
@@ -1483,7 +1504,37 @@ def _calculate_mtp_acceptance_with_heads(
             logits = logits.full_tensor()
         preds = logits.argmax(dim=-1)
         valid = masked != ignore_index
-        correct_by_head.append((preds.eq(masked) & valid).sum())
-        valid_by_head.append(valid.sum())
+        verifier_for_depth = roll_tensor(verifier_predictions, shifts=-(k + 1), dim=-1)
+        prefix_valid = prefix_valid & valid
+        prefix_matches = prefix_matches & preds.eq(verifier_for_depth)
+        correct_by_head.append((prefix_matches & prefix_valid).sum())
+        valid_by_head.append(prefix_valid.sum())
 
     return correct_by_head, valid_by_head
+
+
+@contextmanager
+def _mtp_validation_forward(llm: torch.nn.Module, *, enabled: bool):
+    """Run MTP during one eval forward without changing child-module eval state."""
+    if not enabled:
+        yield
+        return
+
+    if hasattr(llm, "compute_mtp_in_eval"):
+        previous = llm.compute_mtp_in_eval
+        llm.compute_mtp_in_eval = True
+        try:
+            yield
+        finally:
+            llm.compute_mtp_in_eval = previous
+        return
+
+    # Older Automodel revisions gate MTP only on the root module's ``training``
+    # flag. Assign it directly rather than calling train(), which would recursively
+    # enable dropout and other training-only behavior in the frozen verifier.
+    previous = llm.training
+    llm.training = True
+    try:
+        yield
+    finally:
+        llm.training = previous

--- a/nemo/collections/speechlm2/models/salm_automodel.py
+++ b/nemo/collections/speechlm2/models/salm_automodel.py
@@ -1006,6 +1006,41 @@ class SALMAutomodel(LightningModule, HFHubMixin):
     def configure_optimizers(self):
         return configure_optimizers(self)
 
+    def _apply_mtp_training_mode(self, training_mode: str) -> None:
+        """Apply the optimizer-facing parameter policy for an MTP run.
+
+        ``joint`` preserves the recipe's ordinary freeze policy. ``head_only``
+        freezes every parameter outside ``llm.mtp`` and guarantees that the
+        head wins over any user-supplied ``freeze_params`` expression. The
+        latter is intentionally strict: speech encoder, modality adapter,
+        backbone, embeddings, and LM head all remain fixed.
+
+        This runs after model/checkpoint setup so loading is unaffected, and
+        before Lightning constructs the optimizer.
+        """
+        if training_mode != "head_only":
+            return
+        if not self._mtp_enabled:
+            raise RuntimeError("MTP training_mode='head_only' requires an attached MTP head.")
+
+        mtp_param_ids = {id(param) for param in self.llm.mtp.parameters()}
+        if not mtp_param_ids:
+            raise RuntimeError("MTP training_mode='head_only' found an MTP module with no parameters.")
+        for param in self.parameters():
+            param.requires_grad_(id(param) in mtp_param_ids)
+
+        # freeze_and_subset applies recipe regexes when configure_optimizers is
+        # called. Ensure broad expressions such as '^llm\\..+$' cannot remove
+        # the one parameter namespace that head-only mode promises to train.
+        keep_pattern = r"^llm\.mtp\..+$"
+        if "prevent_freeze_params" not in self.cfg:
+            self.cfg.prevent_freeze_params = []
+        if keep_pattern not in self.cfg.prevent_freeze_params:
+            self.cfg.prevent_freeze_params.append(keep_pattern)
+
+        trainable = sum(param.numel() for param in self.llm.mtp.parameters() if param.requires_grad)
+        logging.info(f"MTP training mode=head_only: trainable MTP parameters={trainable}; all others frozen")
+
     def _build_and_attach_mtp_head(self, mtp_cfg, dtype) -> None:
         """Construct the NemotronV3 MTP head and attach it as ``self.llm.mtp``.
 
@@ -1135,6 +1170,12 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         # So we load the LLM normally and then construct + attach the head ourselves.
         mtp_cfg = self.cfg.get("mtp", None)
         mtp_requested = mtp_cfg is not None and mtp_cfg.get("enabled", False)
+        mtp_training_mode = str(mtp_cfg.get("training_mode", "joint")) if mtp_requested else "disabled"
+        if mtp_requested and mtp_training_mode not in {"joint", "head_only"}:
+            raise ValueError(
+                f"Unknown mtp.training_mode {mtp_training_mode!r}; expected 'joint' or 'head_only' when MTP is enabled"
+            )
+        logging.info(f"MTP training mode={mtp_training_mode}")
         if mtp_requested:
             # MTP supports both BSHD and packed THD. For THD the MTP loss must
             # receive cu_seqlens so target rolling is masked at packed sequence
@@ -1199,6 +1240,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
 
         if device_mesh is None:
             maybe_load_pretrained_models(self)
+            self._apply_mtp_training_mode(mtp_training_mode)
             return
 
         # Cast perception to training dtype BEFORE FSDP2 wrapping.
@@ -1244,6 +1286,8 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         # (fresh optimizer/scheduler). Must happen after FSDP wrapping so that
         # DCP loading can fill DTensor parameters with correct shards.
         maybe_load_pretrained_models(self)
+
+        self._apply_mtp_training_mode(mtp_training_mode)
 
     @property
     def oomptimizer_schema(self) -> dict:

--- a/nemo/collections/speechlm2/models/salm_automodel.py
+++ b/nemo/collections/speechlm2/models/salm_automodel.py
@@ -112,6 +112,14 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         return int(mtp_config.num_layers)
 
     @property
+    def _context_parallel_size(self) -> int:
+        """Return the configured context-parallel world size."""
+        device_mesh = getattr(self, "_device_mesh", None)
+        if device_mesh is None or "cp" not in (device_mesh.mesh_dim_names or ()):
+            return 1
+        return int(device_mesh["cp"].size())
+
+    @property
     def embed_tokens(self):
         """Navigate to the LLM's embedding layer (kept inside the LLM)."""
         if self.llm is None:
@@ -262,7 +270,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                 stacklevel=2,
             )
 
-    def prepare_inputs(self, batch: dict):
+    def prepare_inputs(self, batch: dict, *, include_mtp_inputs: bool = True):
         """
         Performs additional processing on the mini-batch collected from dataloader.
         Notably:
@@ -280,6 +288,9 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         When ``batch["spk_targets"]`` is present, those RTTM-derived speaker
         targets are injected into a ``ParallelExpertEncoder``. Otherwise, the
         encoder runs its embedded Sortformer to predict diarization.
+
+        ``include_mtp_inputs=False`` avoids constructing future-token tensors
+        when validation cannot consume MTP outputs, such as under CP.
         """
         from nemo.collections.speechlm2.parts.cp_helpers import (
             encode_audio_with_cp_distribution,
@@ -337,7 +348,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                 padding_id=self.text_pad_id,
                 placeholder_id=self.audio_locator_tag_id,
                 device_mesh=device_mesh,
-                mtp_num_depths=self._mtp_num_depths,
+                mtp_num_depths=self._mtp_num_depths if include_mtp_inputs else 0,
             )
             if dummy_audio_loss is not None:
                 ans["dummy_audio_loss"] = dummy_audio_loss
@@ -664,8 +675,11 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         for name, dataset_batch in batch.items():
             if dataset_batch is None:
                 continue  # some dataset is exhausted
-            inputs = self.prepare_inputs(dataset_batch)
-            mtp_metrics_disabled_for_cp = self._mtp_enabled and "mtp_per_depth_targets" in inputs
+            mtp_metrics_disabled_for_cp = self._mtp_enabled and self._context_parallel_size > 1
+            inputs = self.prepare_inputs(
+                dataset_batch,
+                include_mtp_inputs=not mtp_metrics_disabled_for_cp,
+            )
             if mtp_metrics_disabled_for_cp:
                 logging.warning(
                     "MTP teacher-forced agreement metrics are disabled under context parallelism because "
@@ -708,7 +722,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
 
             # Multi-Token Prediction teacher-forced prefix agreement for each depth.
             mtp_h = forward_outputs.get("mtp_per_depth_h", None)
-            if mtp_h is not None:
+            if mtp_h is not None and not mtp_metrics_disabled_for_cp:
                 mtp_cu_seqlens = inputs.get("llm_kwargs", {}).get("cu_seqlens")
                 correct_by_head, valid_by_head = calculate_mtp_teacher_forced_agreement(
                     mtp_per_depth_h=mtp_h,

--- a/nemo/collections/speechlm2/models/salm_automodel.py
+++ b/nemo/collections/speechlm2/models/salm_automodel.py
@@ -102,6 +102,16 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         return getattr(getattr(self, "llm", None), "mtp", None) is not None
 
     @property
+    def _mtp_num_depths(self) -> int:
+        """Return the logical number of MTP prediction depths."""
+        if not self._mtp_enabled:
+            return 0
+        mtp_config = getattr(self.llm, "mtp_config", None)
+        if mtp_config is None:
+            raise RuntimeError("The attached MTP head does not expose its logical depth through llm.mtp_config")
+        return int(mtp_config.num_layers)
+
+    @property
     def embed_tokens(self):
         """Navigate to the LLM's embedding layer (kept inside the LLM)."""
         if self.llm is None:
@@ -178,8 +188,10 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         |speech and text embeddings| -> |llm| -> |lm_head| -> |token ids|
 
         ``llm_kwargs`` carries optional THD/packed-sequence metadata
-        (``qkv_format``, ``cu_seqlens``, ``position_ids``, ``max_seqlen``);
-        it is empty for the BSHD path.
+        (``qkv_format``, ``cu_seqlens``, ``position_ids``, ``max_seqlen``)
+        and CP-prepared MTP position IDs. ``mtp_embed_inputs`` is removed and
+        passed through Automodel's positional per-depth embedding contract.
+        These values are absent for the BSHD path.
         """
         # input_embeds: (B, T, H) for BSHD or (T_total, H) for THD packed
         # (the THD shape mirrors Automodel's _shard_thd_chunk_for_te output —
@@ -192,8 +204,10 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             seq_len = input_embeds.shape[0] if input_embeds.ndim == 2 else input_embeds.shape[1]
             llm_input_ids = torch.zeros((1, seq_len), device=input_embeds.device, dtype=torch.long)
 
+        mtp_embed_inputs = tuple(llm_kwargs.pop("mtp_embed_inputs", ()))
         out = self.llm(
-            input_ids=llm_input_ids,
+            llm_input_ids,
+            *mtp_embed_inputs,
             inputs_embeds=input_embeds,
             attention_mask=attention_mask,
             past_key_values=cache,
@@ -323,6 +337,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                 padding_id=self.text_pad_id,
                 placeholder_id=self.audio_locator_tag_id,
                 device_mesh=device_mesh,
+                mtp_num_depths=self._mtp_num_depths,
             )
             if dummy_audio_loss is not None:
                 ans["dummy_audio_loss"] = dummy_audio_loss
@@ -408,11 +423,6 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         )
         mtp_cfg = self.cfg.get("mtp", None)
         mtp_enabled = mtp_cfg is not None and bool(mtp_cfg.get("enabled", False))
-        if cp_size > 1 and mtp_enabled:
-            raise ValueError(
-                "SALMAutomodel MTP currently requires cp_size=1. Context parallelism uses an interleaved "
-                "THD partition, so rank-local labels cannot be rolled into correct next-token MTP targets yet."
-            )
         if tp_size > 1 and mtp_enabled:
             raise ValueError(
                 "SALMAutomodel MTP currently requires tp_size=1. The MTP head has no tensor-parallel plan, "
@@ -493,10 +503,14 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             # from the current sequence's last token. Pass cu_seqlens (empty/None for
             # BSHD, where each row is already a single sequence) so the loss derives
             # seq_idx and masks cross-sequence targets.
-            mtp_cu_seqlens = inputs.get("llm_kwargs", {}).get("cu_seqlens")
+            mtp_per_depth_targets = inputs.get("mtp_per_depth_targets")
+            mtp_cu_seqlens = (
+                None if mtp_per_depth_targets is not None else inputs.get("llm_kwargs", {}).get("cu_seqlens")
+            )
             with loss_parallel():
                 mtp_loss_output = calculate_mtp_loss(
                     self._mtp_loss_fn,
+                    mtp_per_depth_targets=mtp_per_depth_targets,
                     mtp_per_depth_h=mtp_h,
                     labels=inputs["target_ids"],
                     model=self.llm,
@@ -689,7 +703,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
 
             # Multi-Token Prediction teacher-forced prefix agreement for each depth.
             mtp_h = forward_outputs.get("mtp_per_depth_h", None)
-            if mtp_h is not None:
+            if mtp_h is not None and "mtp_per_depth_targets" not in inputs:
                 mtp_cu_seqlens = inputs.get("llm_kwargs", {}).get("cu_seqlens")
                 correct_by_head, valid_by_head = calculate_mtp_teacher_forced_agreement(
                     mtp_per_depth_h=mtp_h,

--- a/nemo/collections/speechlm2/models/salm_automodel.py
+++ b/nemo/collections/speechlm2/models/salm_automodel.py
@@ -1080,56 +1080,6 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         trainable = sum(param.numel() for param in self.llm.mtp.parameters() if param.requires_grad)
         logging.info(f"MTP training mode=head_only: trainable MTP parameters={trainable}; all others frozen")
 
-    def _build_and_attach_mtp_head(self, mtp_cfg, dtype) -> None:
-        """Construct the NemotronV3 MTP head and attach it as ``self.llm.mtp``.
-
-        This fallback is used only when the selected checkpoint has no native MTP
-        module. Neither the config override nor the ``config=`` from_pretrained
-        path can inject a pattern for that case, so we set it on the live HF
-        config, build the head with Automodel's factory, and attach freshly
-        initialized weights.
-
-        NOTE: the head is built unsharded here; ``configure_model`` then ``fully_shard``s it
-        over the DP mesh (right after the perception module) so its gradients reduce-scatter
-        across the data-parallel group like every other parameter.
-        """
-        from nemo_automodel.components.models.nemotron_v3.mtp import build_mtp_config_from_hf, build_nemotron_v3_mtp
-
-        llm = self.llm
-        cfg_obj = llm.config
-        cfg_obj.mtp_hybrid_override_pattern = str(mtp_cfg.get("hybrid_override_pattern", "*"))
-        requested_depth = int(mtp_cfg.get("num_nextn_predict_layers", 1))
-        cfg_obj.num_nextn_predict_layers = requested_depth
-        mtp_config = build_mtp_config_from_hf(
-            cfg_obj,
-            loss_scaling_factor=self._mtp_loss_scaling_factor,
-            use_repeated_layer=bool(mtp_cfg.get("use_repeated_layer", False)),
-        )
-        # HF/vLLM config has no weight-tying flag for repeated MTP layers. Export
-        # the physical depth so reload constructs exactly the layers present in
-        # the state dict instead of D independent layers for one tied layer.
-        cfg_obj.num_nextn_predict_layers = mtp_config.num_physical_depths
-
-        llm.mtp_config = mtp_config
-        mtp = build_nemotron_v3_mtp(
-            cfg_obj,
-            mtp_config=mtp_config,
-            backend=llm.backend,
-            moe_config=llm.model.moe_config,
-            dtype=dtype,
-        )
-        device = (
-            torch.device("cuda", torch.cuda.current_device()) if torch.cuda.is_available() else torch.device("cpu")
-        )
-        mtp = mtp.to(device=device, dtype=dtype)
-        for sublayer in mtp.layers:
-            sublayer.init_weights(buffer_device=device)
-        llm.mtp = mtp
-        warnings.warn(
-            f"MTP head attached (unsharded): num_layers={mtp_config.num_layers} "
-            f"pattern={cfg_obj.mtp_hybrid_override_pattern!r}"
-        )
-
     def configure_model(
         self,
         distributed_setup=None,
@@ -1206,14 +1156,11 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         if sdpa_method is not None:
             automodel_kwargs["sdpa_method"] = list(OmegaConf.to_container(sdpa_method, resolve=True))
 
-        # Multi-Token Prediction (MTP): native checkpoint heads load normally. For a
-        # checkpoint without one, we add an auxiliary head after loading because we
-        # cannot inject the head's settings through from_pretrained:
-        #   * mtp_hybrid_override_pattern is read ONLY from the HF config, but the base
-        #     config class doesn't declare it, so HF drops it as an unknown kwarg;
-        #   * passing config= collides — NemotronHForCausalLM.__init__ has **kwargs, so
-        #     Automodel's _filter_kwargs_for_init can't strip the positional ``config``.
-        # So we load the LLM normally and then construct + attach the head ourselves.
+        # Multi-Token Prediction (MTP): load the checkpoint config first and add a
+        # missing/replacement head definition before model construction. Automodel can
+        # then initialize, EP/FSDP-shard, activation-checkpoint, and compile the MTP
+        # sublayers together with the backbone. Native checkpoint MTP config is kept by
+        # default; set replace_existing_head=true to use the recipe's head definition.
         mtp_cfg = self.cfg.get("mtp", None)
         mtp_requested = mtp_cfg is not None and mtp_cfg.get("enabled", False)
         mtp_training_mode = str(mtp_cfg.get("training_mode", "joint")) if mtp_requested else "disabled"
@@ -1229,11 +1176,23 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             # THD context (qkv_format/cu_seqlens/seq_idx) from the model forward.
             self._mtp_loss_scaling_factor = float(mtp_cfg.get("loss_scaling_factor", 0.1))
             self._mtp_loss_fn = _build_mtp_loss_fn()
-            if mtp_cfg.get("use_repeated_layer", False):
+            requested_depth = int(mtp_cfg.get("num_nextn_predict_layers", 1))
+            use_repeated_layer = bool(mtp_cfg.get("use_repeated_layer", False))
+            # HF/vLLM exports describe physical layers. A repeated MTP head has one
+            # physical layer even when it performs multiple logical prediction steps.
+            physical_depth = 1 if use_repeated_layer else requested_depth
+            automodel_kwargs["mtp_config_overrides"] = {
+                "num_nextn_predict_layers": physical_depth,
+                "mtp_hybrid_override_pattern": str(mtp_cfg.get("hybrid_override_pattern", "*")),
+                "mtp_layers_block_type": None,
+            }
+            automodel_kwargs["replace_mtp_config"] = bool(mtp_cfg.get("replace_existing_head", False))
+            automodel_kwargs["mtp_loss_scaling_factor"] = self._mtp_loss_scaling_factor
+            if use_repeated_layer:
                 # HF exports contain the physical depth so their state dict has the
                 # same number of layers on reload. Restore the logical iteration count
                 # from the SpeechLM config when constructing that physical head.
-                automodel_kwargs["num_nextn_predict_layers"] = int(mtp_cfg.get("num_nextn_predict_layers", 1))
+                automodel_kwargs["num_nextn_predict_layers"] = requested_depth
                 automodel_kwargs["mtp_use_repeated_layer"] = True
         else:
             # Some checkpoints (including Nemotron-3.5 Lightning) ship a native
@@ -1255,15 +1214,8 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             # actual state dict so conversion/reload does not recreate a missing head.
             self.llm.config.num_nextn_predict_layers = 0
 
-        # Build + attach the MTP head ourselves only when the checkpoint did not
-        # provide one. Native checkpoint MTP modules were already sharded by
-        # Automodel as part of the LLM load and must not be wrapped a second time.
-        mtp_attached_after_load = False
         if mtp_requested and not self._mtp_enabled:
-            self._build_and_attach_mtp_head(mtp_cfg, dtype)
-            mtp_attached_after_load = True
-        if mtp_requested and not self._mtp_enabled:
-            raise RuntimeError("MTP enabled but self.llm.mtp is still None after _build_and_attach_mtp_head.")
+            raise RuntimeError("MTP is enabled but Automodel did not construct an MTP head from the configured model.")
         if not mtp_requested and self._mtp_enabled:
             raise RuntimeError("MTP is disabled but the loaded LLM still has an MTP head attached.")
 
@@ -1318,14 +1270,6 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         if fsdp_mesh.size() > 1:
             self._use_fsdp = True
             self.perception = fully_shard(self.perception, mesh=fsdp_mesh)
-            # A fallback MTP head is attached AFTER the LLM's own FSDP/EP wrapping,
-            # so it is still unsharded. Shard it over the same DP
-            # mesh — otherwise its parameters are replicated and its gradients never
-            # reduce-scatter across the DP group, so each rank would diverge on real
-            # (per-rank-different) data. The default fallback pattern is
-            # attention-only, for which plain FSDP2 over the DP mesh is appropriate.
-            if mtp_attached_after_load:
-                self.llm.mtp = fully_shard(self.llm.mtp, mesh=fsdp_mesh)
 
         # Enable MoE FSDP gradient accumulation optimization.
         # The MoEFSDPSyncMixin on the LLM defers gradient sync/resharding on

--- a/nemo/collections/speechlm2/models/salm_automodel.py
+++ b/nemo/collections/speechlm2/models/salm_automodel.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import re
 import warnings
 from collections import defaultdict
 from contextlib import contextmanager
@@ -359,6 +360,14 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         self._validate_parallelism_compatibility()
         self._configure_moe_aux_loss_scaler()
 
+    def on_validation_start(self) -> None:
+        """Reject unsupported parallel layouts for fit and standalone validation."""
+        self._validate_parallelism_compatibility()
+
+    def on_test_start(self) -> None:
+        """Reject unsupported parallel layouts for standalone testing."""
+        self._validate_parallelism_compatibility()
+
     def _validate_parallelism_compatibility(self) -> None:
         """Raise on known-incompatible THD/CP/backend configurations.
 
@@ -370,11 +379,14 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         from nemo.collections.speechlm2.parts.parallel import validate_parallelism_compatibility
 
         cp_size = 1
+        tp_size = 1
         device_mesh = getattr(self, "_device_mesh", None)
         if device_mesh is not None:
             names = device_mesh.mesh_dim_names or ()
             if "cp" in names:
                 cp_size = device_mesh["cp"].size()
+            if "tp" in names:
+                tp_size = device_mesh["tp"].size()
 
         attn_backend = self.cfg.get("automodel_backend", {}).get("attn", "te")
         nvte_fused_attn = os.environ.get("NVTE_FUSED_ATTN")
@@ -388,10 +400,17 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             device_capability=device_capability,
         )
         mtp_cfg = self.cfg.get("mtp", None)
-        if cp_size > 1 and mtp_cfg is not None and bool(mtp_cfg.get("enabled", False)):
+        mtp_enabled = mtp_cfg is not None and bool(mtp_cfg.get("enabled", False))
+        if cp_size > 1 and mtp_enabled:
             raise ValueError(
                 "SALMAutomodel MTP currently requires cp_size=1. Context parallelism uses an interleaved "
                 "THD partition, so rank-local labels cannot be rolled into correct next-token MTP targets yet."
+            )
+        if tp_size > 1 and mtp_enabled:
+            raise ValueError(
+                "SALMAutomodel MTP currently requires tp_size=1. The MTP head has no tensor-parallel plan, "
+                "and fused MTP loss cannot materialize a TP-sharded LM-head weight with a DP-only "
+                "gradient-reduction group."
             )
 
     def training_step(self, dataloader_iter):
@@ -476,6 +495,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                     model=self.llm,
                     scaling_factor=self._mtp_loss_scaling_factor,
                     num_label_tokens=num_frames_global,
+                    grad_reduce_group=dp_group,
                     cu_seqlens=mtp_cu_seqlens,
                 )
             mtp_loss = dp_size * mtp_loss
@@ -574,12 +594,13 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             if lss_vals:
                 self.log("val_lss", torch.stack(lss_vals).mean(), on_epoch=True, sync_dist=True)
 
-        # Multi-Token Prediction acceptance metrics. Each accumulated per-head count is already
-        # a prefix count: depth k contributes only when the verifier matched every draft through
-        # depth k. Therefore the expected greedy acceptance length is one always-accepted target
-        # token plus the sum of the measured prefix-acceptance probabilities.
+        # Multi-Token Prediction teacher-forced agreement metrics. Each accumulated per-head
+        # count is already a prefix count: depth k contributes only when every draft through
+        # depth k agrees with verifier logits from the ground-truth-conditioned validation
+        # forward. This is a cheap quality proxy, not speculative-decoding acceptance: exact
+        # acceptance requires verifier forwards conditioned on each proposed draft prefix.
         if self._partial_val_mtp_correct:
-            accept_lengths = []
+            agreement_lengths = []
             for name in self._partial_val_mtp_correct:
                 correct = torch.stack(self._partial_val_mtp_correct[name]).sum(dim=0)
                 valid = torch.stack(self._partial_val_mtp_valid[name]).sum(dim=0)
@@ -587,12 +608,24 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                 reduced = self._reduce_validation_metric_sums(torch.cat([correct, valid]), reduction_group)
                 per_head = reduced[:D] / reduced[D:].clamp(min=1)
                 for head_idx, p in enumerate(per_head, start=1):
-                    self.log(f"val_mtp_acc_{name}/head_{head_idx}", p, on_epoch=True, sync_dist=True)
-                accept_length = 1.0 + per_head.sum()
-                self.log(f"val_mtp_accept_length_{name}", accept_length, on_epoch=True, sync_dist=True)
-                accept_lengths.append(accept_length)
-            if accept_lengths:
-                self.log("val_mtp_accept_length", torch.stack(accept_lengths).mean(), on_epoch=True, sync_dist=True)
+                    self.log(
+                        f"val_mtp_teacher_forced_agreement_{name}/head_{head_idx}",
+                        p,
+                        on_epoch=True,
+                        sync_dist=True,
+                    )
+                agreement_length = 1.0 + per_head.sum()
+                self.log(
+                    f"val_mtp_teacher_forced_prefix_length_{name}", agreement_length, on_epoch=True, sync_dist=True
+                )
+                agreement_lengths.append(agreement_length)
+            if agreement_lengths:
+                self.log(
+                    "val_mtp_teacher_forced_prefix_length",
+                    torch.stack(agreement_lengths).mean(),
+                    on_epoch=True,
+                    sync_dist=True,
+                )
 
         self._partial_val_loss_sums.clear()
         self._partial_val_corrects.clear()
@@ -631,14 +664,13 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                     ignore_index=-100,
                 )
 
-            if isinstance(logits, DTensor):
-                logits = logits.full_tensor()
             if self.lss_loss is not None and num_frames > 0:
-                log_probs = torch.nn.functional.log_softmax(logits.float(), dim=-1)
+                lss_logits = logits.full_tensor() if isinstance(logits, DTensor) else logits
+                log_probs = torch.nn.functional.log_softmax(lss_logits.float(), dim=-1)
                 lss_val = self.lss_loss(log_probs=log_probs, labels=inputs["target_ids"])
                 self._partial_val_lss[name].append(lss_val.detach())
 
-            verifier_predictions = logits.argmax(dim=-1)
+            verifier_predictions = _vocab_parallel_argmax(logits)
             preds = verifier_predictions.view(-1)
             refs = inputs["target_ids"].reshape(-1)
             preds = preds[refs != -100]
@@ -649,12 +681,11 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             self._partial_val_corrects[name].append(correct.detach().to(loss_sum.dtype))
             self._partial_val_num_frames[name].append(num_frames.detach().to(loss_sum.dtype))
 
-            # Multi-Token Prediction acceptance: verifier-matched prefix rates for each
-            # depth, accumulated for epoch-end expected-length reporting.
+            # Multi-Token Prediction teacher-forced prefix agreement for each depth.
             mtp_h = forward_outputs.get("mtp_per_depth_h", None)
             if mtp_h is not None:
                 mtp_cu_seqlens = inputs.get("llm_kwargs", {}).get("cu_seqlens")
-                correct_by_head, valid_by_head = _calculate_mtp_acceptance_with_heads(
+                correct_by_head, valid_by_head = _calculate_mtp_teacher_forced_agreement_with_heads(
                     mtp_per_depth_h=mtp_h,
                     labels=inputs["target_ids"],
                     model=self.llm,
@@ -1001,7 +1032,8 @@ class SALMAutomodel(LightningModule, HFHubMixin):
     def _apply_mtp_training_mode(self, training_mode: str) -> None:
         """Apply the optimizer-facing parameter policy for an MTP run.
 
-        ``joint`` preserves the recipe's ordinary freeze policy. ``head_only``
+        ``joint`` preserves the recipe's ordinary freeze policy while making
+        its documented ``llm.mtp`` keep rule wrapper-aware. ``head_only``
         freezes every parameter outside ``llm.mtp`` and guarantees that the
         head wins over any user-supplied ``freeze_params`` expression. The
         latter is intentionally strict: speech encoder, modality adapter,
@@ -1010,23 +1042,38 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         This runs after model/checkpoint setup so loading is unaffected, and
         before Lightning constructs the optimizer.
         """
-        if training_mode != "head_only":
+        if training_mode not in {"joint", "head_only"}:
             return
         if not self._mtp_enabled:
-            raise RuntimeError("MTP training_mode='head_only' requires an attached MTP head.")
+            if training_mode == "head_only":
+                raise RuntimeError("MTP training_mode='head_only' requires an attached MTP head.")
+            return
 
-        mtp_param_ids = {id(param) for param in self.llm.mtp.parameters()}
+        # freeze_and_subset applies recipe regexes when configure_optimizers is
+        # called. Resolve the live module path so wrappers such as torch.compile
+        # (``_orig_mod``), DDP, or PEFT cannot cause a broad ``^llm\\..+$`` rule
+        # to remove the one parameter namespace that head-only mode promises to train.
+        mtp_module = self.llm.mtp
+        mtp_module_name = next((name for name, module in self.named_modules() if module is mtp_module), None)
+        if not mtp_module_name:
+            raise RuntimeError("Could not resolve the attached MTP module's parameter namespace.")
+        keep_pattern = rf"^{re.escape(mtp_module_name)}\..+$"
+        if "prevent_freeze_params" not in self.cfg:
+            self.cfg.prevent_freeze_params = []
+
+        if training_mode == "joint":
+            canonical_keep_pattern = r"^llm\.mtp\..+$"
+            if canonical_keep_pattern in self.cfg.prevent_freeze_params:
+                if keep_pattern not in self.cfg.prevent_freeze_params:
+                    self.cfg.prevent_freeze_params.append(keep_pattern)
+            return
+
+        mtp_param_ids = {id(param) for param in mtp_module.parameters()}
         if not mtp_param_ids:
             raise RuntimeError("MTP training_mode='head_only' found an MTP module with no parameters.")
         for param in self.parameters():
             param.requires_grad_(id(param) in mtp_param_ids)
 
-        # freeze_and_subset applies recipe regexes when configure_optimizers is
-        # called. Ensure broad expressions such as '^llm\\..+$' cannot remove
-        # the one parameter namespace that head-only mode promises to train.
-        keep_pattern = r"^llm\.mtp\..+$"
-        if "prevent_freeze_params" not in self.cfg:
-            self.cfg.prevent_freeze_params = []
         if keep_pattern not in self.cfg.prevent_freeze_params:
             self.cfg.prevent_freeze_params.append(keep_pattern)
 
@@ -1051,14 +1098,18 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         llm = self.llm
         cfg_obj = llm.config
         cfg_obj.mtp_hybrid_override_pattern = str(mtp_cfg.get("hybrid_override_pattern", "*"))
-        # Persist depth count on the HF config so save_llm_backbone_config()
-        # writes a config.json that vLLM can use to instantiate MTP heads.
-        cfg_obj.num_nextn_predict_layers = int(mtp_cfg.get("num_nextn_predict_layers", 1))
+        requested_depth = int(mtp_cfg.get("num_nextn_predict_layers", 1))
+        cfg_obj.num_nextn_predict_layers = requested_depth
         mtp_config = build_mtp_config_from_hf(
             cfg_obj,
             loss_scaling_factor=self._mtp_loss_scaling_factor,
             use_repeated_layer=bool(mtp_cfg.get("use_repeated_layer", False)),
         )
+        # HF/vLLM config has no weight-tying flag for repeated MTP layers. Export
+        # the physical depth so reload constructs exactly the layers present in
+        # the state dict instead of D independent layers for one tied layer.
+        cfg_obj.num_nextn_predict_layers = mtp_config.num_physical_depths
+
         llm.mtp_config = mtp_config
         mtp = build_nemotron_v3_mtp(
             cfg_obj,
@@ -1070,7 +1121,10 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         device = (
             torch.device("cuda", torch.cuda.current_device()) if torch.cuda.is_available() else torch.device("cpu")
         )
-        llm.mtp = mtp.to(device=device, dtype=dtype)
+        mtp = mtp.to(device=device, dtype=dtype)
+        for sublayer in mtp.layers:
+            sublayer.init_weights(buffer_device=device)
+        llm.mtp = mtp
         warnings.warn(
             f"MTP head attached (unsharded): num_layers={mtp_config.num_layers} "
             f"pattern={cfg_obj.mtp_hybrid_override_pattern!r}"
@@ -1174,12 +1228,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             # boundaries (see training_step); the MTP sublayers already get the
             # THD context (qkv_format/cu_seqlens/seq_idx) from the model forward.
             self._mtp_loss_scaling_factor = float(mtp_cfg.get("loss_scaling_factor", 0.1))
-            # Fuse the shared LM projection with CE so each MTP depth does not materialize
-            # a full [tokens, vocab] logits tensor. reduction="sum" lets the helper
-            # normalize by the global labeled-token count.
-            from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
-
-            self._mtp_loss_fn = FusedLinearCrossEntropy(reduction="sum")
+            self._mtp_loss_fn = _build_mtp_loss_fn()
         else:
             # Some checkpoints (including Nemotron-3.5 Lightning) ship a native
             # MTP head in config.json. Explicitly override its depth to zero so
@@ -1314,6 +1363,28 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         }
 
 
+def _build_mtp_loss_fn() -> torch.nn.Module:
+    """Select the memory-efficient MTP loss with an optional-dependency fallback."""
+    from nemo_automodel.components.loss import linear_ce
+
+    if linear_ce.HAVE_CUT_CROSS_ENTROPY:
+        # Fuse the shared LM projection with CE so each MTP depth does not materialize
+        # a full [tokens, vocab] logits tensor. reduction="sum" lets the helper
+        # normalize by the global labeled-token count.
+        return linear_ce.FusedLinearCrossEntropy(reduction="sum")
+
+    # cut-cross-entropy is optional in Automodel and is absent from existing NeMo
+    # Speech containers. Retain the pre-fused compatibility path so enabling MTP
+    # does not introduce a new undeclared runtime requirement.
+    from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
+
+    logging.warning(
+        "cut_cross_entropy is unavailable; falling back to the unfused MTP loss. "
+        "Install cut-cross-entropy to reduce peak MTP loss memory."
+    )
+    return MaskedCrossEntropy(reduction="sum", fp32_upcast=False)
+
+
 def _calculate_mtp_loss_with_heads(
     loss_fn,
     *,
@@ -1323,6 +1394,7 @@ def _calculate_mtp_loss_with_heads(
     model: torch.nn.Module,
     scaling_factor: float = 0.1,
     num_label_tokens: torch.Tensor | None = None,
+    grad_reduce_group: dist.ProcessGroup | None = None,
     ignore_index: int = -100,
     cu_seqlens: torch.Tensor | None = None,
     seq_idx: torch.Tensor | None = None,
@@ -1365,7 +1437,11 @@ def _calculate_mtp_loss_with_heads(
         lm_weight = lm_head.weight
         if isinstance(lm_weight, DTensor):
             materialize = getattr(loss_fn, "materialize_lm_weight", None)
-            lm_weight = materialize(lm_weight) if materialize is not None else lm_weight.full_tensor()
+            lm_weight = (
+                materialize(lm_weight, grad_reduce_group=grad_reduce_group)
+                if materialize is not None
+                else lm_weight.full_tensor()
+            )
 
     if seq_idx is None and cu_seqlens is not None:
         cs = cu_seqlens
@@ -1417,6 +1493,7 @@ def _calculate_mtp_loss_with_heads(
                 model=model,
                 lm_weight=lm_weight,
                 num_label_tokens=num_label_tokens,
+                grad_reduce_group=grad_reduce_group,
             )
         else:
             lm_head = _get_lm_head_module(model)
@@ -1438,7 +1515,20 @@ def _calculate_mtp_loss_with_heads(
     return total, head_losses, raw_head_losses
 
 
-def _calculate_mtp_acceptance_with_heads(
+def _vocab_parallel_argmax(logits: torch.Tensor) -> torch.Tensor:
+    """Return global vocabulary argmax IDs without gathering full logits.
+
+    PyTorch's DTensor argmax handler reduces sharded maxima and their global
+    indices across the vocabulary mesh. Materialize only the resulting token-ID
+    tensor, whose vocabulary dimension has already been removed.
+    """
+    predictions = logits.argmax(dim=-1)
+    if isinstance(predictions, DTensor):
+        predictions = predictions.full_tensor()
+    return predictions
+
+
+def _calculate_mtp_teacher_forced_agreement_with_heads(
     *,
     mtp_per_depth_h: list[torch.Tensor],
     labels: torch.Tensor,
@@ -1448,13 +1538,15 @@ def _calculate_mtp_acceptance_with_heads(
     cu_seqlens: torch.Tensor | None = None,
     seq_idx: torch.Tensor | None = None,
 ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
-    """Per-head MTP token-acceptance counts for validation.
+    """Per-head teacher-forced MTP/verifier agreement counts for validation.
 
     For each MTP depth ``k`` the head's argmax prediction is compared with the
-    verifier's prediction for the same future position. Counts are prefix-based:
-    depth ``k`` is accepted only when every draft through ``k`` matches. The same
-    rolled/masked labels as the MTP loss define eligible validation positions,
-    including cross-sequence masking under packed THD.
+    verifier's prediction for the same future position from the validation
+    forward conditioned on ground-truth tokens. Counts are prefix-based: depth
+    ``k`` agrees only when every draft through ``k`` matches. This must not be
+    reported as speculative-decoding acceptance, which requires verifier logits
+    conditioned on the proposed draft prefix. The same rolled/masked labels as
+    the MTP loss define eligible positions, including packed-THD boundaries.
     """
     from nemo_automodel.components.loss.utils import _get_lm_head_module
     from nemo_automodel.components.models.common.mtp import roll_tensor
@@ -1500,9 +1592,7 @@ def _calculate_mtp_acceptance_with_heads(
             masked = torch.where(rolled_seq_idx != seq_idx, torch.full_like(masked, ignore_index), masked)
 
         logits = lm_head(mtp_output)
-        if isinstance(logits, DTensor):
-            logits = logits.full_tensor()
-        preds = logits.argmax(dim=-1)
+        preds = _vocab_parallel_argmax(logits)
         valid = masked != ignore_index
         verifier_for_depth = roll_tensor(verifier_predictions, shifts=-(k + 1), dim=-1)
         prefix_valid = prefix_valid & valid

--- a/nemo/collections/speechlm2/models/salm_automodel.py
+++ b/nemo/collections/speechlm2/models/salm_automodel.py
@@ -1229,6 +1229,12 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             # THD context (qkv_format/cu_seqlens/seq_idx) from the model forward.
             self._mtp_loss_scaling_factor = float(mtp_cfg.get("loss_scaling_factor", 0.1))
             self._mtp_loss_fn = _build_mtp_loss_fn()
+            if mtp_cfg.get("use_repeated_layer", False):
+                # HF exports contain the physical depth so their state dict has the
+                # same number of layers on reload. Restore the logical iteration count
+                # from the SpeechLM config when constructing that physical head.
+                automodel_kwargs["num_nextn_predict_layers"] = int(mtp_cfg.get("num_nextn_predict_layers", 1))
+                automodel_kwargs["mtp_use_repeated_layer"] = True
         else:
             # Some checkpoints (including Nemotron-3.5 Lightning) ship a native
             # MTP head in config.json. Explicitly override its depth to zero so
@@ -1367,7 +1373,8 @@ def _build_mtp_loss_fn() -> torch.nn.Module:
     """Select the memory-efficient MTP loss with an optional-dependency fallback."""
     from nemo_automodel.components.loss import linear_ce
 
-    if linear_ce.HAVE_CUT_CROSS_ENTROPY:
+    gradient_safe_fused_api = callable(getattr(linear_ce.FusedLinearCrossEntropy, "materialize_lm_weight", None))
+    if linear_ce.HAVE_CUT_CROSS_ENTROPY and gradient_safe_fused_api:
         # Fuse the shared LM projection with CE so each MTP depth does not materialize
         # a full [tokens, vocab] logits tensor. reduction="sum" lets the helper
         # normalize by the global labeled-token count.
@@ -1378,10 +1385,16 @@ def _build_mtp_loss_fn() -> torch.nn.Module:
     # does not introduce a new undeclared runtime requirement.
     from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
 
-    logging.warning(
-        "cut_cross_entropy is unavailable; falling back to the unfused MTP loss. "
-        "Install cut-cross-entropy to reduce peak MTP loss memory."
-    )
+    if linear_ce.HAVE_CUT_CROSS_ENTROPY:
+        logging.warning(
+            "The installed Automodel lacks gradient-safe sharded LM-head materialization; "
+            "falling back to the unfused MTP loss. Upgrade Automodel to enable fused MTP loss."
+        )
+    else:
+        logging.warning(
+            "cut_cross_entropy is unavailable; falling back to the unfused MTP loss. "
+            "Install cut-cross-entropy to reduce peak MTP loss memory."
+        )
     return MaskedCrossEntropy(reduction="sum", fp32_upcast=False)
 
 
@@ -1437,11 +1450,11 @@ def _calculate_mtp_loss_with_heads(
         lm_weight = lm_head.weight
         if isinstance(lm_weight, DTensor):
             materialize = getattr(loss_fn, "materialize_lm_weight", None)
-            lm_weight = (
-                materialize(lm_weight, grad_reduce_group=grad_reduce_group)
-                if materialize is not None
-                else lm_weight.full_tensor()
-            )
+            if not callable(materialize):
+                raise RuntimeError(
+                    "Fused MTP loss requires Automodel's gradient-safe materialize_lm_weight API for DTensor weights"
+                )
+            lm_weight = materialize(lm_weight, grad_reduce_group=grad_reduce_group)
 
     if seq_idx is None and cu_seqlens is not None:
         cs = cu_seqlens

--- a/nemo/collections/speechlm2/models/salm_automodel.py
+++ b/nemo/collections/speechlm2/models/salm_automodel.py
@@ -19,7 +19,6 @@ from typing import Any
 import torch
 import torch.distributed as dist
 from lightning import LightningModule
-from nemo_automodel.components.loss.mtp import MTPLossOutput, calculate_mtp_loss
 from omegaconf import DictConfig, OmegaConf
 from torch import Tensor
 from torch.distributed.fsdp import fully_shard
@@ -36,6 +35,7 @@ from nemo.collections.speechlm2.parts.encoder_chunking import encode_audio_with_
 from nemo.collections.speechlm2.parts.hf_hub import HFHubMixin
 from nemo.collections.speechlm2.parts.mtp import (
     build_mtp_loss_fn,
+    calculate_mtp_loss_with_per_depth,
     calculate_mtp_teacher_forced_agreement,
     compute_mtp_agreement_lengths,
     mtp_validation_forward,
@@ -508,7 +508,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                 None if mtp_per_depth_targets is not None else inputs.get("llm_kwargs", {}).get("cu_seqlens")
             )
             with loss_parallel():
-                mtp_loss_output = calculate_mtp_loss(
+                mtp_loss_output = calculate_mtp_loss_with_per_depth(
                     self._mtp_loss_fn,
                     mtp_per_depth_targets=mtp_per_depth_targets,
                     mtp_per_depth_h=mtp_h,
@@ -520,8 +520,6 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                     cu_seqlens=mtp_cu_seqlens,
                     return_per_depth=True,
                 )
-                if not isinstance(mtp_loss_output, MTPLossOutput):
-                    raise TypeError("Automodel did not return the requested per-depth MTP loss output")
                 mtp_loss = mtp_loss_output.loss
                 mtp_raw_loss_by_head = mtp_loss_output.per_depth_losses
             mtp_loss = dp_size * mtp_loss

--- a/nemo/collections/speechlm2/models/salm_automodel.py
+++ b/nemo/collections/speechlm2/models/salm_automodel.py
@@ -201,9 +201,9 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             ans = {"logits": out['logits']}  # (B, T, text_vocab_size)
             if cache is not None:
                 ans["cache"] = out["past_key_values"]
-            # MTP per-depth hidden states (present only when the LLM has an MTP head and
-            # is in training mode). Use getattr rather than out['mtp_per_depth_h'] to avoid
-            # a KeyError when the field is absent.
+            # MTP per-depth hidden states are returned when an MTP head is attached and
+            # MTP computation is enabled for this forward (during training or explicitly
+            # during validation).
             mtp_h = getattr(out, "mtp_per_depth_h", None)
             if mtp_h is not None:
                 ans["mtp_per_depth_h"] = mtp_h
@@ -606,7 +606,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                 valid = torch.stack(self._partial_val_mtp_valid[name]).sum(dim=0)
                 D = correct.numel()
                 reduced = self._reduce_validation_metric_sums(torch.cat([correct, valid]), reduction_group)
-                per_head = reduced[:D] / reduced[D:].clamp(min=1)
+                per_head = reduced[:D].float() / reduced[D:].clamp(min=1).float()
                 for head_idx, p in enumerate(per_head, start=1):
                     self.log(
                         f"val_mtp_teacher_forced_agreement_{name}/head_{head_idx}",
@@ -692,8 +692,8 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                     verifier_predictions=verifier_predictions,
                     cu_seqlens=mtp_cu_seqlens,
                 )
-                self._partial_val_mtp_correct[name].append(torch.stack(correct_by_head).detach().to(loss_sum.dtype))
-                self._partial_val_mtp_valid[name].append(torch.stack(valid_by_head).detach().to(loss_sum.dtype))
+                self._partial_val_mtp_correct[name].append(torch.stack(correct_by_head).detach().to(torch.int64))
+                self._partial_val_mtp_valid[name].append(torch.stack(valid_by_head).detach().to(torch.int64))
 
     def on_test_epoch_start(self) -> None:
         return self.on_validation_epoch_start()

--- a/nemo/collections/speechlm2/models/salm_automodel.py
+++ b/nemo/collections/speechlm2/models/salm_automodel.py
@@ -42,6 +42,7 @@ from nemo.collections.speechlm2.parts.pretrained import (
 )
 from nemo.core.neural_types import AudioSignal, LabelsType, LengthsType, MaskType, NeuralType
 from nemo.core.utils.lightning_utils import read_batch
+from nemo.utils import logging
 
 
 class SALMAutomodel(LightningModule, HFHubMixin):
@@ -85,6 +86,11 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             if p is not None:
                 return p._local_tensor.device if isinstance(p, DTensor) else p.device
         return super().device
+
+    @property
+    def _mtp_enabled(self) -> bool:
+        """True when the MTP head is attached, regardless of how the model was loaded."""
+        return getattr(getattr(self, "llm", None), "mtp", None) is not None
 
     @property
     def embed_tokens(self):
@@ -193,6 +199,12 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             ans = {"logits": out['logits']}  # (B, T, text_vocab_size)
             if cache is not None:
                 ans["cache"] = out["past_key_values"]
+            # MTP per-depth hidden states (present only when the LLM has an MTP head and
+            # is in training mode). Use getattr rather than out['mtp_per_depth_h'] to avoid
+            # a KeyError when the field is absent.
+            mtp_h = getattr(out, "mtp_per_depth_h", None)
+            if mtp_h is not None:
+                ans["mtp_per_depth_h"] = mtp_h
         return ans
 
     def _uses_parallel_expert_encoder(self) -> bool:
@@ -436,6 +448,39 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         with torch.no_grad():
             loss_display = loss_sum.detach() / num_frames.clamp(min=1)
 
+        # Multi-Token Prediction auxiliary loss. Compute the aggregate and per-head losses
+        # in one pass so WandB can show each MTP depth without repeating the expensive
+        # lm_head + CE work. ``mtp_loss`` keeps the same meaning as before: the weighted
+        # auxiliary loss added to the training objective after the DP-size correction.
+        mtp_metrics = {}
+        mtp_h = forward_outputs.get("mtp_per_depth_h", None)
+        if mtp_h is not None:
+            # Under packed THD multiple utterances share one token stream, so the
+            # per-depth label roll must not predict the next sequence's first token
+            # from the current sequence's last token. Pass cu_seqlens (empty/None for
+            # BSHD, where each row is already a single sequence) so the loss derives
+            # seq_idx and masks cross-sequence targets.
+            mtp_cu_seqlens = inputs.get("llm_kwargs", {}).get("cu_seqlens")
+            with loss_parallel():
+                mtp_loss, mtp_loss_by_head, mtp_raw_loss_by_head = _calculate_mtp_loss_with_heads(
+                    self._mtp_loss_fn,
+                    mtp_per_depth_h=mtp_h,
+                    labels=inputs["target_ids"],
+                    model=self.llm,
+                    scaling_factor=self._mtp_loss_scaling_factor,
+                    num_label_tokens=num_frames_global,
+                    cu_seqlens=mtp_cu_seqlens,
+                )
+            mtp_loss = dp_size * mtp_loss
+            mtp_loss_by_head = [dp_size * head_loss for head_loss in mtp_loss_by_head]
+            mtp_raw_loss_by_head = [dp_size * head_loss for head_loss in mtp_raw_loss_by_head]
+            loss = loss + mtp_loss
+            mtp_metrics["mtp_loss"] = mtp_loss.detach()
+            for head_idx, head_loss in enumerate(mtp_loss_by_head, start=1):
+                mtp_metrics[f"mtp_loss/head_{head_idx}"] = head_loss.detach()
+            for head_idx, head_loss in enumerate(mtp_raw_loss_by_head, start=1):
+                mtp_metrics[f"mtp_loss_unscaled/head_{head_idx}"] = head_loss.detach()
+
         # Input embeds shape is (B, T, H) for BSHD or (T, H) for THD packed.
         input_embeds = inputs["input_embeds"]
         if input_embeds.dim() == 2:
@@ -457,6 +502,9 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         # batch_size kwarg is required by Lightning when training_step uses
         # the ``dataloader_iter`` signature (it can't auto-infer otherwise).
         self.log("loss", loss_display, on_step=True, prog_bar=True, batch_size=B)
+        if mtp_metrics:
+            self.log("mtp_loss", mtp_metrics.pop("mtp_loss"), on_step=True, prog_bar=True, batch_size=B)
+            self.log_dict(mtp_metrics, on_step=True, batch_size=B)
         self.log_dict({k: v for k, v in ans.items() if k != "loss"}, on_step=True, batch_size=B)
         self.maybe_log_moe_metrics(batch_idx)
         return ans
@@ -483,6 +531,8 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         self._partial_val_corrects = defaultdict(list)
         self._partial_val_num_frames = defaultdict(list)
         self._partial_val_lss = defaultdict(list)
+        self._partial_val_mtp_correct = defaultdict(list)
+        self._partial_val_mtp_valid = defaultdict(list)
 
     def on_validation_epoch_end(self) -> None:
         val_losses = []
@@ -517,10 +567,32 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             if lss_vals:
                 self.log("val_lss", torch.stack(lss_vals).mean(), on_epoch=True, sync_dist=True)
 
+        # Multi-Token Prediction acceptance metrics: per-head acceptance probability and the
+        # expected acceptance length (number of tokens a greedy verifier would accept, i.e. the
+        # always-accepted main-head token plus the cumulative product of each MTP head's accept
+        # probability). Per-head marginal rates approximate the conditional accept probabilities.
+        if self._partial_val_mtp_correct:
+            accept_lengths = []
+            for name in self._partial_val_mtp_correct:
+                correct = torch.stack(self._partial_val_mtp_correct[name]).sum(dim=0)
+                valid = torch.stack(self._partial_val_mtp_valid[name]).sum(dim=0)
+                D = correct.numel()
+                reduced = self._reduce_validation_metric_sums(torch.cat([correct, valid]), reduction_group)
+                per_head = reduced[:D] / reduced[D:].clamp(min=1)
+                for head_idx, p in enumerate(per_head, start=1):
+                    self.log(f"val_mtp_acc_{name}/head_{head_idx}", p, on_epoch=True, sync_dist=True)
+                accept_length = 1.0 + torch.cumprod(per_head, dim=0).sum()
+                self.log(f"val_mtp_accept_length_{name}", accept_length, on_epoch=True, sync_dist=True)
+                accept_lengths.append(accept_length)
+            if accept_lengths:
+                self.log("val_mtp_accept_length", torch.stack(accept_lengths).mean(), on_epoch=True, sync_dist=True)
+
         self._partial_val_loss_sums.clear()
         self._partial_val_corrects.clear()
         self._partial_val_num_frames.clear()
         self._partial_val_lss.clear()
+        self._partial_val_mtp_correct.clear()
+        self._partial_val_mtp_valid.clear()
 
     def _reduce_validation_metric_sums(self, metric_sums: Tensor, group) -> Tensor:
         if group is not None and dist.is_available() and dist.is_initialized():
@@ -533,11 +605,32 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             if dataset_batch is None:
                 continue  # some dataset is exhausted
             inputs = self.prepare_inputs(dataset_batch)
-            forward_outputs = self(
-                inputs["input_embeds"],
-                attention_mask=inputs["attention_mask"],
-                **inputs.get("llm_kwargs", {}),
-            )
+            # Enable the MTP heads under eval so we can measure per-head token
+            # acceptance during validation; the LLM gates them on self.training
+            # otherwise. Restored immediately so generation stays unaffected.
+            # ``hasattr`` (not ``getattr(..., None)``) so we can distinguish "LLM
+            # doesn't support eval-mode MTP" from the normal False default and warn
+            # once — otherwise the acceptance metrics silently never appear.
+            _mtp_eval_supported = hasattr(self.llm, "compute_mtp_in_eval")
+            if not _mtp_eval_supported and self._mtp_enabled and not getattr(self, "_warned_no_mtp_eval", False):
+                logging.warning(
+                    "MTP is enabled but the LLM has no `compute_mtp_in_eval` attribute, so validation "
+                    "will not report MTP acceptance metrics. Upgrade nemo_automodel to a revision that "
+                    "supports eval-mode MTP (the heads are gated on `self.training` otherwise)."
+                )
+                self._warned_no_mtp_eval = True
+            if _mtp_eval_supported:
+                _prev_mtp_eval = self.llm.compute_mtp_in_eval
+                self.llm.compute_mtp_in_eval = True
+            try:
+                forward_outputs = self(
+                    inputs["input_embeds"],
+                    attention_mask=inputs["attention_mask"],
+                    **inputs.get("llm_kwargs", {}),
+                )
+            finally:
+                if _mtp_eval_supported:
+                    self.llm.compute_mtp_in_eval = _prev_mtp_eval
             num_frames = (inputs["target_ids"] != -100).long().sum()
             with loss_parallel():
                 logits = forward_outputs["logits"]
@@ -564,6 +657,20 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             self._partial_val_loss_sums[name].append(loss_sum.detach())
             self._partial_val_corrects[name].append(correct.detach().to(loss_sum.dtype))
             self._partial_val_num_frames[name].append(num_frames.detach().to(loss_sum.dtype))
+
+            # Multi-Token Prediction acceptance: per-head match rate of each MTP head's
+            # argmax against the token it predicts, accumulated for epoch-end reporting.
+            mtp_h = forward_outputs.get("mtp_per_depth_h", None)
+            if mtp_h is not None:
+                mtp_cu_seqlens = inputs.get("llm_kwargs", {}).get("cu_seqlens")
+                correct_by_head, valid_by_head = _calculate_mtp_acceptance_with_heads(
+                    mtp_per_depth_h=mtp_h,
+                    labels=inputs["target_ids"],
+                    model=self.llm,
+                    cu_seqlens=mtp_cu_seqlens,
+                )
+                self._partial_val_mtp_correct[name].append(torch.stack(correct_by_head).detach().to(loss_sum.dtype))
+                self._partial_val_mtp_valid[name].append(torch.stack(valid_by_head).detach().to(loss_sum.dtype))
 
     def on_test_epoch_start(self) -> None:
         return self.on_validation_epoch_start()
@@ -899,6 +1006,49 @@ class SALMAutomodel(LightningModule, HFHubMixin):
     def configure_optimizers(self):
         return configure_optimizers(self)
 
+    def _build_and_attach_mtp_head(self, mtp_cfg, dtype) -> None:
+        """Construct the NemotronV3 MTP head and attach it as ``self.llm.mtp``.
+
+        This fallback is used only when the selected checkpoint has no native MTP
+        module. Neither the config override nor the ``config=`` from_pretrained
+        path can inject a pattern for that case, so we set it on the live HF
+        config, build the head with Automodel's factory, and attach freshly
+        initialized weights.
+
+        NOTE: the head is built unsharded here; ``configure_model`` then ``fully_shard``s it
+        over the DP mesh (right after the perception module) so its gradients reduce-scatter
+        across the data-parallel group like every other parameter.
+        """
+        from nemo_automodel.components.models.nemotron_v3.mtp import build_mtp_config_from_hf, build_nemotron_v3_mtp
+
+        llm = self.llm
+        cfg_obj = llm.config
+        cfg_obj.mtp_hybrid_override_pattern = str(mtp_cfg.get("hybrid_override_pattern", "*"))
+        # Persist depth count on the HF config so save_llm_backbone_config()
+        # writes a config.json that vLLM can use to instantiate MTP heads.
+        cfg_obj.num_nextn_predict_layers = int(mtp_cfg.get("num_nextn_predict_layers", 1))
+        mtp_config = build_mtp_config_from_hf(
+            cfg_obj,
+            loss_scaling_factor=self._mtp_loss_scaling_factor,
+            use_repeated_layer=bool(mtp_cfg.get("use_repeated_layer", False)),
+        )
+        llm.mtp_config = mtp_config
+        mtp = build_nemotron_v3_mtp(
+            cfg_obj,
+            mtp_config=mtp_config,
+            backend=llm.backend,
+            moe_config=llm.model.moe_config,
+            dtype=dtype,
+        )
+        device = (
+            torch.device("cuda", torch.cuda.current_device()) if torch.cuda.is_available() else torch.device("cpu")
+        )
+        llm.mtp = mtp.to(device=device, dtype=dtype)
+        warnings.warn(
+            f"MTP head attached (unsharded): num_layers={mtp_config.num_layers} "
+            f"pattern={cfg_obj.mtp_hybrid_override_pattern!r}"
+        )
+
     def configure_model(
         self,
         distributed_setup=None,
@@ -975,6 +1125,34 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         if sdpa_method is not None:
             automodel_kwargs["sdpa_method"] = list(OmegaConf.to_container(sdpa_method, resolve=True))
 
+        # Multi-Token Prediction (MTP): native checkpoint heads load normally. For a
+        # checkpoint without one, we add an auxiliary head after loading because we
+        # cannot inject the head's settings through from_pretrained:
+        #   * mtp_hybrid_override_pattern is read ONLY from the HF config, but the base
+        #     config class doesn't declare it, so HF drops it as an unknown kwarg;
+        #   * passing config= collides — NemotronHForCausalLM.__init__ has **kwargs, so
+        #     Automodel's _filter_kwargs_for_init can't strip the positional ``config``.
+        # So we load the LLM normally and then construct + attach the head ourselves.
+        mtp_cfg = self.cfg.get("mtp", None)
+        mtp_requested = mtp_cfg is not None and mtp_cfg.get("enabled", False)
+        if mtp_requested:
+            # MTP supports both BSHD and packed THD. For THD the MTP loss must
+            # receive cu_seqlens so target rolling is masked at packed sequence
+            # boundaries (see training_step); the MTP sublayers already get the
+            # THD context (qkv_format/cu_seqlens/seq_idx) from the model forward.
+            self._mtp_loss_scaling_factor = float(mtp_cfg.get("loss_scaling_factor", 0.1))
+            # Same per-token loss class the Automodel recipe uses for MTP; reduction="sum"
+            # so calculate_mtp_loss can normalize by our global token count.
+            from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
+
+            self._mtp_loss_fn = MaskedCrossEntropy(reduction="sum", fp32_upcast=False)
+        else:
+            # Some checkpoints (including Nemotron-3.5 Lightning) ship a native
+            # MTP head in config.json. Explicitly override its depth to zero so
+            # users who omit the block or set ``mtp.enabled: false`` do not pay
+            # the MTP memory/compute cost during SpeechLM fine-tuning.
+            automodel_kwargs["num_nextn_predict_layers"] = 0
+
         self.llm = load_pretrained_automodel_llm(
             self.cfg.pretrained_llm,
             pretrained_weights=pretrained_llm_weights,
@@ -982,6 +1160,18 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             trust_remote_code=self.cfg.get("trust_remote_code", False),
             **automodel_kwargs,
         )
+
+        # Build + attach the MTP head ourselves only when the checkpoint did not
+        # provide one. Native checkpoint MTP modules were already sharded by
+        # Automodel as part of the LLM load and must not be wrapped a second time.
+        mtp_attached_after_load = False
+        if mtp_requested and not self._mtp_enabled:
+            self._build_and_attach_mtp_head(mtp_cfg, dtype)
+            mtp_attached_after_load = True
+        if mtp_requested and not self._mtp_enabled:
+            raise RuntimeError("MTP enabled but self.llm.mtp is still None after _build_and_attach_mtp_head.")
+        if not mtp_requested and self._mtp_enabled:
+            raise RuntimeError("MTP is disabled but the loaded LLM still has an MTP head attached.")
 
         # Apply MoE options (aux_loss_coeff override, load balance tracking)
         self.setup_moe_options()
@@ -1033,6 +1223,14 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         if fsdp_mesh.size() > 1:
             self._use_fsdp = True
             self.perception = fully_shard(self.perception, mesh=fsdp_mesh)
+            # A fallback MTP head is attached AFTER the LLM's own FSDP/EP wrapping,
+            # so it is still unsharded. Shard it over the same DP
+            # mesh — otherwise its parameters are replicated and its gradients never
+            # reduce-scatter across the DP group, so each rank would diverge on real
+            # (per-rank-different) data. The default fallback pattern is
+            # attention-only, for which plain FSDP2 over the DP mesh is appropriate.
+            if mtp_attached_after_load:
+                self.llm.mtp = fully_shard(self.llm.mtp, mesh=fsdp_mesh)
 
         # Enable MoE FSDP gradient accumulation optimization.
         # The MoEFSDPSyncMixin on the LLM defers gradient sync/resharding on
@@ -1072,3 +1270,176 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                 {"name": "loss_mask", "type": NeuralType(("B", "T"), MaskType()), "seq_length": "output"},
             ],
         }
+
+
+def _calculate_mtp_loss_with_heads(
+    loss_fn,
+    *,
+    mtp_per_depth_h: list[torch.Tensor] | None = None,
+    mtp_per_depth_logits: list[torch.Tensor] | None = None,
+    labels: torch.Tensor,
+    model: torch.nn.Module,
+    scaling_factor: float = 0.1,
+    num_label_tokens: torch.Tensor | None = None,
+    ignore_index: int = -100,
+    cu_seqlens: torch.Tensor | None = None,
+    seq_idx: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, list[torch.Tensor], list[torch.Tensor]]:
+    """Compute aggregate MTP loss and per-head losses for logging.
+
+    This mirrors Automodel's ``calculate_mtp_loss`` but keeps the intermediate
+    depth losses so Lightning/WandB can display each MTP head. Returned
+    ``head_losses`` are the weighted contributions that sum to ``total``;
+    returned ``raw_head_losses`` are normalized CE values before applying
+    ``scaling_factor / D``. The caller applies the same DP correction used by
+    the main training loss.
+    """
+    from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
+    from nemo_automodel.components.loss.utils import _get_lm_head_module, calculate_loss
+    from nemo_automodel.components.models.common.mtp import roll_tensor
+
+    if (mtp_per_depth_h is None) == (mtp_per_depth_logits is None):
+        raise ValueError("Provide exactly one of mtp_per_depth_h or mtp_per_depth_logits")
+
+    mtp_outputs = mtp_per_depth_logits if mtp_per_depth_logits is not None else mtp_per_depth_h
+
+    if labels.dim() == 1:
+        mtp_outputs = [h.squeeze(0) if (h.dim() == 3 and h.shape[0] == 1) else h for h in mtp_outputs]
+
+    D = len(mtp_outputs)
+    cur_labels = labels
+    total = mtp_outputs[0].new_zeros(())
+    head_losses = []
+    raw_head_losses = []
+
+    if seq_idx is None and cu_seqlens is not None:
+        cs = cu_seqlens
+        if cs.dim() == 2 and cs.shape[0] == 1:
+            cs = cs.squeeze(0)
+        if cs.dim() == 1:
+            total_len = labels.shape[-1]
+            positions = torch.arange(total_len, device=labels.device)
+            seq_idx = torch.searchsorted(cs[1:].contiguous(), positions, right=True)
+            if labels.dim() == 2:
+                seq_idx = seq_idx.unsqueeze(0).expand(labels.shape[0], -1)
+    elif seq_idx is not None:
+        if seq_idx.dim() == 1 and labels.dim() == 2:
+            seq_idx = seq_idx.unsqueeze(0).expand(labels.shape[0], -1)
+        elif seq_idx.dim() == 2 and labels.dim() == 1 and seq_idx.shape[0] == 1:
+            seq_idx = seq_idx.squeeze(0)
+        if seq_idx.shape != labels.shape:
+            raise ValueError(
+                f"_calculate_mtp_loss_with_heads: seq_idx.shape={tuple(seq_idx.shape)} does not "
+                f"match labels.shape={tuple(labels.shape)}"
+            )
+
+    for k, mtp_output in enumerate(mtp_outputs):
+        cur_labels = roll_tensor(cur_labels, shifts=-1, dim=-1)
+        masked = cur_labels.clone()
+        n_invalid = min(k + 1, masked.shape[-1])
+        masked[..., -n_invalid:] = ignore_index
+
+        if seq_idx is not None:
+            rolled_seq_idx = roll_tensor(seq_idx, shifts=-(k + 1), dim=-1)
+            cross_seq = rolled_seq_idx != seq_idx
+            masked = torch.where(cross_seq, torch.full_like(masked, ignore_index), masked)
+
+        if mtp_per_depth_logits is not None:
+            if isinstance(loss_fn, FusedLinearCrossEntropy):
+                raise ValueError("MTP logits are incompatible with FusedLinearCrossEntropy")
+            depth_loss = calculate_loss(
+                loss_fn,
+                logits=mtp_output,
+                labels=masked,
+                model=model,
+                num_label_tokens=num_label_tokens,
+            )
+        elif isinstance(loss_fn, FusedLinearCrossEntropy):
+            depth_loss = calculate_loss(
+                loss_fn,
+                hidden_states=mtp_output,
+                labels=masked,
+                model=model,
+                num_label_tokens=num_label_tokens,
+            )
+        else:
+            lm_head = _get_lm_head_module(model)
+            if lm_head is None:
+                raise ValueError("lm_head module not found in model")
+            depth_loss = calculate_loss(
+                loss_fn,
+                logits=lm_head(mtp_output),
+                labels=masked,
+                model=model,
+                num_label_tokens=num_label_tokens,
+            )
+
+        raw_head_losses.append(depth_loss)
+        head_loss = depth_loss * (scaling_factor / D)
+        head_losses.append(head_loss)
+        total = total + head_loss
+
+    return total, head_losses, raw_head_losses
+
+
+def _calculate_mtp_acceptance_with_heads(
+    *,
+    mtp_per_depth_h: list[torch.Tensor],
+    labels: torch.Tensor,
+    model: torch.nn.Module,
+    ignore_index: int = -100,
+    cu_seqlens: torch.Tensor | None = None,
+    seq_idx: torch.Tensor | None = None,
+) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    """Per-head MTP token-acceptance counts for validation.
+
+    For each MTP depth ``k`` the head's argmax prediction is compared against the
+    token ``k + 1`` steps ahead, using exactly the same rolled/masked targets as
+    ``_calculate_mtp_loss_with_heads`` (including cross-sequence masking under
+    packed THD). Returns ``(correct_by_head, valid_by_head)`` scalar tensors so
+    the epoch end can report per-head acceptance probability and expected
+    acceptance length without repeating the forward pass.
+    """
+    from nemo_automodel.components.loss.utils import _get_lm_head_module
+    from nemo_automodel.components.models.common.mtp import roll_tensor
+
+    mtp_outputs = mtp_per_depth_h
+    if labels.dim() == 1:
+        mtp_outputs = [h.squeeze(0) if (h.dim() == 3 and h.shape[0] == 1) else h for h in mtp_outputs]
+
+    lm_head = _get_lm_head_module(model)
+    if lm_head is None:
+        raise ValueError("lm_head module not found in model")
+
+    if seq_idx is None and cu_seqlens is not None:
+        cs = cu_seqlens
+        if cs.dim() == 2 and cs.shape[0] == 1:
+            cs = cs.squeeze(0)
+        if cs.dim() == 1:
+            positions = torch.arange(labels.shape[-1], device=labels.device)
+            seq_idx = torch.searchsorted(cs[1:].contiguous(), positions, right=True)
+            if labels.dim() == 2:
+                seq_idx = seq_idx.unsqueeze(0).expand(labels.shape[0], -1)
+
+    cur_labels = labels
+    correct_by_head = []
+    valid_by_head = []
+    for k, mtp_output in enumerate(mtp_outputs):
+        cur_labels = roll_tensor(cur_labels, shifts=-1, dim=-1)
+        masked = cur_labels.clone()
+        n_invalid = min(k + 1, masked.shape[-1])
+        masked[..., -n_invalid:] = ignore_index
+
+        if seq_idx is not None:
+            rolled_seq_idx = roll_tensor(seq_idx, shifts=-(k + 1), dim=-1)
+            masked = torch.where(rolled_seq_idx != seq_idx, torch.full_like(masked, ignore_index), masked)
+
+        logits = lm_head(mtp_output)
+        if isinstance(logits, DTensor):
+            logits = logits.full_tensor()
+        preds = logits.argmax(dim=-1)
+        valid = masked != ignore_index
+        correct_by_head.append((preds.eq(masked) & valid).sum())
+        valid_by_head.append(valid.sum())
+
+    return correct_by_head, valid_by_head

--- a/nemo/collections/speechlm2/models/salm_automodel.py
+++ b/nemo/collections/speechlm2/models/salm_automodel.py
@@ -1206,6 +1206,12 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             trust_remote_code=self.cfg.get("trust_remote_code", False),
             **automodel_kwargs,
         )
+        if mtp_requested and use_repeated_layer:
+            # Automodel consumes constructor kwargs that match HF config fields,
+            # so the logical iteration count above temporarily overwrites the
+            # serialized depth. The built MTPConfig retains that logical count;
+            # restore the HF config to the one physical layer saved in the state dict.
+            self.llm.config.num_nextn_predict_layers = physical_depth
         if not mtp_requested:
             # The constructor override suppresses a checkpoint-native MTP module but does
             # not mutate the HF config. Keep the serialized config consistent with the

--- a/nemo/collections/speechlm2/models/salm_automodel.py
+++ b/nemo/collections/speechlm2/models/salm_automodel.py
@@ -51,7 +51,7 @@ from nemo.collections.speechlm2.parts.pretrained import (
 )
 from nemo.core.neural_types import AudioSignal, LabelsType, LengthsType, MaskType, NeuralType
 from nemo.core.utils.lightning_utils import read_batch
-from nemo.utils import logging
+from nemo.utils import logging, logging_mode
 
 
 class SALMAutomodel(LightningModule, HFHubMixin):
@@ -703,7 +703,13 @@ class SALMAutomodel(LightningModule, HFHubMixin):
 
             # Multi-Token Prediction teacher-forced prefix agreement for each depth.
             mtp_h = forward_outputs.get("mtp_per_depth_h", None)
-            if mtp_h is not None and "mtp_per_depth_targets" not in inputs:
+            if mtp_h is not None and "mtp_per_depth_targets" in inputs:
+                logging.warning(
+                    "MTP teacher-forced agreement metrics are disabled under context parallelism because "
+                    "rank-local verifier predictions cannot be shifted across CP boundaries.",
+                    mode=logging_mode.ONCE,
+                )
+            elif mtp_h is not None:
                 mtp_cu_seqlens = inputs.get("llm_kwargs", {}).get("cu_seqlens")
                 correct_by_head, valid_by_head = calculate_mtp_teacher_forced_agreement(
                     mtp_per_depth_h=mtp_h,

--- a/nemo/collections/speechlm2/models/salm_automodel.py
+++ b/nemo/collections/speechlm2/models/salm_automodel.py
@@ -667,8 +667,15 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             if dataset_batch is None:
                 continue  # some dataset is exhausted
             inputs = self.prepare_inputs(dataset_batch)
+            mtp_metrics_disabled_for_cp = self._mtp_enabled and "mtp_per_depth_targets" in inputs
+            if mtp_metrics_disabled_for_cp:
+                logging.warning(
+                    "MTP teacher-forced agreement metrics are disabled under context parallelism because "
+                    "rank-local verifier predictions cannot be shifted across CP boundaries.",
+                    mode=logging_mode.ONCE,
+                )
             # Enable MTP only around the validation forward while keeping the model in eval mode.
-            with mtp_validation_forward(self.llm, enabled=self._mtp_enabled):
+            with mtp_validation_forward(self.llm, enabled=self._mtp_enabled and not mtp_metrics_disabled_for_cp):
                 forward_outputs = self(
                     inputs["input_embeds"],
                     attention_mask=inputs["attention_mask"],
@@ -703,13 +710,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
 
             # Multi-Token Prediction teacher-forced prefix agreement for each depth.
             mtp_h = forward_outputs.get("mtp_per_depth_h", None)
-            if mtp_h is not None and "mtp_per_depth_targets" in inputs:
-                logging.warning(
-                    "MTP teacher-forced agreement metrics are disabled under context parallelism because "
-                    "rank-local verifier predictions cannot be shifted across CP boundaries.",
-                    mode=logging_mode.ONCE,
-                )
-            elif mtp_h is not None:
+            if mtp_h is not None:
                 mtp_cu_seqlens = inputs.get("llm_kwargs", {}).get("cu_seqlens")
                 correct_by_head, valid_by_head = calculate_mtp_teacher_forced_agreement(
                     mtp_per_depth_h=mtp_h,

--- a/nemo/collections/speechlm2/models/salm_automodel.py
+++ b/nemo/collections/speechlm2/models/salm_automodel.py
@@ -395,13 +395,13 @@ class SALMAutomodel(LightningModule, HFHubMixin):
 
     def on_validation_start(self) -> None:
         """Reject unsupported parallel layouts for fit and standalone validation."""
-        self._validate_parallelism_compatibility()
+        self._validate_parallelism_compatibility(check_backward=False)
 
     def on_test_start(self) -> None:
         """Reject unsupported parallel layouts for standalone testing."""
-        self._validate_parallelism_compatibility()
+        self._validate_parallelism_compatibility(check_backward=False)
 
-    def _validate_parallelism_compatibility(self) -> None:
+    def _validate_parallelism_compatibility(self, *, check_backward: bool = True) -> None:
         """Raise on known-incompatible THD/CP/backend configurations.
 
         Delegates to :func:`nemo.collections.speechlm2.parts.parallel.validate_parallelism_compatibility`
@@ -431,6 +431,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             attn_backend=attn_backend,
             nvte_fused_attn=nvte_fused_attn,
             device_capability=device_capability,
+            check_backward=check_backward,
         )
         mtp_cfg = self.cfg.get("mtp", None)
         mtp_enabled = mtp_cfg is not None and bool(mtp_cfg.get("enabled", False))

--- a/nemo/collections/speechlm2/models/salm_automodel.py
+++ b/nemo/collections/speechlm2/models/salm_automodel.py
@@ -14,13 +14,12 @@
 import re
 import warnings
 from collections import defaultdict
-from collections.abc import Iterator
-from contextlib import contextmanager
 from typing import Any
 
 import torch
 import torch.distributed as dist
 from lightning import LightningModule
+from nemo_automodel.components.loss.mtp import MTPLossOutput, calculate_mtp_loss
 from omegaconf import DictConfig, OmegaConf
 from torch import Tensor
 from torch.distributed.fsdp import fully_shard
@@ -35,6 +34,13 @@ from nemo.collections.speechlm2.models.salm import _resolve_audios_in_prompt, re
 from nemo.collections.speechlm2.parts.automodel_lora import ensure_lora_trainable, make_peft_config, maybe_install_lora
 from nemo.collections.speechlm2.parts.encoder_chunking import encode_audio_with_optional_chunking
 from nemo.collections.speechlm2.parts.hf_hub import HFHubMixin
+from nemo.collections.speechlm2.parts.mtp import (
+    build_mtp_loss_fn,
+    calculate_mtp_teacher_forced_agreement,
+    compute_mtp_agreement_lengths,
+    mtp_validation_forward,
+    vocab_parallel_argmax,
+)
 from nemo.collections.speechlm2.parts.multispeaker import build_speaker_tokens, maybe_init_lss_loss
 from nemo.collections.speechlm2.parts.optim_setup import configure_optimizers, is_frozen
 from nemo.collections.speechlm2.parts.pretrained import (
@@ -489,7 +495,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             # seq_idx and masks cross-sequence targets.
             mtp_cu_seqlens = inputs.get("llm_kwargs", {}).get("cu_seqlens")
             with loss_parallel():
-                mtp_loss, mtp_raw_loss_by_head = _calculate_mtp_loss_with_heads(
+                mtp_loss_output = calculate_mtp_loss(
                     self._mtp_loss_fn,
                     mtp_per_depth_h=mtp_h,
                     labels=inputs["target_ids"],
@@ -498,7 +504,12 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                     num_label_tokens=num_frames_global,
                     grad_reduce_group=dp_group,
                     cu_seqlens=mtp_cu_seqlens,
+                    return_per_depth=True,
                 )
+                if not isinstance(mtp_loss_output, MTPLossOutput):
+                    raise TypeError("Automodel did not return the requested per-depth MTP loss output")
+                mtp_loss = mtp_loss_output.loss
+                mtp_raw_loss_by_head = mtp_loss_output.per_depth_losses
             mtp_loss = dp_size * mtp_loss
             mtp_raw_loss_by_head = [dp_size * head_loss for head_loss in mtp_raw_loss_by_head]
             loss = loss + mtp_loss
@@ -600,11 +611,11 @@ class SALMAutomodel(LightningModule, HFHubMixin):
         if self._partial_val_mtp_correct:
             agreement_lengths = []
             for name in self._partial_val_mtp_correct:
-                correct = torch.stack(self._partial_val_mtp_correct[name]).sum(dim=0)
-                valid = torch.stack(self._partial_val_mtp_valid[name]).sum(dim=0)
-                D = correct.numel()
-                reduced = self._reduce_validation_metric_sums(torch.cat([correct, valid]), reduction_group)
-                per_head = reduced[:D].float() / reduced[D:].clamp(min=1).float()
+                per_head, agreement_length = compute_mtp_agreement_lengths(
+                    self._partial_val_mtp_correct[name],
+                    self._partial_val_mtp_valid[name],
+                    reduce_sums=lambda values: self._reduce_validation_metric_sums(values, reduction_group),
+                )
                 for head_idx, p in enumerate(per_head, start=1):
                     self.log(
                         f"val_mtp_teacher_forced_agreement_{name}/head_{head_idx}",
@@ -612,7 +623,6 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                         on_epoch=True,
                         sync_dist=True,
                     )
-                agreement_length = 1.0 + per_head.sum()
                 self.log(
                     f"val_mtp_teacher_forced_prefix_length_{name}", agreement_length, on_epoch=True, sync_dist=True
                 )
@@ -643,10 +653,8 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             if dataset_batch is None:
                 continue  # some dataset is exhausted
             inputs = self.prepare_inputs(dataset_batch)
-            # Enable MTP only around the validation forward. New Automodel revisions expose
-            # ``compute_mtp_in_eval``; the compatibility path for the currently pinned revision
-            # flips only the root module's gate while leaving every child in eval mode.
-            with _mtp_validation_forward(self.llm, enabled=self._mtp_enabled):
+            # Enable MTP only around the validation forward while keeping the model in eval mode.
+            with mtp_validation_forward(self.llm, enabled=self._mtp_enabled):
                 forward_outputs = self(
                     inputs["input_embeds"],
                     attention_mask=inputs["attention_mask"],
@@ -668,7 +676,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                 lss_val = self.lss_loss(log_probs=log_probs, labels=inputs["target_ids"])
                 self._partial_val_lss[name].append(lss_val.detach())
 
-            verifier_predictions = _vocab_parallel_argmax(logits)
+            verifier_predictions = vocab_parallel_argmax(logits)
             preds = verifier_predictions.view(-1)
             refs = inputs["target_ids"].reshape(-1)
             preds = preds[refs != -100]
@@ -683,7 +691,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             mtp_h = forward_outputs.get("mtp_per_depth_h", None)
             if mtp_h is not None:
                 mtp_cu_seqlens = inputs.get("llm_kwargs", {}).get("cu_seqlens")
-                correct_by_head, valid_by_head = _calculate_mtp_teacher_forced_agreement_with_heads(
+                correct_by_head, valid_by_head = calculate_mtp_teacher_forced_agreement(
                     mtp_per_depth_h=mtp_h,
                     labels=inputs["target_ids"],
                     model=self.llm,
@@ -1173,7 +1181,7 @@ class SALMAutomodel(LightningModule, HFHubMixin):
             # boundaries (see training_step); the MTP sublayers already get the
             # THD context (qkv_format/cu_seqlens/seq_idx) from the model forward.
             self._mtp_loss_scaling_factor = float(mtp_cfg.get("loss_scaling_factor", 0.1))
-            self._mtp_loss_fn = _build_mtp_loss_fn()
+            self._mtp_loss_fn = build_mtp_loss_fn()
             requested_depth = int(mtp_cfg.get("num_nextn_predict_layers", 1))
             use_repeated_layer = bool(mtp_cfg.get("use_repeated_layer", False))
             # HF/vLLM exports describe physical layers. A repeated MTP head has one
@@ -1315,271 +1323,3 @@ class SALMAutomodel(LightningModule, HFHubMixin):
                 {"name": "loss_mask", "type": NeuralType(("B", "T"), MaskType()), "seq_length": "output"},
             ],
         }
-
-
-def _build_mtp_loss_fn() -> torch.nn.Module:
-    """Select the memory-efficient MTP loss with an optional-dependency fallback."""
-    from nemo_automodel.components.loss import linear_ce
-
-    gradient_safe_fused_api = callable(getattr(linear_ce.FusedLinearCrossEntropy, "materialize_lm_weight", None))
-    if linear_ce.HAVE_CUT_CROSS_ENTROPY and gradient_safe_fused_api:
-        # Fuse the shared LM projection with CE so each MTP depth does not materialize
-        # a full [tokens, vocab] logits tensor. reduction="sum" lets the helper
-        # normalize by the global labeled-token count.
-        return linear_ce.FusedLinearCrossEntropy(reduction="sum")
-
-    # cut-cross-entropy is optional in Automodel and is absent from existing NeMo
-    # Speech containers. Retain the pre-fused compatibility path so enabling MTP
-    # does not introduce a new undeclared runtime requirement.
-    from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
-
-    if linear_ce.HAVE_CUT_CROSS_ENTROPY:
-        logging.warning(
-            "The installed Automodel lacks gradient-safe sharded LM-head materialization; "
-            "falling back to the unfused MTP loss. Upgrade Automodel to enable fused MTP loss."
-        )
-    else:
-        logging.warning(
-            "cut_cross_entropy is unavailable; falling back to the unfused MTP loss. "
-            "Install cut-cross-entropy to reduce peak MTP loss memory."
-        )
-    return MaskedCrossEntropy(reduction="sum", fp32_upcast=False)
-
-
-def _resolve_mtp_seq_idx(
-    labels: torch.Tensor,
-    *,
-    cu_seqlens: torch.Tensor | None = None,
-    seq_idx: torch.Tensor | None = None,
-) -> torch.Tensor | None:
-    """Resolve packed-sequence IDs and align them with the label layout."""
-    if seq_idx is None and cu_seqlens is not None:
-        cs = cu_seqlens
-        if cs.dim() == 2:
-            if cs.shape[0] != 1:
-                raise ValueError(f"MTP cu_seqlens must have shape [N+1] or [1, N+1], got {tuple(cs.shape)}")
-            cs = cs.squeeze(0)
-        if cs.dim() != 1:
-            raise ValueError(f"MTP cu_seqlens must have shape [N+1] or [1, N+1], got {tuple(cs.shape)}")
-        positions = torch.arange(labels.shape[-1], device=labels.device)
-        seq_idx = torch.searchsorted(cs[1:].contiguous(), positions, right=True)
-
-    if seq_idx is None:
-        return None
-    if seq_idx.dim() == 1 and labels.dim() == 2:
-        seq_idx = seq_idx.unsqueeze(0).expand(labels.shape[0], -1)
-    elif seq_idx.dim() == 2 and labels.dim() == 1 and seq_idx.shape[0] == 1:
-        seq_idx = seq_idx.squeeze(0)
-    if seq_idx.shape != labels.shape:
-        raise ValueError(f"MTP seq_idx shape {tuple(seq_idx.shape)} does not match labels shape {tuple(labels.shape)}")
-    return seq_idx
-
-
-def _iter_mtp_depth_targets(
-    labels: torch.Tensor,
-    num_depths: int,
-    *,
-    ignore_index: int = -100,
-    cu_seqlens: torch.Tensor | None = None,
-    seq_idx: torch.Tensor | None = None,
-) -> Iterator[torch.Tensor]:
-    """Yield shifted labels with trailing and packed-boundary positions masked."""
-    from nemo_automodel.components.models.common.mtp import roll_tensor
-
-    seq_idx = _resolve_mtp_seq_idx(labels, cu_seqlens=cu_seqlens, seq_idx=seq_idx)
-    cur_labels = labels
-    for depth in range(1, num_depths + 1):
-        cur_labels = roll_tensor(cur_labels, shifts=-1, dim=-1)
-        masked = cur_labels.clone()
-        n_invalid = min(depth, masked.shape[-1])
-        masked[..., -n_invalid:] = ignore_index
-
-        if seq_idx is not None:
-            rolled_seq_idx = roll_tensor(seq_idx, shifts=-depth, dim=-1)
-            masked = torch.where(rolled_seq_idx != seq_idx, torch.full_like(masked, ignore_index), masked)
-
-        yield masked
-
-
-def _calculate_mtp_loss_with_heads(
-    loss_fn,
-    *,
-    mtp_per_depth_h: list[torch.Tensor],
-    labels: torch.Tensor,
-    model: torch.nn.Module,
-    scaling_factor: float = 0.1,
-    num_label_tokens: torch.Tensor | None = None,
-    grad_reduce_group: dist.ProcessGroup | None = None,
-    ignore_index: int = -100,
-    cu_seqlens: torch.Tensor | None = None,
-    seq_idx: torch.Tensor | None = None,
-) -> tuple[torch.Tensor, list[torch.Tensor]]:
-    """Compute aggregate MTP loss and per-head losses for logging.
-
-    This mirrors Automodel's ``calculate_mtp_loss`` but keeps the intermediate
-    depth losses so Lightning/WandB can display each MTP head. Returned
-    ``raw_head_losses`` are normalized CE values before applying
-    ``scaling_factor / D``. The caller applies the same DP correction used by
-    the main training loss.
-    """
-    from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
-    from nemo_automodel.components.loss.utils import _get_lm_head_module, calculate_loss
-
-    if labels.dim() == 1:
-        mtp_per_depth_h = [h.squeeze(0) if (h.dim() == 3 and h.shape[0] == 1) else h for h in mtp_per_depth_h]
-
-    D = len(mtp_per_depth_h)
-    head_scale = scaling_factor / D
-    total = mtp_per_depth_h[0].new_zeros(())
-    raw_head_losses = []
-
-    lm_head = _get_lm_head_module(model)
-    if lm_head is None:
-        raise ValueError("lm_head module not found in model")
-
-    # FusedLinearCrossEntropy consumes the shared LM-head weight directly. Materialize
-    # a possibly sharded weight once and reuse it for every depth; gathering separately
-    # inside calculate_loss retains one full vocabulary matrix per head for backward.
-    lm_weight = None
-    if isinstance(loss_fn, FusedLinearCrossEntropy):
-        lm_weight = lm_head.weight
-        if isinstance(lm_weight, DTensor):
-            materialize = getattr(loss_fn, "materialize_lm_weight", None)
-            if not callable(materialize):
-                raise RuntimeError(
-                    "Fused MTP loss requires Automodel's gradient-safe materialize_lm_weight API for DTensor weights"
-                )
-            lm_weight = materialize(lm_weight, grad_reduce_group=grad_reduce_group)
-
-    depth_targets = _iter_mtp_depth_targets(
-        labels,
-        D,
-        ignore_index=ignore_index,
-        cu_seqlens=cu_seqlens,
-        seq_idx=seq_idx,
-    )
-    for mtp_output, masked in zip(mtp_per_depth_h, depth_targets):
-        if isinstance(loss_fn, FusedLinearCrossEntropy):
-            depth_loss = calculate_loss(
-                loss_fn,
-                hidden_states=mtp_output,
-                labels=masked,
-                model=model,
-                lm_weight=lm_weight,
-                num_label_tokens=num_label_tokens,
-                grad_reduce_group=grad_reduce_group,
-            )
-        else:
-            depth_loss = calculate_loss(
-                loss_fn,
-                logits=lm_head(mtp_output),
-                labels=masked,
-                num_label_tokens=num_label_tokens,
-            )
-
-        raw_head_losses.append(depth_loss)
-        total = total + depth_loss * head_scale
-
-    return total, raw_head_losses
-
-
-def _vocab_parallel_argmax(logits: torch.Tensor) -> torch.Tensor:
-    """Return global vocabulary argmax IDs without gathering full logits.
-
-    PyTorch's DTensor argmax handler reduces sharded maxima and their global
-    indices across the vocabulary mesh. Materialize only the resulting token-ID
-    tensor, whose vocabulary dimension has already been removed.
-    """
-    predictions = logits.argmax(dim=-1)
-    if isinstance(predictions, DTensor):
-        predictions = predictions.full_tensor()
-    return predictions
-
-
-def _calculate_mtp_teacher_forced_agreement_with_heads(
-    *,
-    mtp_per_depth_h: list[torch.Tensor],
-    labels: torch.Tensor,
-    model: torch.nn.Module,
-    verifier_predictions: torch.Tensor,
-    ignore_index: int = -100,
-    cu_seqlens: torch.Tensor | None = None,
-    seq_idx: torch.Tensor | None = None,
-) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
-    """Per-head teacher-forced MTP/verifier agreement counts for validation.
-
-    For each MTP depth ``k`` the head's argmax prediction is compared with the
-    verifier's prediction for the same future position from the validation
-    forward conditioned on ground-truth tokens. Counts are prefix-based: depth
-    ``k`` agrees only when every draft through ``k`` matches. This must not be
-    reported as speculative-decoding acceptance, which requires verifier logits
-    conditioned on the proposed draft prefix. The same rolled/masked labels as
-    the MTP loss define eligible positions, including packed-THD boundaries.
-    """
-    from nemo_automodel.components.loss.utils import _get_lm_head_module
-    from nemo_automodel.components.models.common.mtp import roll_tensor
-
-    mtp_outputs = mtp_per_depth_h
-    if labels.dim() == 1:
-        mtp_outputs = [h.squeeze(0) if (h.dim() == 3 and h.shape[0] == 1) else h for h in mtp_outputs]
-        if verifier_predictions.dim() == 2 and verifier_predictions.shape[0] == 1:
-            verifier_predictions = verifier_predictions.squeeze(0)
-    if verifier_predictions.shape != labels.shape:
-        raise ValueError(
-            f"verifier_predictions.shape={tuple(verifier_predictions.shape)} does not "
-            f"match labels.shape={tuple(labels.shape)}"
-        )
-
-    lm_head = _get_lm_head_module(model)
-    if lm_head is None:
-        raise ValueError("lm_head module not found in model")
-
-    prefix_matches = torch.ones_like(labels, dtype=torch.bool)
-    prefix_valid = torch.ones_like(labels, dtype=torch.bool)
-    correct_by_head = []
-    valid_by_head = []
-    depth_targets = _iter_mtp_depth_targets(
-        labels,
-        len(mtp_outputs),
-        ignore_index=ignore_index,
-        cu_seqlens=cu_seqlens,
-        seq_idx=seq_idx,
-    )
-    for k, (mtp_output, masked) in enumerate(zip(mtp_outputs, depth_targets)):
-        logits = lm_head(mtp_output)
-        preds = _vocab_parallel_argmax(logits)
-        valid = masked != ignore_index
-        verifier_for_depth = roll_tensor(verifier_predictions, shifts=-(k + 1), dim=-1)
-        prefix_valid = prefix_valid & valid
-        prefix_matches = prefix_matches & preds.eq(verifier_for_depth)
-        correct_by_head.append((prefix_matches & prefix_valid).sum())
-        valid_by_head.append(prefix_valid.sum())
-
-    return correct_by_head, valid_by_head
-
-
-@contextmanager
-def _mtp_validation_forward(llm: torch.nn.Module, *, enabled: bool):
-    """Run MTP during one eval forward without changing child-module eval state."""
-    if not enabled:
-        yield
-        return
-
-    if hasattr(llm, "compute_mtp_in_eval"):
-        previous = llm.compute_mtp_in_eval
-        llm.compute_mtp_in_eval = True
-        try:
-            yield
-        finally:
-            llm.compute_mtp_in_eval = previous
-        return
-
-    # Older Automodel revisions gate MTP only on the root module's ``training``
-    # flag. Assign it directly rather than calling train(), which would recursively
-    # enable dropout and other training-only behavior in the frozen verifier.
-    previous = llm.training
-    llm.training = True
-    try:
-        yield
-    finally:
-        llm.training = previous

--- a/nemo/collections/speechlm2/parts/mtp.py
+++ b/nemo/collections/speechlm2/parts/mtp.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Reusable Multi-Token Prediction helpers for SpeechLM models."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
+
+import torch
+from torch.distributed.tensor import DTensor
+
+from nemo.utils import logging
+
+
+def build_mtp_loss_fn() -> torch.nn.Module:
+    """Select the memory-efficient MTP loss with an optional-dependency fallback."""
+    from nemo_automodel.components.loss import linear_ce
+
+    if linear_ce.HAVE_CUT_CROSS_ENTROPY:
+        # Fuse the shared LM projection with CE so each MTP depth does not materialize
+        # a full [tokens, vocab] logits tensor. reduction="sum" lets the helper
+        # normalize by the global labeled-token count.
+        return linear_ce.FusedLinearCrossEntropy(reduction="sum")
+
+    # cut-cross-entropy is optional in Automodel and may be absent from NeMo Speech
+    # containers. Retain the unfused path so enabling MTP does not introduce a new
+    # undeclared runtime requirement.
+    from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
+
+    logging.warning(
+        "cut_cross_entropy is unavailable; falling back to the unfused MTP loss. "
+        "Install cut-cross-entropy to reduce peak MTP loss memory."
+    )
+    return MaskedCrossEntropy(reduction="sum", fp32_upcast=False)
+
+
+def resolve_mtp_seq_idx(
+    labels: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor | None = None,
+    seq_idx: torch.Tensor | None = None,
+) -> torch.Tensor | None:
+    """Resolve packed-sequence IDs and align them with the label layout."""
+    if seq_idx is None and cu_seqlens is not None:
+        cs = cu_seqlens
+        if cs.dim() == 2:
+            if cs.shape[0] != 1:
+                raise ValueError(f"MTP cu_seqlens must have shape [N+1] or [1, N+1], got {tuple(cs.shape)}")
+            cs = cs.squeeze(0)
+        if cs.dim() != 1:
+            raise ValueError(f"MTP cu_seqlens must have shape [N+1] or [1, N+1], got {tuple(cs.shape)}")
+        positions = torch.arange(labels.shape[-1], device=labels.device)
+        seq_idx = torch.searchsorted(cs[1:].contiguous(), positions, right=True)
+
+    if seq_idx is None:
+        return None
+    if seq_idx.dim() == 1 and labels.dim() == 2:
+        seq_idx = seq_idx.unsqueeze(0).expand(labels.shape[0], -1)
+    elif seq_idx.dim() == 2 and labels.dim() == 1 and seq_idx.shape[0] == 1:
+        seq_idx = seq_idx.squeeze(0)
+    if seq_idx.shape != labels.shape:
+        raise ValueError(f"MTP seq_idx shape {tuple(seq_idx.shape)} does not match labels shape {tuple(labels.shape)}")
+    return seq_idx
+
+
+def iter_mtp_depth_targets(
+    labels: torch.Tensor,
+    num_depths: int,
+    *,
+    ignore_index: int = -100,
+    cu_seqlens: torch.Tensor | None = None,
+    seq_idx: torch.Tensor | None = None,
+) -> Iterator[torch.Tensor]:
+    """Yield shifted labels with trailing and packed-boundary positions masked."""
+    from nemo_automodel.components.models.common.mtp import roll_tensor
+
+    seq_idx = resolve_mtp_seq_idx(labels, cu_seqlens=cu_seqlens, seq_idx=seq_idx)
+    cur_labels = labels
+    for depth in range(1, num_depths + 1):
+        cur_labels = roll_tensor(cur_labels, shifts=-1, dim=-1)
+        masked = cur_labels.clone()
+        n_invalid = min(depth, masked.shape[-1])
+        masked[..., -n_invalid:] = ignore_index
+
+        if seq_idx is not None:
+            rolled_seq_idx = roll_tensor(seq_idx, shifts=-depth, dim=-1)
+            masked = torch.where(rolled_seq_idx != seq_idx, torch.full_like(masked, ignore_index), masked)
+
+        yield masked
+
+
+def vocab_parallel_argmax(logits: torch.Tensor) -> torch.Tensor:
+    """Return global vocabulary argmax IDs without gathering full logits.
+
+    PyTorch's DTensor argmax handler reduces sharded maxima and their global
+    indices across the vocabulary mesh. Materialize only the resulting token-ID
+    tensor, whose vocabulary dimension has already been removed.
+    """
+    predictions = logits.argmax(dim=-1)
+    if isinstance(predictions, DTensor):
+        predictions = predictions.full_tensor()
+    return predictions
+
+
+def calculate_mtp_teacher_forced_agreement(
+    *,
+    mtp_per_depth_h: list[torch.Tensor],
+    labels: torch.Tensor,
+    model: torch.nn.Module,
+    verifier_predictions: torch.Tensor,
+    ignore_index: int = -100,
+    cu_seqlens: torch.Tensor | None = None,
+    seq_idx: torch.Tensor | None = None,
+) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    """Per-head teacher-forced MTP/verifier agreement counts for validation.
+
+    For each MTP depth ``k`` the head's argmax prediction is compared with the
+    verifier's prediction for the same future position from the validation
+    forward conditioned on ground-truth tokens. Counts are prefix-based: depth
+    ``k`` agrees only when every draft through ``k`` matches. This must not be
+    reported as speculative-decoding acceptance, which requires verifier logits
+    conditioned on the proposed draft prefix. The same rolled/masked labels as
+    the MTP loss define eligible positions, including packed-THD boundaries.
+    """
+    from nemo_automodel.components.loss.utils import _get_lm_head_module
+    from nemo_automodel.components.models.common.mtp import roll_tensor
+
+    mtp_outputs = mtp_per_depth_h
+    if labels.dim() == 1:
+        mtp_outputs = [h.squeeze(0) if (h.dim() == 3 and h.shape[0] == 1) else h for h in mtp_outputs]
+        if verifier_predictions.dim() == 2 and verifier_predictions.shape[0] == 1:
+            verifier_predictions = verifier_predictions.squeeze(0)
+    if verifier_predictions.shape != labels.shape:
+        raise ValueError(
+            f"verifier_predictions.shape={tuple(verifier_predictions.shape)} does not "
+            f"match labels.shape={tuple(labels.shape)}"
+        )
+
+    lm_head = _get_lm_head_module(model)
+    if lm_head is None:
+        raise ValueError("lm_head module not found in model")
+
+    prefix_matches = torch.ones_like(labels, dtype=torch.bool)
+    prefix_valid = torch.ones_like(labels, dtype=torch.bool)
+    correct_by_head = []
+    valid_by_head = []
+    depth_targets = iter_mtp_depth_targets(
+        labels,
+        len(mtp_outputs),
+        ignore_index=ignore_index,
+        cu_seqlens=cu_seqlens,
+        seq_idx=seq_idx,
+    )
+    for k, (mtp_output, masked) in enumerate(zip(mtp_outputs, depth_targets)):
+        logits = lm_head(mtp_output)
+        preds = vocab_parallel_argmax(logits)
+        valid = masked != ignore_index
+        verifier_for_depth = roll_tensor(verifier_predictions, shifts=-(k + 1), dim=-1)
+        prefix_valid = prefix_valid & valid
+        prefix_matches = prefix_matches & preds.eq(verifier_for_depth)
+        correct_by_head.append((prefix_matches & prefix_valid).sum())
+        valid_by_head.append(prefix_valid.sum())
+
+    return correct_by_head, valid_by_head
+
+
+@contextmanager
+def mtp_validation_forward(llm: torch.nn.Module, *, enabled: bool):
+    """Run MTP during one eval forward without changing child-module eval state."""
+    if not enabled:
+        yield
+        return
+
+    previous = llm.compute_mtp_in_eval
+    llm.compute_mtp_in_eval = True
+    try:
+        yield
+    finally:
+        llm.compute_mtp_in_eval = previous
+
+
+def compute_mtp_agreement_lengths(
+    correct_counts: Sequence[torch.Tensor],
+    valid_counts: Sequence[torch.Tensor],
+    *,
+    reduce_sums: Callable[[torch.Tensor], torch.Tensor] | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Aggregate prefix-agreement counters into per-depth rates and mean length.
+
+    ``correct_counts`` and ``valid_counts`` contain one integer counter vector
+    per validation step. Their depth dimension must match. ``reduce_sums`` can
+    optionally reduce the concatenated integer counters across data-parallel
+    ranks before conversion to floating point.
+    """
+    if not correct_counts or not valid_counts:
+        raise ValueError("MTP agreement counters must not be empty")
+
+    correct = torch.stack(tuple(correct_counts)).sum(dim=0)
+    valid = torch.stack(tuple(valid_counts)).sum(dim=0)
+    if correct.shape != valid.shape:
+        raise ValueError(
+            f"MTP correct-count shape {tuple(correct.shape)} does not match valid-count shape {tuple(valid.shape)}"
+        )
+
+    num_depths = correct.numel()
+    reduced = torch.cat((correct, valid))
+    if reduce_sums is not None:
+        reduced = reduce_sums(reduced)
+
+    per_depth = reduced[:num_depths].float() / reduced[num_depths:].clamp(min=1).float()
+    mean_prefix_length = per_depth.new_tensor(1.0) + per_depth.sum()
+    return per_depth, mean_prefix_length

--- a/nemo/collections/speechlm2/parts/mtp.py
+++ b/nemo/collections/speechlm2/parts/mtp.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
+from typing import Any
 
 import torch
 from torch.distributed.tensor import DTensor
@@ -44,6 +45,19 @@ def build_mtp_loss_fn() -> torch.nn.Module:
         "Install cut-cross-entropy to reduce peak MTP loss memory."
     )
     return MaskedCrossEntropy(reduction="sum", fp32_upcast=False)
+
+
+def calculate_mtp_loss_with_per_depth(*args: Any, **kwargs: Any) -> Any:
+    """Call Automodel's per-depth MTP loss API only when MTP training runs."""
+    try:
+        from nemo_automodel.components.loss.mtp import MTPLossOutput, calculate_mtp_loss
+    except ImportError as error:
+        raise RuntimeError("MTP training requires an Automodel version with per-depth MTP loss support") from error
+
+    output = calculate_mtp_loss(*args, **kwargs)
+    if not isinstance(output, MTPLossOutput):
+        raise TypeError("Automodel did not return the requested per-depth MTP loss output")
+    return output
 
 
 def resolve_mtp_seq_idx(

--- a/nemo/collections/speechlm2/parts/mtp.py
+++ b/nemo/collections/speechlm2/parts/mtp.py
@@ -22,7 +22,7 @@ from typing import Any
 import torch
 from torch.distributed.tensor import DTensor
 
-from nemo.utils import logging
+from nemo.utils import logging, logging_mode
 
 
 def build_mtp_loss_fn() -> torch.nn.Module:
@@ -197,7 +197,15 @@ def mtp_validation_forward(llm: torch.nn.Module, *, enabled: bool):
         yield
         return
 
-    previous = llm.compute_mtp_in_eval
+    previous = getattr(llm, "compute_mtp_in_eval", None)
+    if previous is None:
+        logging.warning(
+            f"{type(llm).__name__} does not expose compute_mtp_in_eval; skipping the MTP validation forward.",
+            mode=logging_mode.ONCE,
+        )
+        yield
+        return
+
     llm.compute_mtp_in_eval = True
     try:
         yield

--- a/nemo/collections/speechlm2/parts/packed_sequences.py
+++ b/nemo/collections/speechlm2/parts/packed_sequences.py
@@ -23,14 +23,88 @@ multi-utterance minibatch into a single packed sequence so the LLM is fed
 All tensor logic is kept here (no `SALMAutomodel` knowledge) so it is unit
 testable on CPU.
 """
+
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Optional
 
 import torch
 from torch import Tensor
 
 from nemo.collections.speechlm2.parts.input_utils import _unpad_inputs
+
+
+@dataclass(frozen=True)
+class _PackedMTPInputs:
+    """MTP tensors prepared in global packed order and optionally CP-sharded.
+
+    Every tuple contains one tensor per MTP depth. ``embed_inputs`` tensors
+    have shape [tokens, hidden]; ``position_ids`` and ``targets`` tensors have
+    shape [tokens]. Invalid future positions at packed-sequence boundaries are
+    zero-filled for model inputs and use ``ignore_index`` for targets.
+    """
+
+    embed_inputs: tuple[Tensor, ...]
+    position_ids: tuple[Tensor, ...]
+    targets: tuple[Tensor, ...]
+
+
+def _shift_packed_tensor_for_mtp(tensor: Tensor, depth: int, seq_idx: Tensor) -> Tensor:
+    """Shift a packed tensor left without crossing document boundaries.
+
+    Args:
+        tensor: Global packed tensor of shape [tokens, ...].
+        depth: Number of future-token positions to shift.
+        seq_idx: Packed document IDs of shape [tokens].
+
+    Returns:
+        A tensor with the same shape and dtype as ``tensor``. Positions whose
+        future token is outside their current document are zero.
+    """
+    if depth < 1:
+        raise ValueError(f"MTP depth must be positive, got {depth}")
+    if tensor.shape[0] != seq_idx.shape[0]:
+        raise ValueError(
+            f"Packed tensor token count {tensor.shape[0]} does not match seq_idx token count {seq_idx.shape[0]}"
+        )
+
+    shifted = torch.roll(tensor, shifts=-depth, dims=0)
+    shifted_seq_idx = torch.roll(seq_idx, shifts=-depth, dims=0)
+    token_idx = torch.arange(seq_idx.numel(), device=seq_idx.device)
+    valid = (token_idx + depth < seq_idx.numel()) & (shifted_seq_idx == seq_idx)
+    while valid.ndim < shifted.ndim:
+        valid = valid.unsqueeze(-1)
+    return torch.where(valid, shifted, torch.zeros((), dtype=tensor.dtype, device=tensor.device))
+
+
+def _build_packed_mtp_inputs(packed: dict[str, Tensor], num_depths: int) -> _PackedMTPInputs:
+    """Prepare globally shifted, boundary-safe MTP tensors before CP sharding.
+
+    ``packed`` contains embeddings [tokens, hidden], position IDs [tokens],
+    labels [tokens], and global ``cu_seqlens``. The returned tensors retain
+    those layouts and global token order.
+    """
+    from nemo.collections.speechlm2.parts.mtp import iter_mtp_depth_targets, resolve_mtp_seq_idx
+
+    if num_depths < 1:
+        raise ValueError(f"num_depths must be positive, got {num_depths}")
+    seq_idx = resolve_mtp_seq_idx(packed["position_ids"], cu_seqlens=packed["cu_seqlens"])
+    if seq_idx is None:
+        raise RuntimeError("Could not derive packed sequence IDs from cu_seqlens")
+
+    depths = range(1, num_depths + 1)
+    return _PackedMTPInputs(
+        embed_inputs=tuple(_shift_packed_tensor_for_mtp(packed["inputs_embeds"], depth, seq_idx) for depth in depths),
+        position_ids=tuple(_shift_packed_tensor_for_mtp(packed["position_ids"], depth, seq_idx) for depth in depths),
+        targets=tuple(
+            iter_mtp_depth_targets(
+                packed["labels"],
+                num_depths,
+                cu_seqlens=packed["cu_seqlens"],
+            )
+        ),
+    )
 
 
 def pack_audio_into_text_embeds(
@@ -203,12 +277,29 @@ def pack_audio_into_text_embeds(
     }
 
 
-def _shard_packed_for_cp(packed: dict[str, Tensor], cp_mesh) -> dict[str, Tensor]:
+def _shard_packed_for_cp(
+    packed: dict[str, Tensor],
+    cp_mesh,
+    mtp_inputs: _PackedMTPInputs | None = None,
+) -> tuple[dict[str, Tensor], _PackedMTPInputs | None]:
     """Partition a packed THD batch across CP ranks (TE's interleaved scheme).
 
     Mirrors ``nemo_automodel.components.distributed.cp_utils._shard_thd_chunk_for_te``
     but preserves the float dtype of ``inputs_embeds`` (the upstream helper
     casts everything to int64, which would silently corrupt embeddings).
+
+    Args:
+        packed: Global packed tensors. ``inputs_embeds`` has shape [tokens,
+            hidden], while ``labels`` and ``position_ids`` have shape [tokens].
+        cp_mesh: One-dimensional context-parallel device mesh.
+        mtp_inputs: Optional globally shifted and boundary-masked MTP tensors.
+            Embeddings have shape [tokens, hidden]; position IDs and targets
+            have shape [tokens].
+
+    Returns:
+        The rank-local packed mapping and optional rank-local MTP tensors. All
+        token tensors use TE's identical interleaved CP partition and have
+        local shape [tokens / cp_size, ...].
     """
     import transformer_engine_torch as tex  # local import — only needed when CP > 1
 
@@ -224,15 +315,29 @@ def _shard_packed_for_cp(packed: dict[str, Tensor], cp_mesh) -> dict[str, Tensor
     inputs_embeds = inputs_embeds.index_select(0, index)
     labels = labels.index_select(0, index)
     position_ids = position_ids.index_select(0, index)
+    if mtp_inputs is not None:
+        mtp_inputs = _PackedMTPInputs(
+            embed_inputs=tuple(embeds.index_select(0, index).contiguous() for embeds in mtp_inputs.embed_inputs),
+            position_ids=tuple(
+                position_ids.index_select(0, index).to(torch.int64).contiguous()
+                for position_ids in mtp_inputs.position_ids
+            ),
+            targets=tuple(
+                targets.index_select(0, index).to(torch.int64).contiguous() for targets in mtp_inputs.targets
+            ),
+        )
 
-    return {
-        "inputs_embeds": inputs_embeds.contiguous(),
-        "labels": labels.to(torch.int64).contiguous(),
-        "position_ids": position_ids.to(torch.int64).contiguous(),
-        "cu_seqlens": cu_seqlens.to(torch.int32).contiguous(),
-        "max_seqlen": packed["max_seqlen"],
-        "qkv_format": "thd",
-    }
+    return (
+        {
+            "inputs_embeds": inputs_embeds.contiguous(),
+            "labels": labels.to(torch.int64).contiguous(),
+            "position_ids": position_ids.to(torch.int64).contiguous(),
+            "cu_seqlens": cu_seqlens.to(torch.int32).contiguous(),
+            "max_seqlen": packed["max_seqlen"],
+            "qkv_format": "thd",
+        },
+        mtp_inputs,
+    )
 
 
 def prepare_packed_llm_inputs(
@@ -243,26 +348,30 @@ def prepare_packed_llm_inputs(
     padding_id: int,
     placeholder_id: int,
     device_mesh: Optional[Any] = None,
+    mtp_num_depths: int = 0,
 ) -> dict[str, Any]:
     """Pack a SALM minibatch and (optionally) shard it across CP ranks.
 
-    Returns a dict with the same top-level keys produced by the BSHD branch of
-    ``SALMAutomodel.prepare_inputs`` plus an ``llm_kwargs`` dict carrying the
-    THD metadata to splat into ``self.llm(...)``::
+    Args:
+        input_ids: Token IDs of shape [batch, sequence].
+        text_embs: Text embeddings of shape [batch, sequence, hidden].
+        audio_embs: Audio replacement tensors, each of shape [audio_frames, hidden].
+        target_ids: Unshifted labels of shape [batch, sequence].
+        padding_id: Token ID used for left padding.
+        placeholder_id: Token ID replaced by audio frames.
+        device_mesh: Optional device mesh containing CP and TP axes.
+        mtp_num_depths: Number of future-token MTP input/target tensors to
+            prepare. These are emitted only when CP is active because
+            rank-local rolling is otherwise incorrect.
 
-        {
-            "input_embeds":   Tensor [T, H] (2D, no leading batch dim;
-                              matches the canonical Automodel THD contract
-                              produced by ``_shard_thd_chunk_for_te``),
-            "attention_mask": None,
-            "target_ids":     Tensor [T],
-            "llm_kwargs": {
-                "qkv_format":        "thd",
-                "cu_seqlens":        Tensor [B+1] int32,
-                "position_ids":      Tensor [T] int64,
-                "max_seqlen":        int32 scalar,
-            },
-        }
+    Returns:
+        Mapping containing rank-local THD model inputs. ``input_embeds`` has
+        shape [local_tokens, hidden], ``target_ids`` and ``position_ids`` have
+        shape [local_tokens], and ``cu_seqlens`` describes the global packed
+        stream. Under CP with MTP, ``llm_kwargs`` also contains future
+        embeddings [local_tokens, hidden] and position IDs [local_tokens], and
+        ``mtp_per_depth_targets`` contains one [local_tokens] target tensor per
+        depth. All are shifted in global order before TE partitioning.
     """
     from nemo.collections.speechlm2.parts.cp_helpers import get_cp_mesh
 
@@ -286,10 +395,13 @@ def prepare_packed_llm_inputs(
     num_tokens = packed["seq_lens"].sum()
     num_examples = torch.tensor(input_ids.shape[0], dtype=torch.long, device=input_ids.device)
 
+    mtp_inputs = None
+    if cp_mesh is not None and mtp_num_depths > 0:
+        mtp_inputs = _build_packed_mtp_inputs(packed, mtp_num_depths)
     if cp_mesh is not None:
-        packed = _shard_packed_for_cp(packed, cp_mesh)
+        packed, mtp_inputs = _shard_packed_for_cp(packed, cp_mesh, mtp_inputs)
 
-    return {
+    result = {
         "input_embeds": packed["inputs_embeds"],
         "attention_mask": None,
         "target_ids": packed["labels"],
@@ -309,3 +421,8 @@ def prepare_packed_llm_inputs(
             "max_seqlen": packed["max_seqlen"],
         },
     }
+    if mtp_inputs is not None:
+        result["llm_kwargs"]["mtp_embed_inputs"] = mtp_inputs.embed_inputs
+        result["llm_kwargs"]["mtp_per_depth_position_ids"] = mtp_inputs.position_ids
+        result["mtp_per_depth_targets"] = mtp_inputs.targets
+    return result

--- a/nemo/collections/speechlm2/parts/packed_sequences.py
+++ b/nemo/collections/speechlm2/parts/packed_sequences.py
@@ -35,78 +35,6 @@ from torch import Tensor
 from nemo.collections.speechlm2.parts.input_utils import _unpad_inputs
 
 
-@dataclass(frozen=True)
-class _PackedMTPInputs:
-    """MTP tensors prepared in global packed order and optionally CP-sharded.
-
-    Every tuple contains one tensor per MTP depth. ``embed_inputs`` tensors
-    have shape [tokens, hidden]; ``position_ids`` and ``targets`` tensors have
-    shape [tokens]. Invalid future positions at packed-sequence boundaries are
-    zero-filled for model inputs and use ``ignore_index`` for targets.
-    """
-
-    embed_inputs: tuple[Tensor, ...]
-    position_ids: tuple[Tensor, ...]
-    targets: tuple[Tensor, ...]
-
-
-def _shift_packed_tensor_for_mtp(tensor: Tensor, depth: int, seq_idx: Tensor) -> Tensor:
-    """Shift a packed tensor left without crossing document boundaries.
-
-    Args:
-        tensor: Global packed tensor of shape [tokens, ...].
-        depth: Number of future-token positions to shift.
-        seq_idx: Packed document IDs of shape [tokens].
-
-    Returns:
-        A tensor with the same shape and dtype as ``tensor``. Positions whose
-        future token is outside their current document are zero.
-    """
-    if depth < 1:
-        raise ValueError(f"MTP depth must be positive, got {depth}")
-    if tensor.shape[0] != seq_idx.shape[0]:
-        raise ValueError(
-            f"Packed tensor token count {tensor.shape[0]} does not match seq_idx token count {seq_idx.shape[0]}"
-        )
-
-    shifted = torch.roll(tensor, shifts=-depth, dims=0)
-    shifted_seq_idx = torch.roll(seq_idx, shifts=-depth, dims=0)
-    token_idx = torch.arange(seq_idx.numel(), device=seq_idx.device)
-    valid = (token_idx + depth < seq_idx.numel()) & (shifted_seq_idx == seq_idx)
-    while valid.ndim < shifted.ndim:
-        valid = valid.unsqueeze(-1)
-    return torch.where(valid, shifted, torch.zeros((), dtype=tensor.dtype, device=tensor.device))
-
-
-def _build_packed_mtp_inputs(packed: dict[str, Tensor], num_depths: int) -> _PackedMTPInputs:
-    """Prepare globally shifted, boundary-safe MTP tensors before CP sharding.
-
-    ``packed`` contains embeddings [tokens, hidden], position IDs [tokens],
-    labels [tokens], and global ``cu_seqlens``. The returned tensors retain
-    those layouts and global token order.
-    """
-    from nemo.collections.speechlm2.parts.mtp import iter_mtp_depth_targets, resolve_mtp_seq_idx
-
-    if num_depths < 1:
-        raise ValueError(f"num_depths must be positive, got {num_depths}")
-    seq_idx = resolve_mtp_seq_idx(packed["position_ids"], cu_seqlens=packed["cu_seqlens"])
-    if seq_idx is None:
-        raise RuntimeError("Could not derive packed sequence IDs from cu_seqlens")
-
-    depths = range(1, num_depths + 1)
-    return _PackedMTPInputs(
-        embed_inputs=tuple(_shift_packed_tensor_for_mtp(packed["inputs_embeds"], depth, seq_idx) for depth in depths),
-        position_ids=tuple(_shift_packed_tensor_for_mtp(packed["position_ids"], depth, seq_idx) for depth in depths),
-        targets=tuple(
-            iter_mtp_depth_targets(
-                packed["labels"],
-                num_depths,
-                cu_seqlens=packed["cu_seqlens"],
-            )
-        ),
-    )
-
-
 def pack_audio_into_text_embeds(
     input_ids: Tensor,
     embeds: Tensor,
@@ -426,3 +354,69 @@ def prepare_packed_llm_inputs(
         result["llm_kwargs"]["mtp_per_depth_position_ids"] = mtp_inputs.position_ids
         result["mtp_per_depth_targets"] = mtp_inputs.targets
     return result
+
+
+@dataclass(frozen=True)
+class _PackedMTPInputs:
+    """MTP tensors prepared in global packed order and optionally CP-sharded.
+
+    Every tuple contains one tensor per MTP depth. ``embed_inputs`` tensors
+    have shape [tokens, hidden]; ``position_ids`` and ``targets`` tensors have
+    shape [tokens]. Invalid future positions at packed-sequence boundaries are
+    zero-filled for model inputs and use ``ignore_index`` for targets.
+    """
+
+    embed_inputs: tuple[Tensor, ...]
+    position_ids: tuple[Tensor, ...]
+    targets: tuple[Tensor, ...]
+
+
+def _shift_packed_tensor_for_mtp(tensor: Tensor, depth: int, seq_idx: Tensor) -> Tensor:
+    """Shift a packed tensor left without crossing document boundaries.
+
+    Args:
+        tensor: Global packed tensor of shape [tokens, ...].
+        depth: Number of future-token positions to shift.
+        seq_idx: Packed document IDs of shape [tokens].
+
+    Returns:
+        A tensor with the same shape and dtype as ``tensor``. Positions whose
+        future token is outside their current document are zero.
+    """
+    if depth < 1:
+        raise ValueError(f"MTP depth must be positive, got {depth}")
+    if tensor.shape[0] != seq_idx.shape[0]:
+        raise ValueError(
+            f"Packed tensor token count {tensor.shape[0]} does not match seq_idx token count {seq_idx.shape[0]}"
+        )
+
+    shifted = torch.roll(tensor, shifts=-depth, dims=0)
+    shifted_seq_idx = torch.roll(seq_idx, shifts=-depth, dims=0)
+    token_idx = torch.arange(seq_idx.numel(), device=seq_idx.device)
+    valid = (token_idx + depth < seq_idx.numel()) & (shifted_seq_idx == seq_idx)
+    while valid.ndim < shifted.ndim:
+        valid = valid.unsqueeze(-1)
+    return torch.where(valid, shifted, torch.zeros((), dtype=tensor.dtype, device=tensor.device))
+
+
+def _build_packed_mtp_inputs(packed: dict[str, Tensor], num_depths: int) -> _PackedMTPInputs:
+    """Prepare globally shifted, boundary-safe MTP tensors before CP sharding.
+
+    ``packed`` contains embeddings [tokens, hidden], position IDs [tokens],
+    labels [tokens], and global ``cu_seqlens``. The returned tensors retain
+    those layouts and global token order.
+    """
+    from nemo.collections.speechlm2.parts.mtp import iter_mtp_depth_targets, resolve_mtp_seq_idx
+
+    if num_depths < 1:
+        raise ValueError(f"num_depths must be positive, got {num_depths}")
+    seq_idx = resolve_mtp_seq_idx(packed["position_ids"], cu_seqlens=packed["cu_seqlens"])
+    if seq_idx is None:
+        raise RuntimeError("Could not derive packed sequence IDs from cu_seqlens")
+
+    depths = range(1, num_depths + 1)
+    return _PackedMTPInputs(
+        embed_inputs=tuple(_shift_packed_tensor_for_mtp(packed["inputs_embeds"], depth, seq_idx) for depth in depths),
+        position_ids=tuple(_shift_packed_tensor_for_mtp(packed["position_ids"], depth, seq_idx) for depth in depths),
+        targets=tuple(iter_mtp_depth_targets(packed["labels"], num_depths, seq_idx=seq_idx)),
+    )

--- a/nemo/collections/speechlm2/parts/packed_sequences.py
+++ b/nemo/collections/speechlm2/parts/packed_sequences.py
@@ -371,13 +371,25 @@ class _PackedMTPInputs:
     targets: tuple[Tensor, ...]
 
 
-def _shift_packed_tensor_for_mtp(tensor: Tensor, depth: int, seq_idx: Tensor) -> Tensor:
+def _build_packed_mtp_shift_masks(seq_idx: Tensor, num_depths: int) -> tuple[Tensor, ...]:
+    """Build one packed-boundary validity mask per MTP depth."""
+    if num_depths < 1:
+        raise ValueError(f"num_depths must be positive, got {num_depths}")
+
+    token_idx = torch.arange(seq_idx.numel(), device=seq_idx.device)
+    return tuple(
+        (token_idx + depth < seq_idx.numel()) & (torch.roll(seq_idx, shifts=-depth, dims=0) == seq_idx)
+        for depth in range(1, num_depths + 1)
+    )
+
+
+def _shift_packed_tensor_for_mtp(tensor: Tensor, depth: int, valid_mask: Tensor) -> Tensor:
     """Shift a packed tensor left without crossing document boundaries.
 
     Args:
         tensor: Global packed tensor of shape [tokens, ...].
         depth: Number of future-token positions to shift.
-        seq_idx: Packed document IDs of shape [tokens].
+        valid_mask: Precomputed packed-boundary validity mask of shape [tokens].
 
     Returns:
         A tensor with the same shape and dtype as ``tensor``. Positions whose
@@ -385,15 +397,13 @@ def _shift_packed_tensor_for_mtp(tensor: Tensor, depth: int, seq_idx: Tensor) ->
     """
     if depth < 1:
         raise ValueError(f"MTP depth must be positive, got {depth}")
-    if tensor.shape[0] != seq_idx.shape[0]:
+    if tensor.shape[0] != valid_mask.shape[0]:
         raise ValueError(
-            f"Packed tensor token count {tensor.shape[0]} does not match seq_idx token count {seq_idx.shape[0]}"
+            f"Packed tensor token count {tensor.shape[0]} does not match validity mask token count {valid_mask.shape[0]}"
         )
 
     shifted = torch.roll(tensor, shifts=-depth, dims=0)
-    shifted_seq_idx = torch.roll(seq_idx, shifts=-depth, dims=0)
-    token_idx = torch.arange(seq_idx.numel(), device=seq_idx.device)
-    valid = (token_idx + depth < seq_idx.numel()) & (shifted_seq_idx == seq_idx)
+    valid = valid_mask
     while valid.ndim < shifted.ndim:
         valid = valid.unsqueeze(-1)
     return torch.where(valid, shifted, torch.zeros((), dtype=tensor.dtype, device=tensor.device))
@@ -415,8 +425,15 @@ def _build_packed_mtp_inputs(packed: dict[str, Tensor], num_depths: int) -> _Pac
         raise RuntimeError("Could not derive packed sequence IDs from cu_seqlens")
 
     depths = range(1, num_depths + 1)
+    valid_masks = _build_packed_mtp_shift_masks(seq_idx, num_depths)
     return _PackedMTPInputs(
-        embed_inputs=tuple(_shift_packed_tensor_for_mtp(packed["inputs_embeds"], depth, seq_idx) for depth in depths),
-        position_ids=tuple(_shift_packed_tensor_for_mtp(packed["position_ids"], depth, seq_idx) for depth in depths),
+        embed_inputs=tuple(
+            _shift_packed_tensor_for_mtp(packed["inputs_embeds"], depth, valid_mask)
+            for depth, valid_mask in zip(depths, valid_masks)
+        ),
+        position_ids=tuple(
+            _shift_packed_tensor_for_mtp(packed["position_ids"], depth, valid_mask)
+            for depth, valid_mask in zip(depths, valid_masks)
+        ),
         targets=tuple(iter_mtp_depth_targets(packed["labels"], num_depths, seq_idx=seq_idx)),
     )

--- a/nemo/collections/speechlm2/parts/parallel.py
+++ b/nemo/collections/speechlm2/parts/parallel.py
@@ -38,11 +38,12 @@ def validate_parallelism_compatibility(
     attn_backend: str,
     nvte_fused_attn: Optional[str],
     device_capability: Optional[tuple[int, int]],
+    check_backward: bool = True,
 ) -> None:
     """Raise on known-incompatible SALMAutomodel configurations.
 
-    Catches three combinations that produce silent NaN gradients or
-    hangs at training time:
+    Catches three combinations that produce incorrect forward execution,
+    silent NaN gradients, or hangs at training time:
 
     1. ``packed_sequences=False`` (BSHD) under ``cp_size > 1``: TE's
        fused-attention CP path rejects ``padding_causal``, so the
@@ -64,14 +65,14 @@ def validate_parallelism_compatibility(
        ``NVTE_FUSED_ATTN=0`` in the launcher environment to force
        FlashAttention dispatch.
 
-    Hard error on (1), (2), and (3)-on-sm_120; ``warnings.warn`` on
-    (3) for other architectures (the bug may not apply but we have no
-    way to be certain).
+    Hard error on (1) and (2). When ``check_backward`` is true, hard error
+    on (3)-on-sm_120 and ``warnings.warn`` on (3) for other architectures
+    (the bug may not apply but we have no way to be certain).
 
     Pure function — no side effects on globals or environment, so it
-    can be unit-tested with synthetic inputs. Called from
-    :meth:`SALMAutomodel.on_fit_start` once the device mesh is wired
-    up.
+    can be unit-tested with synthetic inputs. ``check_backward=False``
+    skips only case (3) for validation/test forwards that do not run a
+    backward pass.
     """
     # Case 1: BSHD + CP > 1 — hard incompatibility.
     if not packed_sequences and cp_size > 1:
@@ -97,7 +98,7 @@ def validate_parallelism_compatibility(
             )
 
         # Case 3: THD + TE attention without NVTE_FUSED_ATTN=0.
-        if nvte_fused_attn != "0":
+        if check_backward and nvte_fused_attn != "0":
             msg = (
                 "SALMAutomodel: ``packed_sequences=true`` with ``attn=te`` and "
                 "``NVTE_FUSED_ATTN`` not set to ``\"0\"`` (got "

--- a/nemo/collections/speechlm2/parts/pretrained.py
+++ b/nemo/collections/speechlm2/parts/pretrained.py
@@ -626,20 +626,14 @@ def init_from_training_checkpoint(model: torch.nn.Module, checkpoint_path: str):
 
     if _is_dcp_checkpoint(checkpoint_path):
         import torch.distributed.checkpoint as dcp
-        from torch.distributed.checkpoint.default_planner import DefaultLoadPlanner
 
         # Lightning saves model weights under the "state_dict" key in DCP.
         # Wrapping with the same structure lets DCP match keys correctly.
         # Optimizer states and other trainer state are ignored automatically
         # because we only provide the model's state_dict.
         state_dict = {"state_dict": model.state_dict()}
-        model_cfg = getattr(model, "cfg", None)
-        allow_partial = bool(model_cfg and model_cfg.get("init_from_checkpoint_allow_partial", False))
-        planner = DefaultLoadPlanner(allow_partial_load=True) if allow_partial else None
-        if allow_partial:
-            logging.info("DCP partial load enabled; checkpoint-missing model keys keep their initialized values")
         with python313_pathlib_pickle_compat():
-            dcp.load(state_dict, checkpoint_id=str(checkpoint_path), planner=planner)
+            dcp.load(state_dict, checkpoint_id=str(checkpoint_path))
         model.load_state_dict(state_dict["state_dict"])
         logging.info(f"Loaded distributed checkpoint from {checkpoint_path}")
     else:

--- a/nemo/collections/speechlm2/parts/pretrained.py
+++ b/nemo/collections/speechlm2/parts/pretrained.py
@@ -633,7 +633,8 @@ def init_from_training_checkpoint(model: torch.nn.Module, checkpoint_path: str):
         # Optimizer states and other trainer state are ignored automatically
         # because we only provide the model's state_dict.
         state_dict = {"state_dict": model.state_dict()}
-        allow_partial = bool(model.cfg.get("init_from_checkpoint_allow_partial", False))
+        model_cfg = getattr(model, "cfg", None)
+        allow_partial = bool(model_cfg and model_cfg.get("init_from_checkpoint_allow_partial", False))
         planner = DefaultLoadPlanner(allow_partial_load=True) if allow_partial else None
         if allow_partial:
             logging.info("DCP partial load enabled; checkpoint-missing model keys keep their initialized values")

--- a/nemo/collections/speechlm2/parts/pretrained.py
+++ b/nemo/collections/speechlm2/parts/pretrained.py
@@ -93,6 +93,8 @@ def load_pretrained_automodel_llm(
     pretrained_weights: bool = True,
     dtype=torch.float32,
     trust_remote_code: bool = False,
+    mtp_config_overrides: dict | None = None,
+    replace_mtp_config: bool = False,
     **kwargs,
 ):
     """
@@ -104,9 +106,15 @@ def load_pretrained_automodel_llm(
     Setting ``pretrained_weights=False`` returns a model that has identical architecture
     with the checkpoint, but is randomly initialized.
 
-    Extra ``kwargs`` (including ``distributed_setup``) are forwarded to the
-    underlying ``from_pretrained`` / ``from_config`` call so that parallelization
-    happens during loading.
+    When ``mtp_config_overrides`` is provided, the checkpoint config is loaded
+    first and the overrides are applied only when it has no enabled MTP head, or
+    unconditionally when ``replace_mtp_config=True``. When overrides apply, the
+    resulting model is constructed through ``from_config`` before its base checkpoint is loaded, so
+    Automodel applies its normal initialization and parallelization to a new MTP
+    head. When the architecture is added or replaced, all checkpoint ``mtp.*``
+    tensors are excluded from the base load so the configured head keeps its
+    fresh initialization. Extra ``kwargs`` (including ``distributed_setup``)
+    are forwarded so parallelization happens during construction.
     """
     from nemo_automodel import NeMoAutoModelForCausalLM
 
@@ -118,6 +126,42 @@ def load_pretrained_automodel_llm(
         trust_remote_code=trust_remote_code,
     )
 
+    if mtp_config_overrides is not None:
+        config_kwargs, automodel_kwargs = _split_automodel_hf_resolution_kwargs(kwargs)
+        if pretrained_weights:
+            checkpoint_path = _resolve_automodel_checkpoint_path(model_path_or_name, config_kwargs)
+        else:
+            checkpoint_path = _resolve_automodel_checkpoint_path(
+                model_path_or_name, config_kwargs, include_weights=False
+            )
+        config = AutoConfig.from_pretrained(
+            checkpoint_path,
+            trust_remote_code=trust_remote_code,
+            local_files_only=True,
+        )
+        checkpoint_has_mtp = _automodel_config_has_mtp(config)
+        config_overridden = replace_mtp_config or not checkpoint_has_mtp
+        if not config_overridden and pretrained_weights:
+            return NeMoAutoModelForCausalLM.from_pretrained(
+                checkpoint_path,
+                torch_dtype=dtype,
+                trust_remote_code=trust_remote_code,
+                **automodel_kwargs,
+            )
+        if config_overridden:
+            for name, value in mtp_config_overrides.items():
+                setattr(config, name, value)
+        model = NeMoAutoModelForCausalLM.from_config(
+            config,
+            torch_dtype=dtype,
+            load_base_model=False,
+            trust_remote_code=trust_remote_code,
+            **automodel_kwargs,
+        )
+        if pretrained_weights and config_overridden:
+            _load_automodel_base_checkpoint_without_mtp(model, checkpoint_path, automodel_kwargs)
+        return model
+
     if pretrained_weights:
         return NeMoAutoModelForCausalLM.from_pretrained(
             model_path_or_name,
@@ -128,6 +172,36 @@ def load_pretrained_automodel_llm(
     else:
         config = AutoConfig.from_pretrained(model_path_or_name, trust_remote_code=trust_remote_code)
         return NeMoAutoModelForCausalLM.from_config(config, torch_dtype=dtype, **kwargs)
+
+
+def _load_automodel_base_checkpoint_without_mtp(model, model_path_or_name: str, automodel_kwargs: dict) -> None:
+    """Load an Automodel base checkpoint without overwriting a freshly configured MTP head."""
+    from nemo_automodel.components.checkpoint.checkpointing import Checkpointer, CheckpointingConfig
+
+    distributed_setup = automodel_kwargs.get("distributed_setup")
+    mesh_context = getattr(distributed_setup, "mesh_context", None)
+    cache_dir = automodel_kwargs.get("cache_dir")
+    checkpointer = Checkpointer(
+        CheckpointingConfig(
+            enabled=True,
+            checkpoint_dir="",
+            model_save_format="safetensors",
+            model_cache_dir=cache_dir,
+            model_repo_id=model_path_or_name,
+            save_consolidated=False,
+            is_peft=automodel_kwargs.get("peft_config") is not None,
+            skip_task_head_prefixes_for_base_model=["mtp."],
+        ),
+        0,
+        0,
+        0,
+        getattr(mesh_context, "moe_mesh", None),
+        process_group=getattr(mesh_context, "process_group", None),
+    )
+
+    device = torch.device("cuda", torch.cuda.current_device()) if torch.cuda.is_available() else torch.device("cpu")
+    with _exclude_mtp_checkpoint_state(model):
+        checkpointer.load_base_model(model, device, cache_dir, model_path_or_name, load_base_model=True)
 
 
 def update_perception_output_dim(model):
@@ -659,3 +733,124 @@ def maybe_load_pretrained_models(model: torch.nn.Module):
 
     if model.cfg.get("init_from_checkpoint", None):
         init_from_training_checkpoint(model, model.cfg.init_from_checkpoint)
+
+
+def _automodel_config_has_mtp(config) -> bool:
+    """Whether an HF config describes an enabled MTP head."""
+    depth = getattr(config, "num_nextn_predict_layers", None)
+    if depth is None:
+        depth = getattr(config, "mtp_num_hidden_layers", 0)
+    return int(depth or 0) > 0
+
+
+_AUTOMODEL_HF_RESOLUTION_KWARGS = {
+    "cache_dir",
+    "force_download",
+    "local_files_only",
+    "proxies",
+    "resume_download",
+    "revision",
+    "subfolder",
+    "token",
+    "use_auth_token",
+}
+
+
+def _split_automodel_hf_resolution_kwargs(kwargs: dict) -> tuple[dict, dict]:
+    """Separate Hugging Face repository resolution options from model-construction options."""
+    config_kwargs = {name: value for name, value in kwargs.items() if name in _AUTOMODEL_HF_RESOLUTION_KWARGS}
+    automodel_kwargs = {name: value for name, value in kwargs.items() if name not in _AUTOMODEL_HF_RESOLUTION_KWARGS}
+    if "cache_dir" in kwargs:
+        automodel_kwargs["cache_dir"] = kwargs["cache_dir"]
+    return config_kwargs, automodel_kwargs
+
+
+def _resolve_automodel_checkpoint_path(
+    model_path_or_name: str, hf_kwargs: dict, *, include_weights: bool = True
+) -> str:
+    """Resolve one exact local checkpoint snapshot for config-first Automodel loading."""
+    model_path = Path(model_path_or_name)
+    subfolder = hf_kwargs.get("subfolder")
+    if model_path.exists():
+        resolved_path = model_path
+    else:
+        from huggingface_hub import snapshot_download
+
+        snapshot_kwargs = {
+            name: value
+            for name, value in hf_kwargs.items()
+            if name
+            in {
+                "cache_dir",
+                "force_download",
+                "local_files_only",
+                "proxies",
+                "resume_download",
+                "revision",
+                "token",
+            }
+        }
+        if "token" not in snapshot_kwargs and "use_auth_token" in hf_kwargs:
+            snapshot_kwargs["token"] = hf_kwargs["use_auth_token"]
+        if not include_weights:
+            snapshot_kwargs["allow_patterns"] = ["*.json", "*.py"]
+        resolved_path = Path(snapshot_download(repo_id=model_path_or_name, **snapshot_kwargs))
+
+    if subfolder:
+        resolved_path = resolved_path / subfolder
+    if not resolved_path.exists():
+        raise FileNotFoundError(f"Resolved Automodel checkpoint path does not exist: {resolved_path}")
+    return str(resolved_path)
+
+
+def _is_mtp_state_key(key: str) -> bool:
+    return "mtp" in key.split(".")
+
+
+@contextmanager
+def _exclude_mtp_checkpoint_state(model):
+    """Exclude MTP tensors even in Automodel's direct HF checkpoint fast paths."""
+    load_hook = None
+    if hasattr(model, "register_load_state_dict_pre_hook"):
+
+        def remove_mtp_from_load(_module, state_dict, *_args):
+            for key in list(state_dict):
+                if _is_mtp_state_key(key):
+                    state_dict.pop(key)
+
+        load_hook = model.register_load_state_dict_pre_hook(remove_mtp_from_load)
+
+    adapter = _find_automodel_state_dict_adapter(model)
+    original_from_hf = getattr(adapter, "from_hf", None)
+    adapter_attributes = getattr(adapter, "__dict__", {})
+    had_instance_from_hf = "from_hf" in adapter_attributes
+    instance_from_hf = adapter_attributes.get("from_hf")
+    if original_from_hf is not None:
+
+        def from_hf_without_mtp(state_dict, *args, **kwargs):
+            filtered_state = {key: value for key, value in state_dict.items() if not _is_mtp_state_key(key)}
+            return original_from_hf(filtered_state, *args, **kwargs)
+
+        adapter.from_hf = from_hf_without_mtp
+    try:
+        yield
+    finally:
+        if load_hook is not None:
+            load_hook.remove()
+        if original_from_hf is not None:
+            if had_instance_from_hf:
+                adapter.from_hf = instance_from_hf
+            else:
+                del adapter.from_hf
+
+
+def _find_automodel_state_dict_adapter(model):
+    visited = set()
+    current = model
+    while current is not None and id(current) not in visited:
+        visited.add(id(current))
+        adapter = getattr(current, "state_dict_adapter", None)
+        if adapter is not None:
+            return adapter
+        current = getattr(current, "module", None) or getattr(current, "_orig_mod", None)
+    return None

--- a/nemo/collections/speechlm2/parts/pretrained.py
+++ b/nemo/collections/speechlm2/parts/pretrained.py
@@ -626,14 +626,19 @@ def init_from_training_checkpoint(model: torch.nn.Module, checkpoint_path: str):
 
     if _is_dcp_checkpoint(checkpoint_path):
         import torch.distributed.checkpoint as dcp
+        from torch.distributed.checkpoint.default_planner import DefaultLoadPlanner
 
         # Lightning saves model weights under the "state_dict" key in DCP.
         # Wrapping with the same structure lets DCP match keys correctly.
         # Optimizer states and other trainer state are ignored automatically
         # because we only provide the model's state_dict.
         state_dict = {"state_dict": model.state_dict()}
+        allow_partial = bool(model.cfg.get("init_from_checkpoint_allow_partial", False))
+        planner = DefaultLoadPlanner(allow_partial_load=True) if allow_partial else None
+        if allow_partial:
+            logging.info("DCP partial load enabled; checkpoint-missing model keys keep their initialized values")
         with python313_pathlib_pickle_compat():
-            dcp.load(state_dict, checkpoint_id=str(checkpoint_path))
+            dcp.load(state_dict, checkpoint_id=str(checkpoint_path), planner=planner)
         model.load_state_dict(state_dict["state_dict"])
         logging.info(f"Loaded distributed checkpoint from {checkpoint_path}")
     else:

--- a/nemo/collections/speechlm2/parts/pretrained.py
+++ b/nemo/collections/speechlm2/parts/pretrained.py
@@ -106,16 +106,21 @@ def load_pretrained_automodel_llm(
     Setting ``pretrained_weights=False`` returns a model that has identical architecture
     with the checkpoint, but is randomly initialized.
 
-    When ``mtp_config_overrides`` is provided, the checkpoint config is loaded
-    first and the overrides are applied only when it has no enabled MTP head, or
-    unconditionally when ``replace_mtp_config=True``. When overrides apply, the
-    resulting model is constructed through ``from_config`` before its base checkpoint is loaded, so
-    Automodel applies its normal initialization and parallelization to a new MTP
-    head. When the architecture is added or replaced, all checkpoint ``mtp.*``
-    tensors are excluded from the base load so the configured head keeps its
-    fresh initialization. Extra ``kwargs`` (including ``distributed_setup``)
-    are forwarded so parallelization happens during construction.
+    The checkpoint config is inspected when ``mtp_config_overrides`` is provided
+    or repeated-layer MTP is requested. Overrides are applied only when the
+    checkpoint has no enabled MTP head, or unconditionally when
+    ``replace_mtp_config=True``. A preserved native head must have physical depth
+    one when repeated-layer MTP is requested. When overrides apply, the resulting
+    model is constructed through ``from_config`` before its base checkpoint is
+    loaded, so Automodel applies its normal initialization and parallelization to
+    a new MTP head. All checkpoint ``mtp.*`` tensors are excluded from that base
+    load so the configured head keeps its fresh initialization. Extra ``kwargs``
+    (including ``distributed_setup``) are forwarded so parallelization happens
+    during construction.
     """
+    if replace_mtp_config and mtp_config_overrides is None:
+        raise ValueError("replace_mtp_config=True requires mtp_config_overrides to define the replacement head.")
+
     from nemo_automodel import NeMoAutoModelForCausalLM
 
     from nemo.collections.speechlm2.parts.automodel_compat import remove_automodel_backend_for_hf_fallback
@@ -126,7 +131,8 @@ def load_pretrained_automodel_llm(
         trust_remote_code=trust_remote_code,
     )
 
-    if mtp_config_overrides is not None:
+    use_repeated_mtp = bool(kwargs.get("mtp_use_repeated_layer", False))
+    if mtp_config_overrides is not None or use_repeated_mtp:
         config_kwargs, automodel_kwargs = _split_automodel_hf_resolution_kwargs(kwargs)
         if pretrained_weights:
             checkpoint_path = _resolve_automodel_checkpoint_path(model_path_or_name, config_kwargs)
@@ -139,16 +145,30 @@ def load_pretrained_automodel_llm(
             trust_remote_code=trust_remote_code,
             local_files_only=True,
         )
-        checkpoint_has_mtp = _automodel_config_has_mtp(config)
-        config_overridden = replace_mtp_config or not checkpoint_has_mtp
-        if not config_overridden and pretrained_weights:
+        checkpoint_physical_depth = _automodel_config_mtp_depth(config)
+        checkpoint_has_mtp = checkpoint_physical_depth > 0
+        if use_repeated_mtp and not replace_mtp_config:
+            if not checkpoint_has_mtp and mtp_config_overrides is None:
+                raise ValueError(
+                    "MTP use_repeated_layer=True requires either a checkpoint with a native MTP head or "
+                    "mtp_config_overrides that define a new head."
+                )
+            if checkpoint_has_mtp and checkpoint_physical_depth != 1:
+                raise ValueError(
+                    "MTP use_repeated_layer=True can preserve only a checkpoint with one physical MTP depth; "
+                    f"checkpoint declares {checkpoint_physical_depth}. Set use_repeated_layer=false to preserve "
+                    "the native independent heads, or set replace_existing_head=true to initialize a fresh "
+                    "repeated head."
+                )
+        initialize_fresh_mtp = replace_mtp_config or not checkpoint_has_mtp
+        if not initialize_fresh_mtp and pretrained_weights:
             return NeMoAutoModelForCausalLM.from_pretrained(
                 checkpoint_path,
                 torch_dtype=dtype,
                 trust_remote_code=trust_remote_code,
                 **automodel_kwargs,
             )
-        if config_overridden:
+        if initialize_fresh_mtp:
             for name, value in mtp_config_overrides.items():
                 setattr(config, name, value)
         model = NeMoAutoModelForCausalLM.from_config(
@@ -158,7 +178,7 @@ def load_pretrained_automodel_llm(
             trust_remote_code=trust_remote_code,
             **automodel_kwargs,
         )
-        if pretrained_weights and config_overridden:
+        if pretrained_weights and initialize_fresh_mtp:
             _load_automodel_base_checkpoint_without_mtp(model, checkpoint_path, automodel_kwargs)
         return model
 
@@ -735,12 +755,12 @@ def maybe_load_pretrained_models(model: torch.nn.Module):
         init_from_training_checkpoint(model, model.cfg.init_from_checkpoint)
 
 
-def _automodel_config_has_mtp(config) -> bool:
-    """Whether an HF config describes an enabled MTP head."""
+def _automodel_config_mtp_depth(config) -> int:
+    """Return the physical MTP depth declared by an HF config."""
     depth = getattr(config, "num_nextn_predict_layers", None)
     if depth is None:
         depth = getattr(config, "mtp_num_hidden_layers", 0)
-    return int(depth or 0) > 0
+    return int(depth or 0)
 
 
 _AUTOMODEL_HF_RESOLUTION_KWARGS = {

--- a/tests/collections/speechlm2/test_pretrained.py
+++ b/tests/collections/speechlm2/test_pretrained.py
@@ -548,6 +548,9 @@ def test_exclude_mtp_checkpoint_state_restores_hook_and_adapter_after_error():
         def from_hf(self, state_dict, **_kwargs):
             return state_dict
 
+    def fail_checkpoint_load():
+        raise RuntimeError("checkpoint load failed")
+
     model = torch.nn.Linear(2, 2)
     model.state_dict_adapter = IdentityStateDictAdapter()
 
@@ -555,7 +558,7 @@ def test_exclude_mtp_checkpoint_state_restores_hook_and_adapter_after_error():
         with pretrained._exclude_mtp_checkpoint_state(model):
             assert model._load_state_dict_pre_hooks
             assert "from_hf" in model.state_dict_adapter.__dict__
-            raise RuntimeError("checkpoint load failed")
+            fail_checkpoint_load()
 
     assert not model._load_state_dict_pre_hooks
     assert "from_hf" not in model.state_dict_adapter.__dict__

--- a/tests/collections/speechlm2/test_pretrained.py
+++ b/tests/collections/speechlm2/test_pretrained.py
@@ -174,6 +174,214 @@ def test_load_pretrained_automodel_llm_can_replace_native_mtp_config():
     base_load.assert_called_once_with(result, "native-mtp-checkpoint", {})
 
 
+_REPEATED_MTP_OVERRIDES = {
+    "num_nextn_predict_layers": 1,
+    "mtp_hybrid_override_pattern": "*",
+}
+
+
+@pytest.mark.parametrize(
+    "mtp_config_overrides",
+    [
+        pytest.param(None, id="native-config-only"),
+        pytest.param(_REPEATED_MTP_OVERRIDES, id="fallback-config-present"),
+    ],
+)
+def test_load_pretrained_automodel_llm_accepts_one_depth_native_head_as_repeated(mtp_config_overrides):
+    config = SimpleNamespace(
+        num_nextn_predict_layers=1,
+        mtp_hybrid_override_pattern="*E",
+        name_or_path="one-depth-mtp-checkpoint",
+    )
+    automodel, config_patch, module_patch, compat_patch = _mock_automodel_loader(config)
+    loader_kwargs = {
+        "num_nextn_predict_layers": 4,
+        "mtp_use_repeated_layer": True,
+    }
+    if mtp_config_overrides is not None:
+        loader_kwargs["mtp_config_overrides"] = mtp_config_overrides
+
+    with (
+        config_patch as config_loader,
+        module_patch,
+        compat_patch,
+        patch.object(
+            pretrained,
+            "_resolve_automodel_checkpoint_path",
+            return_value="one-depth-mtp-checkpoint",
+        ) as resolve_checkpoint,
+    ):
+        pretrained.load_pretrained_automodel_llm("one-depth-mtp-checkpoint", **loader_kwargs)
+
+    resolve_checkpoint.assert_called_once_with("one-depth-mtp-checkpoint", {})
+    config_loader.assert_called_once_with(
+        "one-depth-mtp-checkpoint",
+        trust_remote_code=False,
+        local_files_only=True,
+    )
+    automodel.from_pretrained.assert_called_once_with(
+        "one-depth-mtp-checkpoint",
+        torch_dtype=torch.float32,
+        trust_remote_code=False,
+        num_nextn_predict_layers=4,
+        mtp_use_repeated_layer=True,
+    )
+    automodel.from_config.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "mtp_config_overrides",
+    [
+        pytest.param(None, id="native-config-only"),
+        pytest.param(_REPEATED_MTP_OVERRIDES, id="fallback-config-present"),
+    ],
+)
+def test_load_pretrained_automodel_llm_rejects_multi_depth_native_head_as_repeated(mtp_config_overrides):
+    config = SimpleNamespace(
+        num_nextn_predict_layers=4,
+        mtp_hybrid_override_pattern="*E",
+        name_or_path="independent-mtp-checkpoint",
+    )
+    automodel, config_patch, module_patch, compat_patch = _mock_automodel_loader(config)
+    loader_kwargs = {
+        "num_nextn_predict_layers": 4,
+        "mtp_use_repeated_layer": True,
+    }
+    if mtp_config_overrides is not None:
+        loader_kwargs["mtp_config_overrides"] = mtp_config_overrides
+
+    with (
+        config_patch,
+        module_patch,
+        compat_patch,
+        patch.object(
+            pretrained,
+            "_resolve_automodel_checkpoint_path",
+            return_value="independent-mtp-checkpoint",
+        ),
+        pytest.raises(ValueError, match="one physical MTP depth"),
+    ):
+        pretrained.load_pretrained_automodel_llm("independent-mtp-checkpoint", **loader_kwargs)
+
+    automodel.from_pretrained.assert_not_called()
+    automodel.from_config.assert_not_called()
+
+
+def test_load_pretrained_automodel_llm_builds_repeated_head_for_checkpoint_without_mtp():
+    config = SimpleNamespace(num_nextn_predict_layers=0, name_or_path="base-checkpoint")
+    automodel, config_patch, module_patch, compat_patch = _mock_automodel_loader(config)
+
+    with (
+        config_patch,
+        module_patch,
+        compat_patch,
+        patch.object(pretrained, "_resolve_automodel_checkpoint_path", return_value="base-checkpoint"),
+        patch.object(pretrained, "_load_automodel_base_checkpoint_without_mtp", create=True) as base_load,
+    ):
+        result = pretrained.load_pretrained_automodel_llm(
+            "base-checkpoint",
+            mtp_config_overrides=_REPEATED_MTP_OVERRIDES,
+            num_nextn_predict_layers=4,
+            mtp_use_repeated_layer=True,
+        )
+
+    assert config.num_nextn_predict_layers == 1
+    automodel.from_config.assert_called_once_with(
+        config,
+        torch_dtype=torch.float32,
+        load_base_model=False,
+        trust_remote_code=False,
+        num_nextn_predict_layers=4,
+        mtp_use_repeated_layer=True,
+    )
+    base_load.assert_called_once_with(
+        result,
+        "base-checkpoint",
+        {"num_nextn_predict_layers": 4, "mtp_use_repeated_layer": True},
+    )
+    automodel.from_pretrained.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("checkpoint_depth", "mtp_config_overrides"),
+    [
+        pytest.param(0, _REPEATED_MTP_OVERRIDES, id="fresh-head"),
+        pytest.param(1, None, id="native-head"),
+    ],
+)
+def test_load_pretrained_automodel_llm_builds_repeated_model_without_checkpoint_weights(
+    checkpoint_depth, mtp_config_overrides
+):
+    config = SimpleNamespace(num_nextn_predict_layers=checkpoint_depth, name_or_path="config-only-checkpoint")
+    automodel, config_patch, module_patch, compat_patch = _mock_automodel_loader(config)
+    loader_kwargs = {
+        "num_nextn_predict_layers": 4,
+        "mtp_use_repeated_layer": True,
+    }
+    if mtp_config_overrides is not None:
+        loader_kwargs["mtp_config_overrides"] = mtp_config_overrides
+
+    with (
+        config_patch,
+        module_patch,
+        compat_patch,
+        patch.object(
+            pretrained,
+            "_resolve_automodel_checkpoint_path",
+            return_value="config-only-checkpoint",
+        ) as resolve_checkpoint,
+        patch.object(pretrained, "_load_automodel_base_checkpoint_without_mtp", create=True) as base_load,
+    ):
+        result = pretrained.load_pretrained_automodel_llm(
+            "config-only-checkpoint",
+            pretrained_weights=False,
+            **loader_kwargs,
+        )
+
+    assert result is automodel.from_config.return_value
+    assert config.num_nextn_predict_layers == 1
+    resolve_checkpoint.assert_called_once_with("config-only-checkpoint", {}, include_weights=False)
+    automodel.from_config.assert_called_once_with(
+        config,
+        torch_dtype=torch.float32,
+        load_base_model=False,
+        trust_remote_code=False,
+        num_nextn_predict_layers=4,
+        mtp_use_repeated_layer=True,
+    )
+    automodel.from_pretrained.assert_not_called()
+    base_load.assert_not_called()
+
+
+def test_load_pretrained_automodel_llm_rejects_repeated_mode_without_head_definition():
+    config = SimpleNamespace(num_nextn_predict_layers=0, name_or_path="base-checkpoint")
+    automodel, config_patch, module_patch, compat_patch = _mock_automodel_loader(config)
+
+    with (
+        config_patch,
+        module_patch,
+        compat_patch,
+        patch.object(pretrained, "_resolve_automodel_checkpoint_path", return_value="base-checkpoint"),
+        pytest.raises(ValueError, match="requires either a checkpoint with a native MTP head"),
+    ):
+        pretrained.load_pretrained_automodel_llm(
+            "base-checkpoint",
+            num_nextn_predict_layers=4,
+            mtp_use_repeated_layer=True,
+        )
+
+    automodel.from_pretrained.assert_not_called()
+    automodel.from_config.assert_not_called()
+
+
+def test_load_pretrained_automodel_llm_rejects_replace_without_config_overrides():
+    with pytest.raises(ValueError, match="requires mtp_config_overrides"):
+        pretrained.load_pretrained_automodel_llm(
+            "native-mtp-checkpoint",
+            replace_mtp_config=True,
+        )
+
+
 def test_load_pretrained_automodel_llm_forwards_hf_resolution_kwargs():
     config = SimpleNamespace(num_nextn_predict_layers=0, name_or_path="private-checkpoint")
     automodel, config_patch, module_patch, compat_patch = _mock_automodel_loader(config)
@@ -259,12 +467,16 @@ def test_resolve_automodel_checkpoint_path_uses_exact_snapshot(tmp_path, include
     )
 
 
-def test_automodel_native_mtp_detection_supports_non_nemotron_config_fields():
-    assert pretrained._automodel_config_has_mtp(
-        SimpleNamespace(num_nextn_predict_layers=2, mtp_hybrid_override_pattern=None, mtp_layers_block_type=None)
+def test_automodel_mtp_depth_supports_non_nemotron_config_fields():
+    assert (
+        pretrained._automodel_config_mtp_depth(
+            SimpleNamespace(num_nextn_predict_layers=2, mtp_hybrid_override_pattern=None, mtp_layers_block_type=None)
+        )
+        == 2
     )
-    assert pretrained._automodel_config_has_mtp(
-        SimpleNamespace(num_nextn_predict_layers=None, mtp_num_hidden_layers=2)
+    assert (
+        pretrained._automodel_config_mtp_depth(SimpleNamespace(num_nextn_predict_layers=None, mtp_num_hidden_layers=2))
+        == 2
     )
 
 
@@ -329,3 +541,22 @@ def test_automodel_base_load_keeps_fresh_mtp_on_direct_fast_paths(tmp_path, chec
     torch.testing.assert_close(model.base.weight, torch.full_like(model.base.weight, 3.0))
     torch.testing.assert_close(model.mtp.weight, fresh_mtp)
     assert model.state_dict_adapter.loaded_keys == {"base.weight"}
+
+
+def test_exclude_mtp_checkpoint_state_restores_hook_and_adapter_after_error():
+    class IdentityStateDictAdapter:
+        def from_hf(self, state_dict, **_kwargs):
+            return state_dict
+
+    model = torch.nn.Linear(2, 2)
+    model.state_dict_adapter = IdentityStateDictAdapter()
+
+    with pytest.raises(RuntimeError, match="checkpoint load failed"):
+        with pretrained._exclude_mtp_checkpoint_state(model):
+            assert model._load_state_dict_pre_hooks
+            assert "from_hf" in model.state_dict_adapter.__dict__
+            raise RuntimeError("checkpoint load failed")
+
+    assert not model._load_state_dict_pre_hooks
+    assert "from_hf" not in model.state_dict_adapter.__dict__
+    assert model.state_dict_adapter.from_hf.__func__ is IdentityStateDictAdapter.from_hf

--- a/tests/collections/speechlm2/test_pretrained.py
+++ b/tests/collections/speechlm2/test_pretrained.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import pytest
+import torch
 from omegaconf import DictConfig
+from safetensors.torch import save_file
 
 from nemo.collections.speechlm2.parts import pretrained
 
@@ -52,3 +55,277 @@ def test_setup_speech_encoder_hydrates_missing_config_without_weights():
     assert model.cfg.perception.encoder.n_layers == 2
     assert model.cfg.perception.output_dim == 8
     assert model.cfg.perception.modality_adapter.output_dim == 8
+
+
+def _mock_automodel_loader(config):
+    automodel = SimpleNamespace(from_config=MagicMock(return_value=object()), from_pretrained=MagicMock())
+    return (
+        automodel,
+        patch.object(pretrained.AutoConfig, "from_pretrained", return_value=config),
+        patch.dict("sys.modules", {"nemo_automodel": SimpleNamespace(NeMoAutoModelForCausalLM=automodel)}),
+        patch("nemo.collections.speechlm2.parts.automodel_compat.remove_automodel_backend_for_hf_fallback"),
+    )
+
+
+def test_load_pretrained_automodel_llm_builds_missing_mtp_before_loading_weights():
+    config = SimpleNamespace(num_nextn_predict_layers=0, name_or_path="base-checkpoint")
+    automodel, config_patch, module_patch, compat_patch = _mock_automodel_loader(config)
+
+    with (
+        config_patch,
+        module_patch,
+        compat_patch,
+        patch.object(pretrained, "_resolve_automodel_checkpoint_path", return_value="base-checkpoint"),
+        patch.object(pretrained, "_load_automodel_base_checkpoint_without_mtp", create=True) as base_load,
+    ):
+        result = pretrained.load_pretrained_automodel_llm(
+            "base-checkpoint",
+            pretrained_weights=True,
+            dtype=torch.bfloat16,
+            mtp_config_overrides={
+                "num_nextn_predict_layers": 1,
+                "mtp_hybrid_override_pattern": "*",
+                "mtp_layers_block_type": None,
+            },
+        )
+
+    assert result is automodel.from_config.return_value
+    assert config.num_nextn_predict_layers == 1
+    assert config.mtp_hybrid_override_pattern == "*"
+    assert config.mtp_layers_block_type is None
+    automodel.from_config.assert_called_once_with(
+        config,
+        torch_dtype=torch.bfloat16,
+        load_base_model=False,
+        trust_remote_code=False,
+    )
+    base_load.assert_called_once_with(result, "base-checkpoint", {})
+    automodel.from_pretrained.assert_not_called()
+
+
+def test_load_pretrained_automodel_llm_preserves_native_mtp_config_by_default():
+    config = SimpleNamespace(
+        num_nextn_predict_layers=1,
+        mtp_hybrid_override_pattern="*E",
+        name_or_path="native-mtp-checkpoint",
+    )
+    automodel, config_patch, module_patch, compat_patch = _mock_automodel_loader(config)
+
+    with (
+        config_patch,
+        module_patch,
+        compat_patch,
+        patch.object(pretrained, "_resolve_automodel_checkpoint_path", return_value="native-mtp-checkpoint"),
+        patch.object(pretrained, "_load_automodel_base_checkpoint_without_mtp", create=True) as base_load,
+    ):
+        pretrained.load_pretrained_automodel_llm(
+            "native-mtp-checkpoint",
+            mtp_config_overrides={
+                "num_nextn_predict_layers": 2,
+                "mtp_hybrid_override_pattern": "**",
+            },
+        )
+
+    assert config.num_nextn_predict_layers == 1
+    assert config.mtp_hybrid_override_pattern == "*E"
+    automodel.from_pretrained.assert_called_once_with(
+        "native-mtp-checkpoint",
+        torch_dtype=torch.float32,
+        trust_remote_code=False,
+    )
+    automodel.from_config.assert_not_called()
+    base_load.assert_not_called()
+
+
+def test_load_pretrained_automodel_llm_can_replace_native_mtp_config():
+    config = SimpleNamespace(
+        num_nextn_predict_layers=1,
+        mtp_hybrid_override_pattern="*E",
+        name_or_path="native-mtp-checkpoint",
+    )
+    automodel, config_patch, module_patch, compat_patch = _mock_automodel_loader(config)
+
+    with (
+        config_patch,
+        module_patch,
+        compat_patch,
+        patch.object(pretrained, "_resolve_automodel_checkpoint_path", return_value="native-mtp-checkpoint"),
+        patch.object(pretrained, "_load_automodel_base_checkpoint_without_mtp", create=True) as base_load,
+    ):
+        result = pretrained.load_pretrained_automodel_llm(
+            "native-mtp-checkpoint",
+            mtp_config_overrides={
+                "num_nextn_predict_layers": 2,
+                "mtp_hybrid_override_pattern": "**",
+                "mtp_layers_block_type": None,
+            },
+            replace_mtp_config=True,
+        )
+
+    assert config.num_nextn_predict_layers == 2
+    assert config.mtp_hybrid_override_pattern == "**"
+    assert config.mtp_layers_block_type is None
+    automodel.from_config.assert_called_once_with(
+        config,
+        torch_dtype=torch.float32,
+        load_base_model=False,
+        trust_remote_code=False,
+    )
+    base_load.assert_called_once_with(result, "native-mtp-checkpoint", {})
+
+
+def test_load_pretrained_automodel_llm_forwards_hf_resolution_kwargs():
+    config = SimpleNamespace(num_nextn_predict_layers=0, name_or_path="private-checkpoint")
+    automodel, config_patch, module_patch, compat_patch = _mock_automodel_loader(config)
+
+    with (
+        config_patch as config_loader,
+        module_patch,
+        compat_patch,
+        patch.object(
+            pretrained,
+            "_resolve_automodel_checkpoint_path",
+            return_value="/cache/exact-snapshot/subdir",
+            create=True,
+        ) as resolve_checkpoint,
+        patch.object(pretrained, "_load_automodel_base_checkpoint_without_mtp", create=True) as base_load,
+    ):
+        result = pretrained.load_pretrained_automodel_llm(
+            "private-checkpoint",
+            trust_remote_code=True,
+            mtp_config_overrides={"num_nextn_predict_layers": 1, "mtp_hybrid_override_pattern": "*"},
+            token="secret-token",
+            revision="exact-revision",
+            cache_dir="/cache",
+            local_files_only=True,
+            subfolder="subdir",
+        )
+
+    config_loader.assert_called_once_with(
+        "/cache/exact-snapshot/subdir",
+        trust_remote_code=True,
+        local_files_only=True,
+    )
+    resolve_checkpoint.assert_called_once_with(
+        "private-checkpoint",
+        {
+            "token": "secret-token",
+            "revision": "exact-revision",
+            "cache_dir": "/cache",
+            "local_files_only": True,
+            "subfolder": "subdir",
+        },
+    )
+    automodel.from_config.assert_called_once_with(
+        config,
+        torch_dtype=torch.float32,
+        load_base_model=False,
+        trust_remote_code=True,
+        cache_dir="/cache",
+    )
+    base_load.assert_called_once_with(result, "/cache/exact-snapshot/subdir", {"cache_dir": "/cache"})
+
+
+@pytest.mark.parametrize(
+    ("include_weights", "expected_extra_kwargs"),
+    [(True, {}), (False, {"allow_patterns": ["*.json", "*.py"]})],
+)
+def test_resolve_automodel_checkpoint_path_uses_exact_snapshot(tmp_path, include_weights, expected_extra_kwargs):
+    snapshot_root = tmp_path / "snapshot"
+    expected_path = snapshot_root / "weights"
+    expected_path.mkdir(parents=True)
+
+    with patch("huggingface_hub.snapshot_download", return_value=str(snapshot_root)) as snapshot_download:
+        result = pretrained._resolve_automodel_checkpoint_path(
+            "private-checkpoint",
+            {
+                "cache_dir": str(tmp_path / "cache"),
+                "local_files_only": True,
+                "revision": "exact-revision",
+                "subfolder": "weights",
+                "token": "secret-token",
+            },
+            include_weights=include_weights,
+        )
+
+    assert result == str(expected_path)
+    snapshot_download.assert_called_once_with(
+        repo_id="private-checkpoint",
+        cache_dir=str(tmp_path / "cache"),
+        local_files_only=True,
+        revision="exact-revision",
+        token="secret-token",
+        **expected_extra_kwargs,
+    )
+
+
+def test_automodel_native_mtp_detection_supports_non_nemotron_config_fields():
+    assert pretrained._automodel_config_has_mtp(
+        SimpleNamespace(num_nextn_predict_layers=2, mtp_hybrid_override_pattern=None, mtp_layers_block_type=None)
+    )
+    assert pretrained._automodel_config_has_mtp(
+        SimpleNamespace(num_nextn_predict_layers=None, mtp_num_hidden_layers=2)
+    )
+
+
+def test_automodel_base_load_skips_checkpoint_mtp_for_fresh_head(tmp_path):
+    model = SimpleNamespace(config=SimpleNamespace(model_type="nemotron_h"), backbone=object())
+
+    with (
+        patch("nemo_automodel.components.checkpoint.checkpointing.Checkpointer") as checkpointer_cls,
+        patch.object(torch.cuda, "is_available", return_value=False),
+    ):
+        pretrained._load_automodel_base_checkpoint_without_mtp(
+            model,
+            str(tmp_path),
+            {},
+        )
+
+    checkpoint_config = checkpointer_cls.call_args.args[0]
+    assert checkpoint_config.skip_task_head_prefixes_for_base_model == ["mtp."]
+    checkpointer_cls.return_value.load_base_model.assert_called_once_with(
+        model,
+        torch.device("cpu"),
+        None,
+        str(tmp_path),
+        load_base_model=True,
+    )
+    checkpointer_cls.return_value.load_model.assert_not_called()
+
+
+@pytest.mark.parametrize("checkpoint_format", ["bin", "safetensors"])
+def test_automodel_base_load_keeps_fresh_mtp_on_direct_fast_paths(tmp_path, checkpoint_format):
+    class IdentityStateDictAdapter:
+        def __init__(self):
+            self.loaded_keys = None
+
+        def from_hf(self, state_dict, **_kwargs):
+            self.loaded_keys = set(state_dict)
+            return state_dict
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.base = torch.nn.Linear(2, 2, bias=False)
+            self.mtp = torch.nn.Linear(2, 2, bias=False)
+            self.config = SimpleNamespace(model_type="tiny_test", tie_word_embeddings=False)
+            self.state_dict_adapter = IdentityStateDictAdapter()
+
+    model = TinyModel()
+    fresh_mtp = model.mtp.weight.detach().clone()
+    checkpoint_state = {
+        "base.weight": torch.full_like(model.base.weight, 3.0),
+        "mtp.weight": torch.full_like(model.mtp.weight, 9.0),
+    }
+    if checkpoint_format == "bin":
+        torch.save(checkpoint_state, tmp_path / "pytorch_model.bin")
+    else:
+        # Exercise Automodel's single-device custom-model safetensors branch.
+        TinyModel.__module__ = "nemo_automodel.components.models.test"
+        save_file(checkpoint_state, tmp_path / "model.safetensors")
+
+    pretrained._load_automodel_base_checkpoint_without_mtp(model, str(tmp_path), {})
+
+    torch.testing.assert_close(model.base.weight, torch.full_like(model.base.weight, 3.0))
+    torch.testing.assert_close(model.mtp.weight, fresh_mtp)
+    assert model.state_dict_adapter.loaded_keys == {"base.weight"}

--- a/tests/collections/speechlm2/test_salm_automodel_mtp.py
+++ b/tests/collections/speechlm2/test_salm_automodel_mtp.py
@@ -103,6 +103,101 @@ def test_disabled_mtp_overrides_native_checkpoint_head(monkeypatch):
     assert not model._mtp_enabled
 
 
+@pytest.mark.parametrize("training_mode", ["joint", "head_only"])
+def test_base_checkpoint_attaches_fresh_mtp_for_both_training_modes(monkeypatch, training_mode):
+    """A checkpoint with no native head gets a fresh head in either enabled mode."""
+    from omegaconf import DictConfig
+
+    import nemo.collections.speechlm2.models.salm_automodel as salm_module
+
+    class _Perception(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.adapter = torch.nn.Linear(4, 4)
+
+        def set_activation_checkpointing(self, _enabled):
+            return None
+
+    class _LLM(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.backbone = torch.nn.Linear(4, 4)
+            self.config = type("Config", (), {"hidden_size": 4})()
+            self.mtp = None
+
+    model = _bare_model()
+    model.cfg = DictConfig(
+        {
+            "pretrained_llm": "base-checkpoint-without-mtp",
+            "pretrained_asr": "unused-in-test",
+            "pretrained_weights": True,
+            "freeze_params": ["^.+$"] if training_mode == "head_only" else [],
+            "prevent_freeze_params": [],
+            "mtp": {"enabled": True, "training_mode": training_mode},
+        }
+    )
+    model._trainer = None
+    model._use_fsdp = False
+    model._use_tp = False
+    model.setup_moe_options = lambda: None
+
+    monkeypatch.setattr(salm_module, "load_pretrained_automodel_llm", lambda *_args, **_kwargs: _LLM())
+    monkeypatch.setattr(
+        salm_module, "setup_speech_encoder", lambda model, **_kwargs: setattr(model, "perception", _Perception())
+    )
+    monkeypatch.setattr(salm_module, "update_perception_output_dim", lambda _model: None)
+    monkeypatch.setattr(salm_module, "maybe_load_pretrained_models", lambda _model: None)
+
+    def _attach_fresh_head(self, _mtp_cfg, _dtype):
+        self.llm.mtp = torch.nn.Linear(4, 4)
+
+    monkeypatch.setattr(SALMAutomodel, "_build_and_attach_mtp_head", _attach_fresh_head)
+
+    SALMAutomodel.configure_model(model)
+
+    assert model._mtp_enabled
+    assert all(param.requires_grad for param in model.llm.mtp.parameters())
+    if training_mode == "head_only":
+        assert all(not param.requires_grad for param in model.llm.backbone.parameters())
+        assert all(not param.requires_grad for param in model.perception.parameters())
+        assert r"^llm\.mtp\..+$" in model.cfg.prevent_freeze_params
+        from nemo.collections.speechlm2.parts.optim_setup import freeze_and_subset
+
+        optimizer_params = list(
+            freeze_and_subset(model.named_parameters(), model.cfg.freeze_params, model.cfg.prevent_freeze_params)
+        )
+        assert {id(param) for param in optimizer_params} == {id(param) for param in model.llm.mtp.parameters()}
+    else:
+        assert all(param.requires_grad for param in model.llm.backbone.parameters())
+        assert all(param.requires_grad for param in model.perception.parameters())
+
+
+def test_invalid_mtp_training_mode_fails_before_loading(monkeypatch):
+    from omegaconf import DictConfig
+
+    import nemo.collections.speechlm2.models.salm_automodel as salm_module
+
+    model = _bare_model()
+    model.cfg = DictConfig(
+        {
+            "pretrained_llm": "unused",
+            "pretrained_asr": "unused",
+            "mtp": {"enabled": True, "training_mode": "backbone_only"},
+        }
+    )
+    model._trainer = None
+    model._use_fsdp = False
+    model._use_tp = False
+    monkeypatch.setattr(
+        salm_module,
+        "load_pretrained_automodel_llm",
+        lambda *_args, **_kwargs: pytest.fail("invalid mode must fail before loading"),
+    )
+
+    with pytest.raises(ValueError, match="mtp.training_mode"):
+        SALMAutomodel.configure_model(model)
+
+
 # ---------------------------------------------------------------------------
 # forward: mtp_per_depth_h extraction
 # ---------------------------------------------------------------------------

--- a/tests/collections/speechlm2/test_salm_automodel_mtp.py
+++ b/tests/collections/speechlm2/test_salm_automodel_mtp.py
@@ -457,7 +457,7 @@ def test_validation_step_preserves_mtp_counter_precision_with_bf16_logits(monkey
 
 
 def test_validation_step_warns_when_cp_disables_mtp_teacher_forced_metrics(monkeypatch):
-    """CP-precomputed MTP targets disable agreement metrics with a visible warning."""
+    """CP-precomputed MTP targets disable the unused MTP forward with a visible warning."""
     model = _bare_model()
     model.llm = torch.nn.Module()
     model.llm.mtp = torch.nn.Identity()
@@ -473,10 +473,13 @@ def test_validation_step_warns_when_cp_disables_mtp_teacher_forced_metrics(monke
         "llm_kwargs": {},
     }
     model.prepare_inputs = lambda _batch: inputs
-    model.forward = lambda *_args, **_kwargs: {
-        "logits": torch.zeros(2, 4),
-        "mtp_per_depth_h": [torch.zeros(2, 4)],
-    }
+    mtp_eval_states = []
+
+    def _forward(*_args, **_kwargs):
+        mtp_eval_states.append(model.llm.compute_mtp_in_eval)
+        return {"logits": torch.zeros(2, 4)}
+
+    model.forward = _forward
     monkeypatch.setattr(
         salm_module,
         "calculate_mtp_teacher_forced_agreement",
@@ -491,6 +494,7 @@ def test_validation_step_warns_when_cp_disables_mtp_teacher_forced_metrics(monke
 
     SALMAutomodel.validation_step(model, {"ds": {}}, batch_idx=0)
 
+    assert mtp_eval_states == [False]
     assert warnings == [
         (
             "MTP teacher-forced agreement metrics are disabled under context parallelism because "

--- a/tests/collections/speechlm2/test_salm_automodel_mtp.py
+++ b/tests/collections/speechlm2/test_salm_automodel_mtp.py
@@ -255,13 +255,13 @@ def test_forward_omits_mtp_per_depth_h_when_absent():
 
 
 # ---------------------------------------------------------------------------
-# validation MTP acceptance metrics
+# validation MTP teacher-forced agreement metrics
 # ---------------------------------------------------------------------------
 
 
-def test_validation_epoch_end_logs_mtp_acceptance():
-    '''on_validation_epoch_end reports verifier-prefix acceptance probabilities
-    and their expected acceptance length.'''
+def test_validation_epoch_end_logs_mtp_teacher_forced_agreement():
+    '''on_validation_epoch_end reports teacher-forced prefix agreement
+    probabilities and the corresponding prefix length.'''
     from collections import defaultdict
 
     model = _bare_model()
@@ -277,21 +277,21 @@ def test_validation_epoch_end_logs_mtp_acceptance():
     model._partial_val_num_frames = defaultdict(list, {'ds': [torch.tensor(10.0)]})
     model._partial_val_lss = defaultdict(list)
 
-    # Depth-1 prefix: 8/10 accepted; depth-2 prefix: 5/10 accepted.
+    # Depth-1 prefix: 8/10 agree; depth-2 prefix: 5/10 agree.
     model._partial_val_mtp_correct = defaultdict(list, {'ds': [torch.tensor([8.0, 5.0])]})
     model._partial_val_mtp_valid = defaultdict(list, {'ds': [torch.tensor([10.0, 10.0])]})
 
     SALMAutomodel.on_validation_epoch_end(model)
 
-    assert logged['val_mtp_acc_ds/head_1'] == pytest.approx(0.8)
-    assert logged['val_mtp_acc_ds/head_2'] == pytest.approx(0.5)
+    assert logged['val_mtp_teacher_forced_agreement_ds/head_1'] == pytest.approx(0.8)
+    assert logged['val_mtp_teacher_forced_agreement_ds/head_2'] == pytest.approx(0.5)
     # 1 (main verifier token) + P(A1) + P(A1 and A2) = 2.3.
-    assert logged['val_mtp_accept_length_ds'] == pytest.approx(2.3)
-    assert logged['val_mtp_accept_length'] == pytest.approx(2.3)
+    assert logged['val_mtp_teacher_forced_prefix_length_ds'] == pytest.approx(2.3)
+    assert logged['val_mtp_teacher_forced_prefix_length'] == pytest.approx(2.3)
 
 
-def test_calculate_mtp_acceptance_with_heads_counts(monkeypatch):
-    '''Acceptance compares drafts with verifier predictions and requires a matched prefix.'''
+def test_calculate_mtp_teacher_forced_agreement_with_heads_counts(monkeypatch):
+    '''Agreement compares drafts with teacher-forced verifier predictions and requires a matched prefix.'''
     # The helper imports these specific Automodel submodules; importorskip each so the test
     # skips cleanly when the installed Automodel rev predates them (rather than hard-failing).
     pytest.importorskip('nemo_automodel.components.loss.utils', reason='needs Automodel _get_lm_head_module')
@@ -312,11 +312,11 @@ def test_calculate_mtp_acceptance_with_heads_counts(monkeypatch):
     # Depth 1's verifier targets are [1, 2, 3, 0]. Drafts match positions 0, 2, 3.
     depth_1_ids = torch.tensor([[1, 0, 3, 0, 0]])
     # Depth 2 matches all three verifier targets [2, 3, 0], but position 1 cannot
-    # be accepted because depth 1 already mismatched there.
+    # agree at depth 2 because depth 1 already mismatched there.
     depth_2_ids = torch.tensor([[2, 3, 0, 0, 0]])
     mtp_h = [torch.nn.functional.one_hot(ids, num_classes=V).float() for ids in (depth_1_ids, depth_2_ids)]
 
-    correct, valid = salm_module._calculate_mtp_acceptance_with_heads(
+    correct, valid = salm_module._calculate_mtp_teacher_forced_agreement_with_heads(
         mtp_per_depth_h=mtp_h,
         labels=labels,
         model=model,
@@ -353,7 +353,8 @@ def test_mtp_validation_forward_uses_and_restores_native_gate():
     assert not llm.training
 
 
-def test_mtp_rejects_context_parallelism(monkeypatch):
+@pytest.mark.parametrize("hook_name", ["on_validation_start", "on_test_start"])
+def test_standalone_evaluation_rejects_mtp_context_parallelism(monkeypatch, hook_name):
     from omegaconf import DictConfig
 
     import nemo.collections.speechlm2.parts.parallel as parallel_module
@@ -375,7 +376,56 @@ def test_mtp_rejects_context_parallelism(monkeypatch):
     monkeypatch.setattr(parallel_module, "validate_parallelism_compatibility", lambda **_kwargs: None)
 
     with pytest.raises(ValueError, match="requires cp_size=1"):
+        getattr(model, hook_name)()
+
+
+def test_mtp_rejects_tensor_parallelism_before_training(monkeypatch):
+    from omegaconf import DictConfig
+
+    import nemo.collections.speechlm2.parts.parallel as parallel_module
+
+    class _Submesh:
+        def size(self):
+            return 2
+
+    class _Mesh:
+        mesh_dim_names = ("tp",)
+
+        def __getitem__(self, name):
+            assert name == "tp"
+            return _Submesh()
+
+    model = _bare_model()
+    model.cfg = DictConfig({"mtp": {"enabled": True}, "packed_sequences": False})
+    model._device_mesh = _Mesh()
+    monkeypatch.setattr(parallel_module, "validate_parallelism_compatibility", lambda **_kwargs: None)
+
+    with pytest.raises(ValueError, match="requires tp_size=1"):
         model._validate_parallelism_compatibility()
+
+
+def test_vocab_argmax_does_not_materialize_full_dtensor_logits(monkeypatch):
+    expected = torch.tensor([[3, 1]])
+
+    class _FakeDTensor:
+        def __init__(self, *, is_logits):
+            self.is_logits = is_logits
+
+        def argmax(self, dim):
+            assert self.is_logits
+            assert dim == -1
+            return _FakeDTensor(is_logits=False)
+
+        def full_tensor(self):
+            if self.is_logits:
+                pytest.fail("vocabulary-sharded logits must not be fully materialized")
+            return expected
+
+    monkeypatch.setattr(salm_module, "DTensor", _FakeDTensor)
+
+    predictions = salm_module._vocab_parallel_argmax(_FakeDTensor(is_logits=True))
+
+    assert predictions is expected
 
 
 def test_fused_mtp_loss_reuses_lm_weight_without_projecting_logits(monkeypatch):
@@ -399,6 +449,15 @@ def test_fused_mtp_loss_reuses_lm_weight_without_projecting_logits(monkeypatch):
 
     monkeypatch.setattr(loss_utils, "calculate_loss", _calculate_loss)
     mtp_h = [torch.randn(1, 4, 4, requires_grad=True) for _ in range(2)]
+    grad_reduce_group = object()
+    materialize_calls = []
+
+    def _materialize(weight, *, grad_reduce_group=None):
+        materialize_calls.append((weight, grad_reduce_group))
+        return weight
+
+    monkeypatch.setattr(salm_module, "DTensor", torch.nn.Parameter)
+    monkeypatch.setattr(loss_module.FusedLinearCrossEntropy, "materialize_lm_weight", staticmethod(_materialize))
 
     total, head_losses, raw_head_losses = salm_module._calculate_mtp_loss_with_heads(
         loss_fn=loss_module.FusedLinearCrossEntropy(reduction="sum"),
@@ -406,13 +465,169 @@ def test_fused_mtp_loss_reuses_lm_weight_without_projecting_logits(monkeypatch):
         labels=torch.tensor([[0, 1, 2, 3]]),
         model=model,
         scaling_factor=0.1,
+        grad_reduce_group=grad_reduce_group,
     )
 
     assert len(calls) == 2
     assert calls[0]["lm_weight"] is model.lm_head.weight
     assert calls[1]["lm_weight"] is calls[0]["lm_weight"]
+    assert materialize_calls == [(model.lm_head.weight, grad_reduce_group)]
+    assert all(call["grad_reduce_group"] is grad_reduce_group for call in calls)
     assert float(total.detach()) == pytest.approx(0.2)
     assert [float(value.detach()) for value in head_losses] == pytest.approx([0.1, 0.1])
     assert [float(value.detach()) for value in raw_head_losses] == pytest.approx([2.0, 2.0])
     total.backward()
     assert all(hidden.grad is not None for hidden in mtp_h)
+
+
+@pytest.mark.parametrize("cut_ce_available", [True, False])
+def test_mtp_loss_selection_handles_optional_cut_cross_entropy(monkeypatch, cut_ce_available):
+    from nemo_automodel.components.loss import linear_ce
+    from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
+
+    monkeypatch.setattr(linear_ce, "HAVE_CUT_CROSS_ENTROPY", cut_ce_available)
+
+    loss_fn = salm_module._build_mtp_loss_fn()
+
+    expected_type = linear_ce.FusedLinearCrossEntropy if cut_ce_available else MaskedCrossEntropy
+    assert isinstance(loss_fn, expected_type)
+
+
+def test_head_only_keep_pattern_follows_wrapped_mtp_namespace():
+    from omegaconf import DictConfig
+
+    from nemo.collections.speechlm2.parts.optim_setup import freeze_and_subset
+
+    class _LLM(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.backbone = torch.nn.Linear(4, 4)
+            self.mtp = torch.nn.Linear(4, 4)
+
+    class _CompiledWrapper(torch.nn.Module):
+        def __init__(self, module):
+            super().__init__()
+            self._orig_mod = module
+
+        @property
+        def mtp(self):
+            return self._orig_mod.mtp
+
+    model = _bare_model()
+    model.llm = _CompiledWrapper(_LLM())
+    model.perception = torch.nn.Linear(4, 4)
+    model.cfg = DictConfig({"freeze_params": [r"^llm\..+$"], "prevent_freeze_params": []})
+
+    model._apply_mtp_training_mode("head_only")
+
+    assert r"^llm\._orig_mod\.mtp\..+$" in model.cfg.prevent_freeze_params
+    optimizer_params = list(
+        freeze_and_subset(model.named_parameters(), model.cfg.freeze_params, model.cfg.prevent_freeze_params)
+    )
+    assert {id(param) for param in optimizer_params} == {id(param) for param in model.llm.mtp.parameters()}
+
+
+def test_joint_keep_pattern_follows_wrapped_mtp_namespace():
+    from omegaconf import DictConfig
+
+    from nemo.collections.speechlm2.parts.optim_setup import freeze_and_subset
+
+    class _LLM(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.backbone = torch.nn.Linear(4, 4)
+            self.mtp = torch.nn.Linear(4, 4)
+
+    class _CompiledWrapper(torch.nn.Module):
+        def __init__(self, module):
+            super().__init__()
+            self._orig_mod = module
+
+        @property
+        def mtp(self):
+            return self._orig_mod.mtp
+
+    model = _bare_model()
+    model.llm = _CompiledWrapper(_LLM())
+    model.perception = torch.nn.Linear(4, 4)
+    model.cfg = DictConfig(
+        {
+            "freeze_params": [r"^llm\..+$"],
+            "prevent_freeze_params": [r"^llm\.mtp\..+$"],
+        }
+    )
+
+    model._apply_mtp_training_mode("joint")
+
+    assert r"^llm\._orig_mod\.mtp\..+$" in model.cfg.prevent_freeze_params
+    optimizer_params = list(
+        freeze_and_subset(model.named_parameters(), model.cfg.freeze_params, model.cfg.prevent_freeze_params)
+    )
+    optimizer_param_ids = {id(param) for param in optimizer_params}
+    assert {id(param) for param in model.llm.mtp.parameters()} <= optimizer_param_ids
+    assert all(param.requires_grad for param in model.llm.mtp.parameters())
+    assert all(not param.requires_grad for param in model.llm._orig_mod.backbone.parameters())
+
+
+def test_fresh_mtp_head_is_initialized_and_exports_physical_depth(monkeypatch):
+    from types import SimpleNamespace
+
+    from omegaconf import DictConfig
+
+    mtp_module = pytest.importorskip(
+        "nemo_automodel.components.models.nemotron_v3.mtp", reason="needs Automodel NemotronV3 MTP"
+    )
+    initialized_on = []
+
+    class _Layer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.zeros(2, 2))
+
+        def init_weights(self, buffer_device=None):
+            initialized_on.append(buffer_device)
+            with torch.no_grad():
+                self.weight.fill_(0.25)
+
+    class _MTP(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layers = torch.nn.ModuleList([_Layer()])
+
+    class _LLM(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = SimpleNamespace()
+            self.backend = object()
+            self.model = SimpleNamespace(moe_config=None)
+            self.mtp = None
+
+    runtime_mtp_config = SimpleNamespace(num_layers=3, num_physical_depths=1)
+    fresh_mtp = _MTP()
+
+    def _build_config(config, **kwargs):
+        assert config.num_nextn_predict_layers == 3
+        assert kwargs["use_repeated_layer"]
+        return runtime_mtp_config
+
+    monkeypatch.setattr(mtp_module, "build_mtp_config_from_hf", _build_config)
+    monkeypatch.setattr(mtp_module, "build_nemotron_v3_mtp", lambda *_args, **_kwargs: fresh_mtp)
+
+    model = _bare_model()
+    model.llm = _LLM()
+    model._mtp_loss_scaling_factor = 0.1
+    cfg = DictConfig(
+        {
+            "num_nextn_predict_layers": 3,
+            "hybrid_override_pattern": "*",
+            "use_repeated_layer": True,
+        }
+    )
+
+    with pytest.warns(UserWarning, match="MTP head attached"):
+        model._build_and_attach_mtp_head(cfg, torch.float32)
+
+    assert model.llm.mtp is fresh_mtp
+    assert model.llm.config.num_nextn_predict_layers == 1
+    assert initialized_on == [next(fresh_mtp.parameters()).device]
+    assert torch.all(fresh_mtp.layers[0].weight == 0.25)

--- a/tests/collections/speechlm2/test_salm_automodel_mtp.py
+++ b/tests/collections/speechlm2/test_salm_automodel_mtp.py
@@ -456,6 +456,52 @@ def test_validation_step_preserves_mtp_counter_precision_with_bf16_logits(monkey
     assert valid.item() == 10_003
 
 
+def test_validation_step_warns_when_cp_disables_mtp_teacher_forced_metrics(monkeypatch):
+    """CP-precomputed MTP targets disable agreement metrics with a visible warning."""
+    model = _bare_model()
+    model.llm = torch.nn.Module()
+    model.llm.mtp = torch.nn.Identity()
+    model.llm.compute_mtp_in_eval = False
+    model.lss_loss = None
+    SALMAutomodel.on_validation_epoch_start(model)
+
+    inputs = {
+        "input_embeds": torch.zeros(2, 4),
+        "attention_mask": None,
+        "target_ids": torch.tensor([0, 1]),
+        "mtp_per_depth_targets": (torch.tensor([1, -100]),),
+        "llm_kwargs": {},
+    }
+    model.prepare_inputs = lambda _batch: inputs
+    model.forward = lambda *_args, **_kwargs: {
+        "logits": torch.zeros(2, 4),
+        "mtp_per_depth_h": [torch.zeros(2, 4)],
+    }
+    monkeypatch.setattr(
+        salm_module,
+        "calculate_mtp_teacher_forced_agreement",
+        lambda **_kwargs: pytest.fail("CP validation must not calculate rank-local agreement metrics"),
+    )
+    warnings = []
+    monkeypatch.setattr(
+        salm_module.logging,
+        "warning",
+        lambda message, **kwargs: warnings.append((message, kwargs)),
+    )
+
+    SALMAutomodel.validation_step(model, {"ds": {}}, batch_idx=0)
+
+    assert warnings == [
+        (
+            "MTP teacher-forced agreement metrics are disabled under context parallelism because "
+            "rank-local verifier predictions cannot be shifted across CP boundaries.",
+            {"mode": salm_module.logging_mode.ONCE},
+        )
+    ]
+    assert not model._partial_val_mtp_correct["ds"]
+    assert not model._partial_val_mtp_valid["ds"]
+
+
 def test_calculate_mtp_teacher_forced_agreement_with_heads_counts(monkeypatch):
     '''Agreement compares drafts with teacher-forced verifier predictions and requires a matched prefix.'''
     pytest.importorskip('nemo_automodel.components.models.common.mtp', reason='needs Automodel roll_tensor')

--- a/tests/collections/speechlm2/test_salm_automodel_mtp.py
+++ b/tests/collections/speechlm2/test_salm_automodel_mtp.py
@@ -109,8 +109,8 @@ def test_disabled_mtp_overrides_native_checkpoint_head(monkeypatch):
     ("training_mode", "replace_existing_head"),
     [("joint", False), ("head_only", False), ("joint", True)],
 )
-def test_base_checkpoint_attaches_fresh_mtp_for_both_training_modes(monkeypatch, training_mode, replace_existing_head):
-    """A checkpoint with no native head constructs MTP before Automodel loading."""
+def test_configure_model_requests_mtp_and_applies_training_mode(monkeypatch, training_mode, replace_existing_head):
+    """MTP loader options and parameter freezing follow the recipe configuration."""
     from omegaconf import DictConfig
 
     captured_kwargs = {}
@@ -442,6 +442,112 @@ def test_calculate_mtp_teacher_forced_agreement_with_heads_counts(monkeypatch):
     assert [int(value) for value in valid] == [4, 3]
 
 
+@pytest.mark.parametrize(
+    ("labels", "expected"),
+    [
+        (torch.zeros(5, dtype=torch.long), torch.tensor([0, 0, 0, 1, 1])),
+        (torch.zeros(2, 5, dtype=torch.long), torch.tensor([[0, 0, 0, 1, 1], [0, 0, 0, 1, 1]])),
+    ],
+)
+def test_resolve_mtp_seq_idx_from_cu_seqlens(labels, expected):
+    actual = salm_module._resolve_mtp_seq_idx(
+        labels,
+        cu_seqlens=torch.tensor([[0, 3, 5]], dtype=torch.int32),
+    )
+
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ("labels", "seq_idx", "expected"),
+    [
+        (
+            torch.zeros(2, 4, dtype=torch.long),
+            torch.tensor([0, 0, 1, 1]),
+            torch.tensor([[0, 0, 1, 1], [0, 0, 1, 1]]),
+        ),
+        (
+            torch.zeros(4, dtype=torch.long),
+            torch.tensor([[0, 0, 1, 1]]),
+            torch.tensor([0, 0, 1, 1]),
+        ),
+    ],
+)
+def test_resolve_mtp_seq_idx_normalizes_explicit_shape(labels, seq_idx, expected):
+    actual = salm_module._resolve_mtp_seq_idx(labels, seq_idx=seq_idx)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_resolve_mtp_seq_idx_rejects_shape_mismatch():
+    with pytest.raises(ValueError, match="does not match labels shape"):
+        salm_module._resolve_mtp_seq_idx(
+            torch.zeros(2, 4, dtype=torch.long),
+            seq_idx=torch.zeros(3, dtype=torch.long),
+        )
+
+
+def test_iter_mtp_depth_targets_masks_trailing_and_packed_boundaries():
+    targets = list(
+        salm_module._iter_mtp_depth_targets(
+            torch.tensor([10, 11, 12, 20, 21]),
+            2,
+            cu_seqlens=torch.tensor([0, 3, 5], dtype=torch.int32),
+        )
+    )
+
+    torch.testing.assert_close(targets[0], torch.tensor([11, 12, -100, 21, -100]))
+    torch.testing.assert_close(targets[1], torch.tensor([12, -100, -100, -100, -100]))
+
+
+def test_training_step_forwards_packed_cu_seqlens_to_mtp_loss(monkeypatch):
+    class _Perception(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.preprocessor = torch.nn.Identity()
+            self.encoder = torch.nn.Identity()
+
+    model = _bare_model()
+    model.perception = _Perception()
+    model.llm = torch.nn.Identity()
+    model.lss_loss = None
+    model._mtp_loss_fn = object()
+    model._mtp_loss_scaling_factor = 0.1
+    model._trainer = None
+    model.tokenizer = type("Tokenizer", (), {"pad": -1, "unk_id": None})()
+    model._get_moe_dp_group = lambda: None
+    model.log = lambda *_args, **_kwargs: None
+    model.log_dict = lambda *_args, **_kwargs: None
+    model.maybe_log_moe_metrics = lambda _batch_idx: None
+
+    cu_seqlens = torch.tensor([0, 3, 5], dtype=torch.int32)
+    inputs = {
+        "input_embeds": torch.zeros(5, 4),
+        "attention_mask": None,
+        "target_ids": torch.tensor([0, 1, 2, 3, 4]),
+        "llm_kwargs": {"cu_seqlens": cu_seqlens},
+        "num_tokens": 5,
+        "num_examples": 2,
+    }
+    model.prepare_inputs = lambda _batch: inputs
+    model.forward = lambda *_args, **_kwargs: {
+        "logits": torch.zeros(1, 5, 8),
+        "mtp_per_depth_h": [torch.zeros(1, 5, 4)],
+    }
+    captured_kwargs = {}
+
+    def _calculate_mtp_loss(*_args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return torch.tensor(0.25), [torch.tensor(2.5)]
+
+    monkeypatch.setattr(salm_module, "_calculate_mtp_loss_with_heads", _calculate_mtp_loss)
+
+    model._training_step_batch({"input_ids": torch.tensor([[1, 2, 3, 4, 5]])}, batch_idx=0)
+
+    assert captured_kwargs["cu_seqlens"] is cu_seqlens
+    assert captured_kwargs["labels"] is inputs["target_ids"]
+
+
 def test_mtp_validation_forward_legacy_gate_keeps_children_in_eval():
     llm = torch.nn.Module()
     llm.child = torch.nn.Dropout()
@@ -466,6 +572,27 @@ def test_mtp_validation_forward_uses_and_restores_native_gate():
 
     assert not llm.compute_mtp_in_eval
     assert not llm.training
+
+
+@pytest.mark.parametrize("native_gate", [False, True], ids=["legacy-training-flag", "compute-mtp-in-eval"])
+def test_mtp_validation_forward_restores_gate_after_error(native_gate):
+    llm = torch.nn.Module()
+    llm.eval()
+    if native_gate:
+        llm.compute_mtp_in_eval = False
+
+    with pytest.raises(RuntimeError, match="forward failed"):
+        with salm_module._mtp_validation_forward(llm, enabled=True):
+            if native_gate:
+                assert llm.compute_mtp_in_eval
+                assert not llm.training
+            else:
+                assert llm.training
+            raise RuntimeError("forward failed")
+
+    assert not llm.training
+    if native_gate:
+        assert not llm.compute_mtp_in_eval
 
 
 @pytest.mark.parametrize("hook_name", ["on_validation_start", "on_test_start"])
@@ -563,7 +690,7 @@ def test_fused_mtp_loss_reuses_lm_weight_without_projecting_logits(monkeypatch):
         return kwargs["hidden_states"].sum() * 0 + 2.0
 
     monkeypatch.setattr(loss_utils, "calculate_loss", _calculate_loss)
-    mtp_h = [torch.randn(1, 4, 4, requires_grad=True) for _ in range(2)]
+    mtp_h = [torch.randn(1, 5, 4, requires_grad=True) for _ in range(2)]
     grad_reduce_group = object()
     materialize_calls = []
 
@@ -579,53 +706,84 @@ def test_fused_mtp_loss_reuses_lm_weight_without_projecting_logits(monkeypatch):
         raising=False,
     )
 
-    total, head_losses, raw_head_losses = salm_module._calculate_mtp_loss_with_heads(
+    total, raw_head_losses = salm_module._calculate_mtp_loss_with_heads(
         loss_fn=loss_module.FusedLinearCrossEntropy(reduction="sum"),
         mtp_per_depth_h=mtp_h,
-        labels=torch.tensor([[0, 1, 2, 3]]),
+        labels=torch.tensor([[0, 1, 2, 3, 0]]),
         model=model,
         scaling_factor=0.1,
         grad_reduce_group=grad_reduce_group,
+        cu_seqlens=torch.tensor([0, 3, 5], dtype=torch.int32),
     )
 
     assert len(calls) == 2
+    torch.testing.assert_close(calls[0]["labels"], torch.tensor([[1, 2, -100, 0, -100]]))
+    torch.testing.assert_close(calls[1]["labels"], torch.tensor([[2, -100, -100, -100, -100]]))
     assert calls[0]["lm_weight"] is model.lm_head.weight
     assert calls[1]["lm_weight"] is calls[0]["lm_weight"]
     assert materialize_calls == [(model.lm_head.weight, grad_reduce_group)]
     assert all(call["grad_reduce_group"] is grad_reduce_group for call in calls)
     assert float(total.detach()) == pytest.approx(0.2)
-    assert [float(value.detach()) for value in head_losses] == pytest.approx([0.1, 0.1])
     assert [float(value.detach()) for value in raw_head_losses] == pytest.approx([2.0, 2.0])
     total.backward()
     assert all(hidden.grad is not None for hidden in mtp_h)
 
 
-@pytest.mark.parametrize("cut_ce_available", [True, False])
-def test_mtp_loss_selection_handles_optional_cut_cross_entropy(monkeypatch, cut_ce_available):
+def test_unfused_mtp_loss_resolves_lm_head_once(monkeypatch):
+    pytest.importorskip('nemo_automodel.components.models.common.mtp', reason='needs Automodel roll_tensor')
+    loss_utils = pytest.importorskip('nemo_automodel.components.loss.utils', reason='needs Automodel loss utilities')
+    from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
+
+    model = torch.nn.Module()
+    model.lm_head = torch.nn.Linear(4, 4, bias=False)
+    lookup_calls = []
+
+    def _get_lm_head(_model):
+        lookup_calls.append(_model)
+        return model.lm_head
+
+    monkeypatch.setattr(loss_utils, "_get_lm_head_module", _get_lm_head)
+
+    salm_module._calculate_mtp_loss_with_heads(
+        loss_fn=MaskedCrossEntropy(reduction="sum", fp32_upcast=False),
+        mtp_per_depth_h=[torch.randn(1, 4, 4) for _ in range(3)],
+        labels=torch.tensor([[0, 1, 2, 3]]),
+        model=model,
+    )
+
+    assert lookup_calls == [model]
+
+
+@pytest.mark.parametrize(
+    ("cut_ce_available", "gradient_safe_api", "expect_fused"),
+    [
+        pytest.param(False, False, False, id="cut-ce-unavailable"),
+        pytest.param(False, True, False, id="cut-ce-unavailable-with-api"),
+        pytest.param(True, False, False, id="legacy-automodel-api"),
+        pytest.param(True, True, True, id="fused-supported"),
+    ],
+)
+def test_mtp_loss_selection_handles_optional_cut_cross_entropy(
+    monkeypatch, cut_ce_available, gradient_safe_api, expect_fused
+):
     from nemo_automodel.components.loss import linear_ce
     from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
 
     monkeypatch.setattr(linear_ce, "HAVE_CUT_CROSS_ENTROPY", cut_ce_available)
+    if gradient_safe_api:
+        monkeypatch.setattr(
+            linear_ce.FusedLinearCrossEntropy,
+            "materialize_lm_weight",
+            staticmethod(lambda weight, **_kwargs: weight),
+            raising=False,
+        )
+    else:
+        monkeypatch.delattr(linear_ce.FusedLinearCrossEntropy, "materialize_lm_weight", raising=False)
 
     loss_fn = salm_module._build_mtp_loss_fn()
 
-    gradient_safe_fused_api = callable(getattr(linear_ce.FusedLinearCrossEntropy, "materialize_lm_weight", None))
-    expected_type = (
-        linear_ce.FusedLinearCrossEntropy if cut_ce_available and gradient_safe_fused_api else MaskedCrossEntropy
-    )
+    expected_type = linear_ce.FusedLinearCrossEntropy if expect_fused else MaskedCrossEntropy
     assert isinstance(loss_fn, expected_type)
-
-
-def test_mtp_loss_selection_requires_gradient_safe_fused_api(monkeypatch):
-    from nemo_automodel.components.loss import linear_ce
-    from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
-
-    monkeypatch.setattr(linear_ce, "HAVE_CUT_CROSS_ENTROPY", True)
-    monkeypatch.delattr(linear_ce.FusedLinearCrossEntropy, "materialize_lm_weight", raising=False)
-
-    loss_fn = salm_module._build_mtp_loss_fn()
-
-    assert isinstance(loss_fn, MaskedCrossEntropy)
 
 
 def test_head_only_keep_pattern_follows_wrapped_mtp_namespace():

--- a/tests/collections/speechlm2/test_salm_automodel_mtp.py
+++ b/tests/collections/speechlm2/test_salm_automodel_mtp.py
@@ -437,7 +437,7 @@ def test_validation_step_preserves_mtp_counter_precision_with_bf16_logits(monkey
         "llm_kwargs": {},
     }
     logits = torch.zeros(1, 2, 4, dtype=torch.bfloat16)
-    model.prepare_inputs = lambda _batch: inputs
+    model.prepare_inputs = lambda _batch, **_kwargs: inputs
     model.forward = lambda *_args, **_kwargs: {
         "logits": logits,
         "mtp_per_depth_h": [torch.zeros(1, 2, 4)],
@@ -459,11 +459,20 @@ def test_validation_step_preserves_mtp_counter_precision_with_bf16_logits(monkey
 
 
 def test_validation_step_warns_when_cp_disables_mtp_teacher_forced_metrics(monkeypatch):
-    """CP-precomputed MTP targets disable the unused MTP forward with a visible warning."""
+    """CP validation skips MTP inputs/forward/metrics with a visible warning."""
+
+    class _CPDeviceMesh:
+        mesh_dim_names = ("cp",)
+
+        def __getitem__(self, name):
+            assert name == "cp"
+            return SimpleNamespace(size=lambda: 2)
+
     model = _bare_model()
     model.llm = torch.nn.Module()
     model.llm.mtp = torch.nn.Identity()
     model.llm.compute_mtp_in_eval = False
+    model._device_mesh = _CPDeviceMesh()
     model.lss_loss = None
     SALMAutomodel.on_validation_epoch_start(model)
 
@@ -471,15 +480,23 @@ def test_validation_step_warns_when_cp_disables_mtp_teacher_forced_metrics(monke
         "input_embeds": torch.zeros(2, 4),
         "attention_mask": None,
         "target_ids": torch.tensor([0, 1]),
-        "mtp_per_depth_targets": (torch.tensor([1, -100]),),
         "llm_kwargs": {},
     }
-    model.prepare_inputs = lambda _batch: inputs
+    include_mtp_input_flags = []
+
+    def _prepare_inputs(_batch, *, include_mtp_inputs=True):
+        include_mtp_input_flags.append(include_mtp_inputs)
+        return inputs
+
+    model.prepare_inputs = _prepare_inputs
     mtp_eval_states = []
 
     def _forward(*_args, **_kwargs):
         mtp_eval_states.append(model.llm.compute_mtp_in_eval)
-        return {"logits": torch.zeros(2, 4)}
+        return {
+            "logits": torch.zeros(2, 4),
+            "mtp_per_depth_h": [torch.zeros(2, 4)],
+        }
 
     model.forward = _forward
     monkeypatch.setattr(
@@ -496,6 +513,7 @@ def test_validation_step_warns_when_cp_disables_mtp_teacher_forced_metrics(monke
 
     SALMAutomodel.validation_step(model, {"ds": {}}, batch_idx=0)
 
+    assert include_mtp_input_flags == [False]
     assert mtp_eval_states == [False]
     assert warnings == [
         (
@@ -689,6 +707,26 @@ def test_mtp_validation_forward_uses_and_restores_native_gate():
 
     assert not llm.compute_mtp_in_eval
     assert not llm.training
+
+
+def test_mtp_validation_forward_skips_model_without_native_gate(monkeypatch):
+    llm = torch.nn.Module()
+    warnings = []
+    monkeypatch.setattr(
+        mtp_module.logging,
+        "warning",
+        lambda message, **kwargs: warnings.append((message, kwargs)),
+    )
+
+    with mtp_module.mtp_validation_forward(llm, enabled=True):
+        assert not hasattr(llm, "compute_mtp_in_eval")
+
+    assert warnings == [
+        (
+            "Module does not expose compute_mtp_in_eval; skipping the MTP validation forward.",
+            {"mode": mtp_module.logging_mode.ONCE},
+        )
+    ]
 
 
 def test_mtp_validation_forward_restores_native_gate_after_error():

--- a/tests/collections/speechlm2/test_salm_automodel_mtp.py
+++ b/tests/collections/speechlm2/test_salm_automodel_mtp.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -654,12 +656,12 @@ def test_training_step_forwards_packed_cu_seqlens_to_mtp_loss(monkeypatch):
 
     def _calculate_mtp_loss(*_args, **kwargs):
         captured_kwargs.update(kwargs)
-        return salm_module.MTPLossOutput(
+        return SimpleNamespace(
             loss=torch.tensor(0.25),
             per_depth_losses=[torch.tensor(2.5)],
         )
 
-    monkeypatch.setattr(salm_module, "calculate_mtp_loss", _calculate_mtp_loss)
+    monkeypatch.setattr(salm_module, "calculate_mtp_loss_with_per_depth", _calculate_mtp_loss)
 
     model._training_step_batch({"input_ids": torch.tensor([[1, 2, 3, 4, 5]])}, batch_idx=0)
 

--- a/tests/collections/speechlm2/test_salm_automodel_mtp.py
+++ b/tests/collections/speechlm2/test_salm_automodel_mtp.py
@@ -1,0 +1,244 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import torch
+
+from nemo.collections.speechlm2.models import SALMAutomodel
+
+
+def _bare_model():
+    '''Create a SALMAutomodel instance without loading any weights.'''
+    model = SALMAutomodel.__new__(SALMAutomodel)
+    torch.nn.Module.__init__(model)
+    return model
+
+
+# ---------------------------------------------------------------------------
+# _mtp_enabled property
+# ---------------------------------------------------------------------------
+
+
+def test_mtp_enabled_false_when_llm_missing():
+    model = _bare_model()
+    assert not model._mtp_enabled
+
+
+def test_mtp_enabled_false_when_mtp_attr_missing():
+    model = _bare_model()
+    model.llm = torch.nn.Module()
+    assert not model._mtp_enabled
+
+
+def test_mtp_enabled_false_when_mtp_is_none():
+    model = _bare_model()
+    model.llm = torch.nn.Module()
+    model.llm.mtp = None
+    assert not model._mtp_enabled
+
+
+def test_mtp_enabled_true_when_mtp_attached():
+    model = _bare_model()
+    model.llm = torch.nn.Module()
+    model.llm.mtp = torch.nn.Linear(4, 4)
+    assert model._mtp_enabled
+
+
+def test_disabled_mtp_overrides_native_checkpoint_head(monkeypatch):
+    """Native checkpoint MTP weights are not instantiated when MTP is disabled."""
+    from omegaconf import DictConfig
+
+    import nemo.collections.speechlm2.models.salm_automodel as salm_module
+
+    captured_kwargs = {}
+
+    class _Perception(torch.nn.Module):
+        def set_activation_checkpointing(self, _enabled):
+            return None
+
+    class _LLM(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = type("Config", (), {"hidden_size": 8})()
+            self.mtp = None
+
+    def _load_llm(*_args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return _LLM()
+
+    model = _bare_model()
+    model.cfg = DictConfig(
+        {
+            "pretrained_llm": "native-mtp-checkpoint",
+            "pretrained_asr": "unused-in-test",
+            "pretrained_weights": True,
+            "mtp": {"enabled": False},
+        }
+    )
+    model._trainer = None
+    model._use_fsdp = False
+    model._use_tp = False
+    model.setup_moe_options = lambda: None
+
+    monkeypatch.setattr(salm_module, "load_pretrained_automodel_llm", _load_llm)
+    monkeypatch.setattr(
+        salm_module, "setup_speech_encoder", lambda model, **_kwargs: setattr(model, "perception", _Perception())
+    )
+    monkeypatch.setattr(salm_module, "update_perception_output_dim", lambda _model: None)
+    monkeypatch.setattr(salm_module, "maybe_load_pretrained_models", lambda _model: None)
+
+    SALMAutomodel.configure_model(model)
+
+    assert captured_kwargs["num_nextn_predict_layers"] == 0
+    assert not model._mtp_enabled
+
+
+# ---------------------------------------------------------------------------
+# forward: mtp_per_depth_h extraction
+# ---------------------------------------------------------------------------
+
+
+class _DictLikeOutput(dict):
+    '''Mimics a HuggingFace ModelOutput — dict keys are also accessible as attributes.'''
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError(name)
+
+
+class _FakeLLM(torch.nn.Module):
+    def __init__(self, out):
+        super().__init__()
+        self._out = out
+        self.mtp = None
+
+    def forward(self, **_kwargs):
+        return self._out
+
+
+def _make_forward_model(llm_out):
+    '''Minimal model that can run the forward() method with a mocked LLM.'''
+    model = _bare_model()
+    model.llm = _FakeLLM(llm_out)
+    model._use_tp = False
+    return model
+
+
+def test_forward_extracts_mtp_per_depth_h_when_present():
+    mtp_h = torch.randn(1, 4, 8)
+    fake_out = _DictLikeOutput(logits=torch.randn(1, 4, 32), mtp_per_depth_h=mtp_h)
+    model = _make_forward_model(fake_out)
+
+    result = model.forward(
+        input_embeds=torch.randn(1, 4, 32),
+        attention_mask=torch.ones(1, 4, dtype=torch.bool),
+    )
+
+    assert 'mtp_per_depth_h' in result
+    assert result['mtp_per_depth_h'] is mtp_h
+
+
+def test_forward_omits_mtp_per_depth_h_when_absent():
+    fake_out = _DictLikeOutput(logits=torch.randn(1, 4, 32))
+    model = _make_forward_model(fake_out)
+
+    result = model.forward(
+        input_embeds=torch.randn(1, 4, 32),
+        attention_mask=torch.ones(1, 4, dtype=torch.bool),
+    )
+
+    assert 'mtp_per_depth_h' not in result
+
+
+# ---------------------------------------------------------------------------
+# validation MTP acceptance metrics
+# ---------------------------------------------------------------------------
+
+
+def test_validation_epoch_end_logs_mtp_acceptance():
+    '''on_validation_epoch_end reports per-head acceptance probability and the
+    expected acceptance length (always-accepted main token + cumulative product
+    of per-head accept probabilities).'''
+    from collections import defaultdict
+
+    model = _bare_model()
+    model._get_moe_dp_group = lambda: None  # single-rank: _reduce_validation_metric_sums is a no-op
+    model.lss_loss = None
+
+    logged = {}
+    model.log = lambda name, value, **kwargs: logged.__setitem__(name, float(value))
+
+    # Standard val metrics still need populating — the method aggregates them first.
+    model._partial_val_loss_sums = defaultdict(list, {'ds': [torch.tensor(4.0)]})
+    model._partial_val_corrects = defaultdict(list, {'ds': [torch.tensor(8.0)]})
+    model._partial_val_num_frames = defaultdict(list, {'ds': [torch.tensor(10.0)]})
+    model._partial_val_lss = defaultdict(list)
+
+    # Head 1: 8/10 accepted (p1 = 0.8); head 2: 5/10 accepted (p2 = 0.5).
+    model._partial_val_mtp_correct = defaultdict(list, {'ds': [torch.tensor([8.0, 5.0])]})
+    model._partial_val_mtp_valid = defaultdict(list, {'ds': [torch.tensor([10.0, 10.0])]})
+
+    SALMAutomodel.on_validation_epoch_end(model)
+
+    assert logged['val_mtp_acc_ds/head_1'] == pytest.approx(0.8)
+    assert logged['val_mtp_acc_ds/head_2'] == pytest.approx(0.5)
+    # 1 (main) + 0.8 + 0.8 * 0.5 = 2.2
+    assert logged['val_mtp_accept_length_ds'] == pytest.approx(2.2)
+    assert logged['val_mtp_accept_length'] == pytest.approx(2.2)
+
+
+def test_calculate_mtp_acceptance_with_heads_counts(monkeypatch):
+    '''_calculate_mtp_acceptance_with_heads compares each head's argmax against the
+    same rolled/masked targets used by the MTP loss and returns per-head
+    (correct, valid) counts.'''
+    # The helper imports these specific Automodel submodules; importorskip each so the test
+    # skips cleanly when the installed Automodel rev predates them (rather than hard-failing).
+    pytest.importorskip('nemo_automodel.components.loss.utils', reason='needs Automodel _get_lm_head_module')
+    mtp_mod = pytest.importorskip('nemo_automodel.components.models.common.mtp', reason='needs Automodel roll_tensor')
+    roll_tensor = mtp_mod.roll_tensor
+
+    from nemo.collections.speechlm2.models.salm_automodel import _calculate_mtp_acceptance_with_heads
+
+    # Identity lm_head over a V==H one-hot space so argmax(hidden) == predicted token id.
+    V = 4
+    lm_head = torch.nn.Linear(V, V, bias=False)
+    with torch.no_grad():
+        lm_head.weight.copy_(torch.eye(V))
+    model = torch.nn.Module()
+    model.lm_head = lm_head
+    # Avoid depending on Automodel's lm-head discovery internals.
+    monkeypatch.setattr('nemo_automodel.components.loss.utils._get_lm_head_module', lambda m: m.lm_head)
+
+    labels = torch.tensor([[0, 1, 2, 3, 0]])  # (1, T)
+    T = labels.shape[-1]
+    D = 2
+    # Every head predicts token 0 everywhere (one-hot index 0).
+    one_hot_zero = torch.zeros(1, T, V)
+    one_hot_zero[..., 0] = 1.0
+    mtp_h = [one_hot_zero.clone() for _ in range(D)]
+
+    correct, valid = _calculate_mtp_acceptance_with_heads(mtp_per_depth_h=mtp_h, labels=labels, model=model)
+
+    # Independently recompute the rolled/masked targets with the real roll_tensor.
+    cur = labels
+    for k in range(D):
+        cur = roll_tensor(cur, shifts=-1, dim=-1)
+        masked = cur.clone()
+        masked[..., -min(k + 1, T) :] = -100
+        valid_mask = masked != -100
+        exp_valid = int(valid_mask.sum())
+        exp_correct = int(((masked == 0) & valid_mask).sum())  # preds are all 0
+        assert int(valid[k]) == exp_valid
+        assert int(correct[k]) == exp_correct

--- a/tests/collections/speechlm2/test_salm_automodel_mtp.py
+++ b/tests/collections/speechlm2/test_salm_automodel_mtp.py
@@ -57,6 +57,23 @@ def test_mtp_enabled_true_when_mtp_attached():
     assert model._mtp_enabled
 
 
+def test_mtp_num_depths_uses_logical_head_depth():
+    model = _bare_model()
+    model.llm = torch.nn.Module()
+    model.llm.mtp = torch.nn.Linear(4, 4)
+    model.llm.mtp_config = type("MTPConfig", (), {"num_layers": 3})()
+
+    assert model._mtp_num_depths == 3
+
+
+def test_mtp_num_depths_is_zero_without_head():
+    model = _bare_model()
+    model.llm = torch.nn.Module()
+    model.llm.mtp = None
+
+    assert model._mtp_num_depths == 0
+
+
 def test_disabled_mtp_overrides_native_checkpoint_head(monkeypatch):
     """Native checkpoint MTP weights are not instantiated when MTP is disabled."""
     from omegaconf import DictConfig
@@ -299,8 +316,12 @@ class _FakeLLM(torch.nn.Module):
         super().__init__()
         self._out = out
         self.mtp = None
+        self.args = None
+        self.kwargs = None
 
-    def forward(self, **_kwargs):
+    def forward(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
         return self._out
 
 
@@ -336,6 +357,30 @@ def test_forward_omits_mtp_per_depth_h_when_absent():
     )
 
     assert 'mtp_per_depth_h' not in result
+
+
+def test_forward_passes_cp_precomputed_mtp_inputs_to_automodel():
+    fake_out = _DictLikeOutput(logits=torch.randn(1, 4, 32))
+    model = _make_forward_model(fake_out)
+    input_embeds = torch.randn(4, 8)
+    mtp_embed_inputs = (torch.randn(4, 8), torch.randn(4, 8))
+    mtp_position_ids = (torch.tensor([1, 2, 3, 0]), torch.tensor([2, 3, 0, 0]))
+
+    model.forward(
+        input_embeds=input_embeds,
+        qkv_format="thd",
+        position_ids=torch.arange(4),
+        mtp_embed_inputs=mtp_embed_inputs,
+        mtp_per_depth_position_ids=mtp_position_ids,
+    )
+
+    assert model.llm.args is not None
+    torch.testing.assert_close(model.llm.args[0], torch.zeros(1, 4, dtype=torch.long))
+    assert len(model.llm.args[1:]) == len(mtp_embed_inputs)
+    for actual, expected in zip(model.llm.args[1:], mtp_embed_inputs):
+        assert actual is expected
+    assert model.llm.kwargs["mtp_per_depth_position_ids"] is mtp_position_ids
+    assert "mtp_embed_inputs" not in model.llm.kwargs
 
 
 # ---------------------------------------------------------------------------
@@ -572,6 +617,14 @@ def test_training_step_forwards_packed_cu_seqlens_to_mtp_loss(monkeypatch):
     assert captured_kwargs["labels"] is inputs["target_ids"]
     assert captured_kwargs["return_per_depth"] is True
 
+    mtp_per_depth_targets = [torch.tensor([1, 2, 3, 4, -100])]
+    inputs["mtp_per_depth_targets"] = mtp_per_depth_targets
+    captured_kwargs.clear()
+    model._training_step_batch({"input_ids": torch.tensor([[1, 2, 3, 4, 5]])}, batch_idx=1)
+
+    assert captured_kwargs["mtp_per_depth_targets"] is mtp_per_depth_targets
+    assert captured_kwargs["cu_seqlens"] is None
+
 
 def test_mtp_validation_forward_uses_and_restores_native_gate():
     llm = torch.nn.Module()
@@ -605,7 +658,7 @@ def test_mtp_validation_forward_restores_native_gate_after_error():
 
 
 @pytest.mark.parametrize("hook_name", ["on_validation_start", "on_test_start"])
-def test_standalone_evaluation_rejects_mtp_context_parallelism(monkeypatch, hook_name):
+def test_standalone_evaluation_allows_mtp_context_parallelism(monkeypatch, hook_name):
     from omegaconf import DictConfig
 
     import nemo.collections.speechlm2.parts.parallel as parallel_module
@@ -626,8 +679,7 @@ def test_standalone_evaluation_rejects_mtp_context_parallelism(monkeypatch, hook
     model._device_mesh = _Mesh()
     monkeypatch.setattr(parallel_module, "validate_parallelism_compatibility", lambda **_kwargs: None)
 
-    with pytest.raises(ValueError, match="requires cp_size=1"):
-        getattr(model, hook_name)()
+    getattr(model, hook_name)()
 
 
 def test_mtp_rejects_tensor_parallelism_before_training(monkeypatch):

--- a/tests/collections/speechlm2/test_salm_automodel_mtp.py
+++ b/tests/collections/speechlm2/test_salm_automodel_mtp.py
@@ -225,7 +225,10 @@ def test_repeated_layer_settings_reach_native_mtp_constructor(monkeypatch):
     class _LLM(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.config = type("Config", (), {"hidden_size": 4, "num_nextn_predict_layers": 1})()
+            # Automodel consumes the logical constructor override into the HF
+            # config before constructing the repeated physical head.
+            self.config = type("Config", (), {"hidden_size": 4, "num_nextn_predict_layers": 3})()
+            self.mtp_config = type("MTPConfig", (), {"num_layers": 3, "use_repeated_layer": True})()
             self.mtp = torch.nn.Linear(4, 4)
 
     def _load_llm(*_args, **kwargs):
@@ -271,6 +274,8 @@ def test_repeated_layer_settings_reach_native_mtp_constructor(monkeypatch):
     assert captured_kwargs["replace_mtp_config"] is False
     assert captured_kwargs["num_nextn_predict_layers"] == 3
     assert captured_kwargs["mtp_use_repeated_layer"] is True
+    assert model.llm.config.num_nextn_predict_layers == 1
+    assert model.llm.mtp_config.num_layers == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/collections/speechlm2/test_salm_automodel_mtp.py
+++ b/tests/collections/speechlm2/test_salm_automodel_mtp.py
@@ -100,14 +100,20 @@ def test_disabled_mtp_overrides_native_checkpoint_head(monkeypatch):
     SALMAutomodel.configure_model(model)
 
     assert captured_kwargs["num_nextn_predict_layers"] == 0
+    assert "mtp_config_overrides" not in captured_kwargs
     assert model.llm.config.num_nextn_predict_layers == 0
     assert not model._mtp_enabled
 
 
-@pytest.mark.parametrize("training_mode", ["joint", "head_only"])
-def test_base_checkpoint_attaches_fresh_mtp_for_both_training_modes(monkeypatch, training_mode):
-    """A checkpoint with no native head gets a fresh head in either enabled mode."""
+@pytest.mark.parametrize(
+    ("training_mode", "replace_existing_head"),
+    [("joint", False), ("head_only", False), ("joint", True)],
+)
+def test_base_checkpoint_attaches_fresh_mtp_for_both_training_modes(monkeypatch, training_mode, replace_existing_head):
+    """A checkpoint with no native head constructs MTP before Automodel loading."""
     from omegaconf import DictConfig
+
+    captured_kwargs = {}
 
     class _Perception(torch.nn.Module):
         def __init__(self):
@@ -132,7 +138,11 @@ def test_base_checkpoint_attaches_fresh_mtp_for_both_training_modes(monkeypatch,
             "pretrained_weights": True,
             "freeze_params": ["^.+$"] if training_mode == "head_only" else [],
             "prevent_freeze_params": [],
-            "mtp": {"enabled": True, "training_mode": training_mode},
+            "mtp": {
+                "enabled": True,
+                "training_mode": training_mode,
+                "replace_existing_head": replace_existing_head,
+            },
         }
     )
     model._trainer = None
@@ -140,20 +150,27 @@ def test_base_checkpoint_attaches_fresh_mtp_for_both_training_modes(monkeypatch,
     model._use_tp = False
     model.setup_moe_options = lambda: None
 
-    monkeypatch.setattr(salm_module, "load_pretrained_automodel_llm", lambda *_args, **_kwargs: _LLM())
+    def _load_llm(*_args, **kwargs):
+        captured_kwargs.update(kwargs)
+        llm = _LLM()
+        llm.mtp = torch.nn.Linear(4, 4)
+        return llm
+
+    monkeypatch.setattr(salm_module, "load_pretrained_automodel_llm", _load_llm)
     monkeypatch.setattr(
         salm_module, "setup_speech_encoder", lambda model, **_kwargs: setattr(model, "perception", _Perception())
     )
     monkeypatch.setattr(salm_module, "update_perception_output_dim", lambda _model: None)
     monkeypatch.setattr(salm_module, "maybe_load_pretrained_models", lambda _model: None)
 
-    def _attach_fresh_head(self, _mtp_cfg, _dtype):
-        self.llm.mtp = torch.nn.Linear(4, 4)
-
-    monkeypatch.setattr(SALMAutomodel, "_build_and_attach_mtp_head", _attach_fresh_head)
-
     SALMAutomodel.configure_model(model)
 
+    assert captured_kwargs["mtp_config_overrides"] == {
+        "num_nextn_predict_layers": 1,
+        "mtp_hybrid_override_pattern": "*",
+        "mtp_layers_block_type": None,
+    }
+    assert captured_kwargs["replace_mtp_config"] is replace_existing_head
     assert model._mtp_enabled
     assert all(param.requires_grad for param in model.llm.mtp.parameters())
     if training_mode == "head_only":
@@ -246,6 +263,12 @@ def test_repeated_layer_settings_reach_native_mtp_constructor(monkeypatch):
 
     SALMAutomodel.configure_model(model)
 
+    assert captured_kwargs["mtp_config_overrides"] == {
+        "num_nextn_predict_layers": 1,
+        "mtp_hybrid_override_pattern": "*",
+        "mtp_layers_block_type": None,
+    }
+    assert captured_kwargs["replace_mtp_config"] is False
     assert captured_kwargs["num_nextn_predict_layers"] == 3
     assert captured_kwargs["mtp_use_repeated_layer"] is True
 
@@ -679,67 +702,3 @@ def test_joint_keep_pattern_follows_wrapped_mtp_namespace():
     assert {id(param) for param in model.llm.mtp.parameters()} <= optimizer_param_ids
     assert all(param.requires_grad for param in model.llm.mtp.parameters())
     assert all(not param.requires_grad for param in model.llm._orig_mod.backbone.parameters())
-
-
-def test_fresh_mtp_head_is_initialized_and_exports_physical_depth(monkeypatch):
-    from types import SimpleNamespace
-
-    from omegaconf import DictConfig
-
-    mtp_module = pytest.importorskip(
-        "nemo_automodel.components.models.nemotron_v3.mtp", reason="needs Automodel NemotronV3 MTP"
-    )
-    initialized_on = []
-
-    class _Layer(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.weight = torch.nn.Parameter(torch.zeros(2, 2))
-
-        def init_weights(self, buffer_device=None):
-            initialized_on.append(buffer_device)
-            with torch.no_grad():
-                self.weight.fill_(0.25)
-
-    class _MTP(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.layers = torch.nn.ModuleList([_Layer()])
-
-    class _LLM(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.config = SimpleNamespace()
-            self.backend = object()
-            self.model = SimpleNamespace(moe_config=None)
-            self.mtp = None
-
-    runtime_mtp_config = SimpleNamespace(num_layers=3, num_physical_depths=1)
-    fresh_mtp = _MTP()
-
-    def _build_config(config, **kwargs):
-        assert config.num_nextn_predict_layers == 3
-        assert kwargs["use_repeated_layer"]
-        return runtime_mtp_config
-
-    monkeypatch.setattr(mtp_module, "build_mtp_config_from_hf", _build_config)
-    monkeypatch.setattr(mtp_module, "build_nemotron_v3_mtp", lambda *_args, **_kwargs: fresh_mtp)
-
-    model = _bare_model()
-    model.llm = _LLM()
-    model._mtp_loss_scaling_factor = 0.1
-    cfg = DictConfig(
-        {
-            "num_nextn_predict_layers": 3,
-            "hybrid_override_pattern": "*",
-            "use_repeated_layer": True,
-        }
-    )
-
-    with pytest.warns(UserWarning, match="MTP head attached"):
-        model._build_and_attach_mtp_head(cfg, torch.float32)
-
-    assert model.llm.mtp is fresh_mtp
-    assert model.llm.config.num_nextn_predict_layers == 1
-    assert initialized_on == [next(fresh_mtp.parameters()).device]
-    assert torch.all(fresh_mtp.layers[0].weight == 0.25)

--- a/tests/collections/speechlm2/test_salm_automodel_mtp.py
+++ b/tests/collections/speechlm2/test_salm_automodel_mtp.py
@@ -767,12 +767,20 @@ def test_standalone_evaluation_allows_mtp_context_parallelism(monkeypatch, hook_
     model = _bare_model()
     model.cfg = DictConfig({"mtp": {"enabled": True}, "packed_sequences": True})
     model._device_mesh = _Mesh()
-    monkeypatch.setattr(parallel_module, "validate_parallelism_compatibility", lambda **_kwargs: None)
+    captured_kwargs = {}
+    monkeypatch.setattr(
+        parallel_module,
+        "validate_parallelism_compatibility",
+        lambda **kwargs: captured_kwargs.update(kwargs),
+    )
 
     getattr(model, hook_name)()
 
+    assert captured_kwargs["check_backward"] is False
 
-def test_mtp_rejects_tensor_parallelism_before_training(monkeypatch):
+
+@pytest.mark.parametrize("check_backward", [True, False])
+def test_mtp_rejects_tensor_parallelism_before_training(monkeypatch, check_backward):
     from omegaconf import DictConfig
 
     import nemo.collections.speechlm2.parts.parallel as parallel_module
@@ -794,7 +802,7 @@ def test_mtp_rejects_tensor_parallelism_before_training(monkeypatch):
     monkeypatch.setattr(parallel_module, "validate_parallelism_compatibility", lambda **_kwargs: None)
 
     with pytest.raises(ValueError, match="requires tp_size=1"):
-        model._validate_parallelism_compatibility()
+        model._validate_parallelism_compatibility(check_backward=check_backward)
 
 
 def test_vocab_argmax_does_not_materialize_full_dtensor_logits(monkeypatch):

--- a/tests/collections/speechlm2/test_salm_automodel_mtp.py
+++ b/tests/collections/speechlm2/test_salm_automodel_mtp.py
@@ -581,6 +581,9 @@ def test_mtp_validation_forward_uses_and_restores_native_gate():
 
 @pytest.mark.parametrize("native_gate", [False, True], ids=["legacy-training-flag", "compute-mtp-in-eval"])
 def test_mtp_validation_forward_restores_gate_after_error(native_gate):
+    def fail_forward():
+        raise RuntimeError("forward failed")
+
     llm = torch.nn.Module()
     llm.eval()
     if native_gate:
@@ -593,7 +596,7 @@ def test_mtp_validation_forward_restores_gate_after_error(native_gate):
                 assert not llm.training
             else:
                 assert llm.training
-            raise RuntimeError("forward failed")
+            fail_forward()
 
     assert not llm.training
     if native_gate:

--- a/tests/collections/speechlm2/test_salm_automodel_mtp.py
+++ b/tests/collections/speechlm2/test_salm_automodel_mtp.py
@@ -345,6 +345,43 @@ def test_validation_epoch_end_logs_mtp_teacher_forced_agreement():
     assert logged['val_mtp_teacher_forced_prefix_length'] == pytest.approx(2.3)
 
 
+def test_validation_step_preserves_mtp_counter_precision_with_bf16_logits(monkeypatch):
+    """MTP metric counters stay exact even when the validation loss is BF16."""
+    model = _bare_model()
+    model.llm = torch.nn.Module()
+    model.llm.mtp = torch.nn.Identity()
+    model.llm.compute_mtp_in_eval = False
+    model.lss_loss = None
+    SALMAutomodel.on_validation_epoch_start(model)
+
+    inputs = {
+        "input_embeds": torch.zeros(1, 2, 4, dtype=torch.bfloat16),
+        "attention_mask": torch.ones(1, 2, dtype=torch.bool),
+        "target_ids": torch.tensor([[0, 1]]),
+        "llm_kwargs": {},
+    }
+    logits = torch.zeros(1, 2, 4, dtype=torch.bfloat16)
+    model.prepare_inputs = lambda _batch: inputs
+    model.forward = lambda *_args, **_kwargs: {
+        "logits": logits,
+        "mtp_per_depth_h": [torch.zeros(1, 2, 4)],
+    }
+    monkeypatch.setattr(
+        salm_module,
+        "_calculate_mtp_teacher_forced_agreement_with_heads",
+        lambda **_kwargs: ([torch.tensor(10_001)], [torch.tensor(10_003)]),
+    )
+
+    SALMAutomodel.validation_step(model, {"ds": {}}, batch_idx=0)
+
+    correct = model._partial_val_mtp_correct["ds"][0]
+    valid = model._partial_val_mtp_valid["ds"][0]
+    assert correct.dtype == torch.int64
+    assert valid.dtype == torch.int64
+    assert correct.item() == 10_001
+    assert valid.item() == 10_003
+
+
 def test_calculate_mtp_teacher_forced_agreement_with_heads_counts(monkeypatch):
     '''Agreement compares drafts with teacher-forced verifier predictions and requires a matched prefix.'''
     # The helper imports these specific Automodel submodules; importorskip each so the test

--- a/tests/collections/speechlm2/test_salm_automodel_mtp.py
+++ b/tests/collections/speechlm2/test_salm_automodel_mtp.py
@@ -195,6 +195,61 @@ def test_invalid_mtp_training_mode_fails_before_loading(monkeypatch):
         SALMAutomodel.configure_model(model)
 
 
+def test_repeated_layer_settings_reach_native_mtp_constructor(monkeypatch):
+    """Reload preserves logical MTP depth when the checkpoint stores one physical repeated layer."""
+    from omegaconf import DictConfig
+
+    captured_kwargs = {}
+
+    class _Perception(torch.nn.Module):
+        def set_activation_checkpointing(self, _enabled):
+            return None
+
+    class _LLM(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = type("Config", (), {"hidden_size": 4, "num_nextn_predict_layers": 1})()
+            self.mtp = torch.nn.Linear(4, 4)
+
+    def _load_llm(*_args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return _LLM()
+
+    model = _bare_model()
+    model.cfg = DictConfig(
+        {
+            "pretrained_llm": "repeated-mtp-checkpoint",
+            "pretrained_asr": "unused-in-test",
+            "pretrained_weights": True,
+            "freeze_params": [],
+            "prevent_freeze_params": [],
+            "mtp": {
+                "enabled": True,
+                "training_mode": "joint",
+                "num_nextn_predict_layers": 3,
+                "use_repeated_layer": True,
+            },
+        }
+    )
+    model._trainer = None
+    model._use_fsdp = False
+    model._use_tp = False
+    model.setup_moe_options = lambda: None
+
+    monkeypatch.setattr(salm_module, "load_pretrained_automodel_llm", _load_llm)
+    monkeypatch.setattr(salm_module, "_build_mtp_loss_fn", lambda: torch.nn.Identity())
+    monkeypatch.setattr(
+        salm_module, "setup_speech_encoder", lambda model, **_kwargs: setattr(model, "perception", _Perception())
+    )
+    monkeypatch.setattr(salm_module, "update_perception_output_dim", lambda _model: None)
+    monkeypatch.setattr(salm_module, "maybe_load_pretrained_models", lambda _model: None)
+
+    SALMAutomodel.configure_model(model)
+
+    assert captured_kwargs["num_nextn_predict_layers"] == 3
+    assert captured_kwargs["mtp_use_repeated_layer"] is True
+
+
 # ---------------------------------------------------------------------------
 # forward: mtp_per_depth_h extraction
 # ---------------------------------------------------------------------------
@@ -457,7 +512,12 @@ def test_fused_mtp_loss_reuses_lm_weight_without_projecting_logits(monkeypatch):
         return weight
 
     monkeypatch.setattr(salm_module, "DTensor", torch.nn.Parameter)
-    monkeypatch.setattr(loss_module.FusedLinearCrossEntropy, "materialize_lm_weight", staticmethod(_materialize))
+    monkeypatch.setattr(
+        loss_module.FusedLinearCrossEntropy,
+        "materialize_lm_weight",
+        staticmethod(_materialize),
+        raising=False,
+    )
 
     total, head_losses, raw_head_losses = salm_module._calculate_mtp_loss_with_heads(
         loss_fn=loss_module.FusedLinearCrossEntropy(reduction="sum"),
@@ -489,8 +549,23 @@ def test_mtp_loss_selection_handles_optional_cut_cross_entropy(monkeypatch, cut_
 
     loss_fn = salm_module._build_mtp_loss_fn()
 
-    expected_type = linear_ce.FusedLinearCrossEntropy if cut_ce_available else MaskedCrossEntropy
+    gradient_safe_fused_api = callable(getattr(linear_ce.FusedLinearCrossEntropy, "materialize_lm_weight", None))
+    expected_type = (
+        linear_ce.FusedLinearCrossEntropy if cut_ce_available and gradient_safe_fused_api else MaskedCrossEntropy
+    )
     assert isinstance(loss_fn, expected_type)
+
+
+def test_mtp_loss_selection_requires_gradient_safe_fused_api(monkeypatch):
+    from nemo_automodel.components.loss import linear_ce
+    from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
+
+    monkeypatch.setattr(linear_ce, "HAVE_CUT_CROSS_ENTROPY", True)
+    monkeypatch.delattr(linear_ce.FusedLinearCrossEntropy, "materialize_lm_weight", raising=False)
+
+    loss_fn = salm_module._build_mtp_loss_fn()
+
+    assert isinstance(loss_fn, MaskedCrossEntropy)
 
 
 def test_head_only_keep_pattern_follows_wrapped_mtp_namespace():

--- a/tests/collections/speechlm2/test_salm_automodel_mtp.py
+++ b/tests/collections/speechlm2/test_salm_automodel_mtp.py
@@ -15,6 +15,7 @@ import pytest
 import torch
 
 import nemo.collections.speechlm2.models.salm_automodel as salm_module
+import nemo.collections.speechlm2.parts.mtp as mtp_module
 
 SALMAutomodel = salm_module.SALMAutomodel
 
@@ -257,7 +258,7 @@ def test_repeated_layer_settings_reach_native_mtp_constructor(monkeypatch):
     model.setup_moe_options = lambda: None
 
     monkeypatch.setattr(salm_module, "load_pretrained_automodel_llm", _load_llm)
-    monkeypatch.setattr(salm_module, "_build_mtp_loss_fn", lambda: torch.nn.Identity())
+    monkeypatch.setattr(salm_module, "build_mtp_loss_fn", lambda: torch.nn.Identity())
     monkeypatch.setattr(
         salm_module, "setup_speech_encoder", lambda model, **_kwargs: setattr(model, "perception", _Perception())
     )
@@ -396,7 +397,7 @@ def test_validation_step_preserves_mtp_counter_precision_with_bf16_logits(monkey
     }
     monkeypatch.setattr(
         salm_module,
-        "_calculate_mtp_teacher_forced_agreement_with_heads",
+        "calculate_mtp_teacher_forced_agreement",
         lambda **_kwargs: ([torch.tensor(10_001)], [torch.tensor(10_003)]),
     )
 
@@ -412,9 +413,6 @@ def test_validation_step_preserves_mtp_counter_precision_with_bf16_logits(monkey
 
 def test_calculate_mtp_teacher_forced_agreement_with_heads_counts(monkeypatch):
     '''Agreement compares drafts with teacher-forced verifier predictions and requires a matched prefix.'''
-    # The helper imports these specific Automodel submodules; importorskip each so the test
-    # skips cleanly when the installed Automodel rev predates them (rather than hard-failing).
-    pytest.importorskip('nemo_automodel.components.loss.utils', reason='needs Automodel _get_lm_head_module')
     pytest.importorskip('nemo_automodel.components.models.common.mtp', reason='needs Automodel roll_tensor')
 
     # Identity lm_head over a V==H one-hot space so argmax(hidden) == predicted token id.
@@ -436,7 +434,7 @@ def test_calculate_mtp_teacher_forced_agreement_with_heads_counts(monkeypatch):
     depth_2_ids = torch.tensor([[2, 3, 0, 0, 0]])
     mtp_h = [torch.nn.functional.one_hot(ids, num_classes=V).float() for ids in (depth_1_ids, depth_2_ids)]
 
-    correct, valid = salm_module._calculate_mtp_teacher_forced_agreement_with_heads(
+    correct, valid = mtp_module.calculate_mtp_teacher_forced_agreement(
         mtp_per_depth_h=mtp_h,
         labels=labels,
         model=model,
@@ -447,6 +445,24 @@ def test_calculate_mtp_teacher_forced_agreement_with_heads_counts(monkeypatch):
     assert [int(value) for value in valid] == [4, 3]
 
 
+def test_compute_mtp_agreement_lengths_aggregates_steps_before_reduction():
+    reduced_inputs = []
+
+    def reduce_sums(values):
+        reduced_inputs.append(values.clone())
+        return values
+
+    per_depth, mean_length = mtp_module.compute_mtp_agreement_lengths(
+        correct_counts=[torch.tensor([3, 2]), torch.tensor([1, 1])],
+        valid_counts=[torch.tensor([4, 3]), torch.tensor([2, 2])],
+        reduce_sums=reduce_sums,
+    )
+
+    torch.testing.assert_close(reduced_inputs[0], torch.tensor([4, 3, 6, 5]))
+    torch.testing.assert_close(per_depth, torch.tensor([4 / 6, 3 / 5]))
+    torch.testing.assert_close(mean_length, torch.tensor(1 + 4 / 6 + 3 / 5))
+
+
 @pytest.mark.parametrize(
     ("labels", "expected"),
     [
@@ -455,7 +471,7 @@ def test_calculate_mtp_teacher_forced_agreement_with_heads_counts(monkeypatch):
     ],
 )
 def test_resolve_mtp_seq_idx_from_cu_seqlens(labels, expected):
-    actual = salm_module._resolve_mtp_seq_idx(
+    actual = mtp_module.resolve_mtp_seq_idx(
         labels,
         cu_seqlens=torch.tensor([[0, 3, 5]], dtype=torch.int32),
     )
@@ -479,14 +495,14 @@ def test_resolve_mtp_seq_idx_from_cu_seqlens(labels, expected):
     ],
 )
 def test_resolve_mtp_seq_idx_normalizes_explicit_shape(labels, seq_idx, expected):
-    actual = salm_module._resolve_mtp_seq_idx(labels, seq_idx=seq_idx)
+    actual = mtp_module.resolve_mtp_seq_idx(labels, seq_idx=seq_idx)
 
     torch.testing.assert_close(actual, expected)
 
 
 def test_resolve_mtp_seq_idx_rejects_shape_mismatch():
     with pytest.raises(ValueError, match="does not match labels shape"):
-        salm_module._resolve_mtp_seq_idx(
+        mtp_module.resolve_mtp_seq_idx(
             torch.zeros(2, 4, dtype=torch.long),
             seq_idx=torch.zeros(3, dtype=torch.long),
         )
@@ -494,7 +510,7 @@ def test_resolve_mtp_seq_idx_rejects_shape_mismatch():
 
 def test_iter_mtp_depth_targets_masks_trailing_and_packed_boundaries():
     targets = list(
-        salm_module._iter_mtp_depth_targets(
+        mtp_module.iter_mtp_depth_targets(
             torch.tensor([10, 11, 12, 20, 21]),
             2,
             cu_seqlens=torch.tensor([0, 3, 5], dtype=torch.int32),
@@ -543,27 +559,18 @@ def test_training_step_forwards_packed_cu_seqlens_to_mtp_loss(monkeypatch):
 
     def _calculate_mtp_loss(*_args, **kwargs):
         captured_kwargs.update(kwargs)
-        return torch.tensor(0.25), [torch.tensor(2.5)]
+        return salm_module.MTPLossOutput(
+            loss=torch.tensor(0.25),
+            per_depth_losses=[torch.tensor(2.5)],
+        )
 
-    monkeypatch.setattr(salm_module, "_calculate_mtp_loss_with_heads", _calculate_mtp_loss)
+    monkeypatch.setattr(salm_module, "calculate_mtp_loss", _calculate_mtp_loss)
 
     model._training_step_batch({"input_ids": torch.tensor([[1, 2, 3, 4, 5]])}, batch_idx=0)
 
     assert captured_kwargs["cu_seqlens"] is cu_seqlens
     assert captured_kwargs["labels"] is inputs["target_ids"]
-
-
-def test_mtp_validation_forward_legacy_gate_keeps_children_in_eval():
-    llm = torch.nn.Module()
-    llm.child = torch.nn.Dropout()
-    llm.eval()
-
-    with salm_module._mtp_validation_forward(llm, enabled=True):
-        assert llm.training
-        assert not llm.child.training
-
-    assert not llm.training
-    assert not llm.child.training
+    assert captured_kwargs["return_per_depth"] is True
 
 
 def test_mtp_validation_forward_uses_and_restores_native_gate():
@@ -571,7 +578,7 @@ def test_mtp_validation_forward_uses_and_restores_native_gate():
     llm.eval()
     llm.compute_mtp_in_eval = False
 
-    with salm_module._mtp_validation_forward(llm, enabled=True):
+    with mtp_module.mtp_validation_forward(llm, enabled=True):
         assert llm.compute_mtp_in_eval
         assert not llm.training
 
@@ -579,28 +586,22 @@ def test_mtp_validation_forward_uses_and_restores_native_gate():
     assert not llm.training
 
 
-@pytest.mark.parametrize("native_gate", [False, True], ids=["legacy-training-flag", "compute-mtp-in-eval"])
-def test_mtp_validation_forward_restores_gate_after_error(native_gate):
+def test_mtp_validation_forward_restores_native_gate_after_error():
     def fail_forward():
         raise RuntimeError("forward failed")
 
     llm = torch.nn.Module()
     llm.eval()
-    if native_gate:
-        llm.compute_mtp_in_eval = False
+    llm.compute_mtp_in_eval = False
 
     with pytest.raises(RuntimeError, match="forward failed"):
-        with salm_module._mtp_validation_forward(llm, enabled=True):
-            if native_gate:
-                assert llm.compute_mtp_in_eval
-                assert not llm.training
-            else:
-                assert llm.training
+        with mtp_module.mtp_validation_forward(llm, enabled=True):
+            assert llm.compute_mtp_in_eval
+            assert not llm.training
             fail_forward()
 
     assert not llm.training
-    if native_gate:
-        assert not llm.compute_mtp_in_eval
+    assert not llm.compute_mtp_in_eval
 
 
 @pytest.mark.parametrize("hook_name", ["on_validation_start", "on_test_start"])
@@ -671,124 +672,27 @@ def test_vocab_argmax_does_not_materialize_full_dtensor_logits(monkeypatch):
                 pytest.fail("vocabulary-sharded logits must not be fully materialized")
             return expected
 
-    monkeypatch.setattr(salm_module, "DTensor", _FakeDTensor)
+    monkeypatch.setattr(mtp_module, "DTensor", _FakeDTensor)
 
-    predictions = salm_module._vocab_parallel_argmax(_FakeDTensor(is_logits=True))
+    predictions = mtp_module.vocab_parallel_argmax(_FakeDTensor(is_logits=True))
 
     assert predictions is expected
 
 
-def test_fused_mtp_loss_reuses_lm_weight_without_projecting_logits(monkeypatch):
-    pytest.importorskip('nemo_automodel.components.models.common.mtp', reason='needs Automodel roll_tensor')
-    loss_module = pytest.importorskip('nemo_automodel.components.loss.linear_ce', reason='needs fused linear CE')
-    loss_utils = pytest.importorskip('nemo_automodel.components.loss.utils', reason='needs Automodel loss utilities')
-
-    class _FailingLMHead(torch.nn.Linear):
-        def forward(self, _inputs):
-            pytest.fail("fused MTP loss must not materialize logits through lm_head.forward")
-
-    model = torch.nn.Module()
-    model.lm_head = _FailingLMHead(4, 4, bias=False)
-    monkeypatch.setattr(loss_utils, "_get_lm_head_module", lambda _model: model.lm_head)
-
-    calls = []
-
-    def _calculate_loss(_loss_fn, **kwargs):
-        calls.append(kwargs)
-        return kwargs["hidden_states"].sum() * 0 + 2.0
-
-    monkeypatch.setattr(loss_utils, "calculate_loss", _calculate_loss)
-    mtp_h = [torch.randn(1, 5, 4, requires_grad=True) for _ in range(2)]
-    grad_reduce_group = object()
-    materialize_calls = []
-
-    def _materialize(weight, *, grad_reduce_group=None):
-        materialize_calls.append((weight, grad_reduce_group))
-        return weight
-
-    monkeypatch.setattr(salm_module, "DTensor", torch.nn.Parameter)
-    monkeypatch.setattr(
-        loss_module.FusedLinearCrossEntropy,
-        "materialize_lm_weight",
-        staticmethod(_materialize),
-        raising=False,
-    )
-
-    total, raw_head_losses = salm_module._calculate_mtp_loss_with_heads(
-        loss_fn=loss_module.FusedLinearCrossEntropy(reduction="sum"),
-        mtp_per_depth_h=mtp_h,
-        labels=torch.tensor([[0, 1, 2, 3, 0]]),
-        model=model,
-        scaling_factor=0.1,
-        grad_reduce_group=grad_reduce_group,
-        cu_seqlens=torch.tensor([0, 3, 5], dtype=torch.int32),
-    )
-
-    assert len(calls) == 2
-    torch.testing.assert_close(calls[0]["labels"], torch.tensor([[1, 2, -100, 0, -100]]))
-    torch.testing.assert_close(calls[1]["labels"], torch.tensor([[2, -100, -100, -100, -100]]))
-    assert calls[0]["lm_weight"] is model.lm_head.weight
-    assert calls[1]["lm_weight"] is calls[0]["lm_weight"]
-    assert materialize_calls == [(model.lm_head.weight, grad_reduce_group)]
-    assert all(call["grad_reduce_group"] is grad_reduce_group for call in calls)
-    assert float(total.detach()) == pytest.approx(0.2)
-    assert [float(value.detach()) for value in raw_head_losses] == pytest.approx([2.0, 2.0])
-    total.backward()
-    assert all(hidden.grad is not None for hidden in mtp_h)
-
-
-def test_unfused_mtp_loss_resolves_lm_head_once(monkeypatch):
-    pytest.importorskip('nemo_automodel.components.models.common.mtp', reason='needs Automodel roll_tensor')
-    loss_utils = pytest.importorskip('nemo_automodel.components.loss.utils', reason='needs Automodel loss utilities')
-    from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
-
-    model = torch.nn.Module()
-    model.lm_head = torch.nn.Linear(4, 4, bias=False)
-    lookup_calls = []
-
-    def _get_lm_head(_model):
-        lookup_calls.append(_model)
-        return model.lm_head
-
-    monkeypatch.setattr(loss_utils, "_get_lm_head_module", _get_lm_head)
-
-    salm_module._calculate_mtp_loss_with_heads(
-        loss_fn=MaskedCrossEntropy(reduction="sum", fp32_upcast=False),
-        mtp_per_depth_h=[torch.randn(1, 4, 4) for _ in range(3)],
-        labels=torch.tensor([[0, 1, 2, 3]]),
-        model=model,
-    )
-
-    assert lookup_calls == [model]
-
-
 @pytest.mark.parametrize(
-    ("cut_ce_available", "gradient_safe_api", "expect_fused"),
+    ("cut_ce_available", "expect_fused"),
     [
-        pytest.param(False, False, False, id="cut-ce-unavailable"),
-        pytest.param(False, True, False, id="cut-ce-unavailable-with-api"),
-        pytest.param(True, False, False, id="legacy-automodel-api"),
-        pytest.param(True, True, True, id="fused-supported"),
+        pytest.param(False, False, id="cut-ce-unavailable"),
+        pytest.param(True, True, id="fused-supported"),
     ],
 )
-def test_mtp_loss_selection_handles_optional_cut_cross_entropy(
-    monkeypatch, cut_ce_available, gradient_safe_api, expect_fused
-):
+def test_mtp_loss_selection_handles_optional_cut_cross_entropy(monkeypatch, cut_ce_available, expect_fused):
     from nemo_automodel.components.loss import linear_ce
     from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
 
     monkeypatch.setattr(linear_ce, "HAVE_CUT_CROSS_ENTROPY", cut_ce_available)
-    if gradient_safe_api:
-        monkeypatch.setattr(
-            linear_ce.FusedLinearCrossEntropy,
-            "materialize_lm_weight",
-            staticmethod(lambda weight, **_kwargs: weight),
-            raising=False,
-        )
-    else:
-        monkeypatch.delattr(linear_ce.FusedLinearCrossEntropy, "materialize_lm_weight", raising=False)
 
-    loss_fn = salm_module._build_mtp_loss_fn()
+    loss_fn = mtp_module.build_mtp_loss_fn()
 
     expected_type = linear_ce.FusedLinearCrossEntropy if expect_fused else MaskedCrossEntropy
     assert isinstance(loss_fn, expected_type)

--- a/tests/collections/speechlm2/test_salm_automodel_mtp.py
+++ b/tests/collections/speechlm2/test_salm_automodel_mtp.py
@@ -14,7 +14,9 @@
 import pytest
 import torch
 
-from nemo.collections.speechlm2.models import SALMAutomodel
+import nemo.collections.speechlm2.models.salm_automodel as salm_module
+
+SALMAutomodel = salm_module.SALMAutomodel
 
 
 def _bare_model():
@@ -58,8 +60,6 @@ def test_disabled_mtp_overrides_native_checkpoint_head(monkeypatch):
     """Native checkpoint MTP weights are not instantiated when MTP is disabled."""
     from omegaconf import DictConfig
 
-    import nemo.collections.speechlm2.models.salm_automodel as salm_module
-
     captured_kwargs = {}
 
     class _Perception(torch.nn.Module):
@@ -69,7 +69,7 @@ def test_disabled_mtp_overrides_native_checkpoint_head(monkeypatch):
     class _LLM(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.config = type("Config", (), {"hidden_size": 8})()
+            self.config = type("Config", (), {"hidden_size": 8, "num_nextn_predict_layers": 1})()
             self.mtp = None
 
     def _load_llm(*_args, **kwargs):
@@ -100,6 +100,7 @@ def test_disabled_mtp_overrides_native_checkpoint_head(monkeypatch):
     SALMAutomodel.configure_model(model)
 
     assert captured_kwargs["num_nextn_predict_layers"] == 0
+    assert model.llm.config.num_nextn_predict_layers == 0
     assert not model._mtp_enabled
 
 
@@ -107,8 +108,6 @@ def test_disabled_mtp_overrides_native_checkpoint_head(monkeypatch):
 def test_base_checkpoint_attaches_fresh_mtp_for_both_training_modes(monkeypatch, training_mode):
     """A checkpoint with no native head gets a fresh head in either enabled mode."""
     from omegaconf import DictConfig
-
-    import nemo.collections.speechlm2.models.salm_automodel as salm_module
 
     class _Perception(torch.nn.Module):
         def __init__(self):
@@ -174,8 +173,6 @@ def test_base_checkpoint_attaches_fresh_mtp_for_both_training_modes(monkeypatch,
 
 def test_invalid_mtp_training_mode_fails_before_loading(monkeypatch):
     from omegaconf import DictConfig
-
-    import nemo.collections.speechlm2.models.salm_automodel as salm_module
 
     model = _bare_model()
     model.cfg = DictConfig(
@@ -263,9 +260,8 @@ def test_forward_omits_mtp_per_depth_h_when_absent():
 
 
 def test_validation_epoch_end_logs_mtp_acceptance():
-    '''on_validation_epoch_end reports per-head acceptance probability and the
-    expected acceptance length (always-accepted main token + cumulative product
-    of per-head accept probabilities).'''
+    '''on_validation_epoch_end reports verifier-prefix acceptance probabilities
+    and their expected acceptance length.'''
     from collections import defaultdict
 
     model = _bare_model()
@@ -281,7 +277,7 @@ def test_validation_epoch_end_logs_mtp_acceptance():
     model._partial_val_num_frames = defaultdict(list, {'ds': [torch.tensor(10.0)]})
     model._partial_val_lss = defaultdict(list)
 
-    # Head 1: 8/10 accepted (p1 = 0.8); head 2: 5/10 accepted (p2 = 0.5).
+    # Depth-1 prefix: 8/10 accepted; depth-2 prefix: 5/10 accepted.
     model._partial_val_mtp_correct = defaultdict(list, {'ds': [torch.tensor([8.0, 5.0])]})
     model._partial_val_mtp_valid = defaultdict(list, {'ds': [torch.tensor([10.0, 10.0])]})
 
@@ -289,22 +285,17 @@ def test_validation_epoch_end_logs_mtp_acceptance():
 
     assert logged['val_mtp_acc_ds/head_1'] == pytest.approx(0.8)
     assert logged['val_mtp_acc_ds/head_2'] == pytest.approx(0.5)
-    # 1 (main) + 0.8 + 0.8 * 0.5 = 2.2
-    assert logged['val_mtp_accept_length_ds'] == pytest.approx(2.2)
-    assert logged['val_mtp_accept_length'] == pytest.approx(2.2)
+    # 1 (main verifier token) + P(A1) + P(A1 and A2) = 2.3.
+    assert logged['val_mtp_accept_length_ds'] == pytest.approx(2.3)
+    assert logged['val_mtp_accept_length'] == pytest.approx(2.3)
 
 
 def test_calculate_mtp_acceptance_with_heads_counts(monkeypatch):
-    '''_calculate_mtp_acceptance_with_heads compares each head's argmax against the
-    same rolled/masked targets used by the MTP loss and returns per-head
-    (correct, valid) counts.'''
+    '''Acceptance compares drafts with verifier predictions and requires a matched prefix.'''
     # The helper imports these specific Automodel submodules; importorskip each so the test
     # skips cleanly when the installed Automodel rev predates them (rather than hard-failing).
     pytest.importorskip('nemo_automodel.components.loss.utils', reason='needs Automodel _get_lm_head_module')
-    mtp_mod = pytest.importorskip('nemo_automodel.components.models.common.mtp', reason='needs Automodel roll_tensor')
-    roll_tensor = mtp_mod.roll_tensor
-
-    from nemo.collections.speechlm2.models.salm_automodel import _calculate_mtp_acceptance_with_heads
+    pytest.importorskip('nemo_automodel.components.models.common.mtp', reason='needs Automodel roll_tensor')
 
     # Identity lm_head over a V==H one-hot space so argmax(hidden) == predicted token id.
     V = 4
@@ -316,24 +307,112 @@ def test_calculate_mtp_acceptance_with_heads_counts(monkeypatch):
     # Avoid depending on Automodel's lm-head discovery internals.
     monkeypatch.setattr('nemo_automodel.components.loss.utils._get_lm_head_module', lambda m: m.lm_head)
 
-    labels = torch.tensor([[0, 1, 2, 3, 0]])  # (1, T)
-    T = labels.shape[-1]
-    D = 2
-    # Every head predicts token 0 everywhere (one-hot index 0).
-    one_hot_zero = torch.zeros(1, T, V)
-    one_hot_zero[..., 0] = 1.0
-    mtp_h = [one_hot_zero.clone() for _ in range(D)]
+    labels = torch.tensor([[3, 3, 3, 3, 3]])  # Used only to define valid positions.
+    verifier_predictions = torch.tensor([[0, 1, 2, 3, 0]])
+    # Depth 1's verifier targets are [1, 2, 3, 0]. Drafts match positions 0, 2, 3.
+    depth_1_ids = torch.tensor([[1, 0, 3, 0, 0]])
+    # Depth 2 matches all three verifier targets [2, 3, 0], but position 1 cannot
+    # be accepted because depth 1 already mismatched there.
+    depth_2_ids = torch.tensor([[2, 3, 0, 0, 0]])
+    mtp_h = [torch.nn.functional.one_hot(ids, num_classes=V).float() for ids in (depth_1_ids, depth_2_ids)]
 
-    correct, valid = _calculate_mtp_acceptance_with_heads(mtp_per_depth_h=mtp_h, labels=labels, model=model)
+    correct, valid = salm_module._calculate_mtp_acceptance_with_heads(
+        mtp_per_depth_h=mtp_h,
+        labels=labels,
+        model=model,
+        verifier_predictions=verifier_predictions,
+    )
 
-    # Independently recompute the rolled/masked targets with the real roll_tensor.
-    cur = labels
-    for k in range(D):
-        cur = roll_tensor(cur, shifts=-1, dim=-1)
-        masked = cur.clone()
-        masked[..., -min(k + 1, T) :] = -100
-        valid_mask = masked != -100
-        exp_valid = int(valid_mask.sum())
-        exp_correct = int(((masked == 0) & valid_mask).sum())  # preds are all 0
-        assert int(valid[k]) == exp_valid
-        assert int(correct[k]) == exp_correct
+    assert [int(value) for value in correct] == [3, 2]
+    assert [int(value) for value in valid] == [4, 3]
+
+
+def test_mtp_validation_forward_legacy_gate_keeps_children_in_eval():
+    llm = torch.nn.Module()
+    llm.child = torch.nn.Dropout()
+    llm.eval()
+
+    with salm_module._mtp_validation_forward(llm, enabled=True):
+        assert llm.training
+        assert not llm.child.training
+
+    assert not llm.training
+    assert not llm.child.training
+
+
+def test_mtp_validation_forward_uses_and_restores_native_gate():
+    llm = torch.nn.Module()
+    llm.eval()
+    llm.compute_mtp_in_eval = False
+
+    with salm_module._mtp_validation_forward(llm, enabled=True):
+        assert llm.compute_mtp_in_eval
+        assert not llm.training
+
+    assert not llm.compute_mtp_in_eval
+    assert not llm.training
+
+
+def test_mtp_rejects_context_parallelism(monkeypatch):
+    from omegaconf import DictConfig
+
+    import nemo.collections.speechlm2.parts.parallel as parallel_module
+
+    class _Submesh:
+        def size(self):
+            return 2
+
+    class _Mesh:
+        mesh_dim_names = ("cp",)
+
+        def __getitem__(self, name):
+            assert name == "cp"
+            return _Submesh()
+
+    model = _bare_model()
+    model.cfg = DictConfig({"mtp": {"enabled": True}, "packed_sequences": True})
+    model._device_mesh = _Mesh()
+    monkeypatch.setattr(parallel_module, "validate_parallelism_compatibility", lambda **_kwargs: None)
+
+    with pytest.raises(ValueError, match="requires cp_size=1"):
+        model._validate_parallelism_compatibility()
+
+
+def test_fused_mtp_loss_reuses_lm_weight_without_projecting_logits(monkeypatch):
+    pytest.importorskip('nemo_automodel.components.models.common.mtp', reason='needs Automodel roll_tensor')
+    loss_module = pytest.importorskip('nemo_automodel.components.loss.linear_ce', reason='needs fused linear CE')
+    loss_utils = pytest.importorskip('nemo_automodel.components.loss.utils', reason='needs Automodel loss utilities')
+
+    class _FailingLMHead(torch.nn.Linear):
+        def forward(self, _inputs):
+            pytest.fail("fused MTP loss must not materialize logits through lm_head.forward")
+
+    model = torch.nn.Module()
+    model.lm_head = _FailingLMHead(4, 4, bias=False)
+    monkeypatch.setattr(loss_utils, "_get_lm_head_module", lambda _model: model.lm_head)
+
+    calls = []
+
+    def _calculate_loss(_loss_fn, **kwargs):
+        calls.append(kwargs)
+        return kwargs["hidden_states"].sum() * 0 + 2.0
+
+    monkeypatch.setattr(loss_utils, "calculate_loss", _calculate_loss)
+    mtp_h = [torch.randn(1, 4, 4, requires_grad=True) for _ in range(2)]
+
+    total, head_losses, raw_head_losses = salm_module._calculate_mtp_loss_with_heads(
+        loss_fn=loss_module.FusedLinearCrossEntropy(reduction="sum"),
+        mtp_per_depth_h=mtp_h,
+        labels=torch.tensor([[0, 1, 2, 3]]),
+        model=model,
+        scaling_factor=0.1,
+    )
+
+    assert len(calls) == 2
+    assert calls[0]["lm_weight"] is model.lm_head.weight
+    assert calls[1]["lm_weight"] is calls[0]["lm_weight"]
+    assert float(total.detach()) == pytest.approx(0.2)
+    assert [float(value.detach()) for value in head_losses] == pytest.approx([0.1, 0.1])
+    assert [float(value.detach()) for value in raw_head_losses] == pytest.approx([2.0, 2.0])
+    total.backward()
+    assert all(hidden.grad is not None for hidden in mtp_h)

--- a/tests/collections/speechlm2/test_salm_packed_sequences.py
+++ b/tests/collections/speechlm2/test_salm_packed_sequences.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+import nemo.collections.speechlm2.parts.packed_sequences as packed_sequences_module
 from nemo.collections.speechlm2.parts.mtp import iter_mtp_depth_targets
 from nemo.collections.speechlm2.parts.packed_sequences import (
     _build_packed_mtp_inputs,
@@ -250,6 +251,31 @@ def test_build_packed_mtp_inputs_reuses_resolved_seq_idx(monkeypatch):
 
     assert len(calls) == 1
     assert len(mtp_inputs.targets) == 2
+
+
+def test_build_packed_mtp_inputs_reuses_shift_masks(monkeypatch):
+    """Embeddings and position IDs reuse one packed-boundary mask per depth."""
+    packed = {
+        "inputs_embeds": torch.arange(16, dtype=torch.float32).reshape(8, 2),
+        "labels": torch.arange(8),
+        "position_ids": torch.tensor([0, 1, 2, 3, 0, 1, 2, 3]),
+        "cu_seqlens": torch.tensor([0, 4, 8], dtype=torch.int32),
+    }
+    shift = packed_sequences_module._shift_packed_tensor_for_mtp
+    masks_by_depth = {}
+
+    def _record_shift(tensor, depth, valid_mask):
+        masks_by_depth.setdefault(depth, []).append(valid_mask)
+        return shift(tensor, depth, valid_mask)
+
+    monkeypatch.setattr(packed_sequences_module, "_shift_packed_tensor_for_mtp", _record_shift)
+
+    _build_packed_mtp_inputs(packed, 2)
+
+    assert set(masks_by_depth) == {1, 2}
+    for masks in masks_by_depth.values():
+        assert len(masks) == 2
+        assert masks[0] is masks[1]
 
 
 def test_position_ids_reset_per_utt():

--- a/tests/collections/speechlm2/test_salm_packed_sequences.py
+++ b/tests/collections/speechlm2/test_salm_packed_sequences.py
@@ -229,6 +229,29 @@ def test_mtp_inputs_are_shifted_before_te_context_parallel_partition(monkeypatch
     assert not torch.equal(local_results[0][2].targets[0], rank_zero_wrong_local_targets[0])
 
 
+def test_build_packed_mtp_inputs_reuses_resolved_seq_idx(monkeypatch):
+    """Target construction reuses the sequence IDs already resolved for input shifts."""
+    packed = {
+        "inputs_embeds": torch.arange(16, dtype=torch.float32).reshape(8, 2),
+        "labels": torch.arange(8),
+        "position_ids": torch.tensor([0, 1, 2, 3, 0, 1, 2, 3]),
+        "cu_seqlens": torch.tensor([0, 4, 8], dtype=torch.int32),
+    }
+    searchsorted = torch.searchsorted
+    calls = []
+
+    def _record_searchsorted(*args, **kwargs):
+        calls.append((args, kwargs))
+        return searchsorted(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "searchsorted", _record_searchsorted)
+
+    mtp_inputs = _build_packed_mtp_inputs(packed, 2)
+
+    assert len(calls) == 1
+    assert len(mtp_inputs.targets) == 2
+
+
 def test_position_ids_reset_per_utt():
     input_ids, embeds, target_ids, replacements = _basic_batch()
     out = pack_audio_into_text_embeds(

--- a/tests/collections/speechlm2/test_salm_packed_sequences.py
+++ b/tests/collections/speechlm2/test_salm_packed_sequences.py
@@ -21,12 +21,11 @@ import torch
 
 import nemo.collections.speechlm2.parts.packed_sequences as packed_sequences_module
 from nemo.collections.speechlm2.parts.mtp import iter_mtp_depth_targets
-from nemo.collections.speechlm2.parts.packed_sequences import (
-    _build_packed_mtp_inputs,
-    _shard_packed_for_cp,
-    pack_audio_into_text_embeds,
-    prepare_packed_llm_inputs,
-)
+
+_build_packed_mtp_inputs = packed_sequences_module._build_packed_mtp_inputs
+_shard_packed_for_cp = packed_sequences_module._shard_packed_for_cp
+pack_audio_into_text_embeds = packed_sequences_module.pack_audio_into_text_embeds
+prepare_packed_llm_inputs = packed_sequences_module.prepare_packed_llm_inputs
 
 PAD = 0
 AUDIO = 100

--- a/tests/collections/speechlm2/test_salm_packed_sequences.py
+++ b/tests/collections/speechlm2/test_salm_packed_sequences.py
@@ -12,12 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import ast
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
 
-from nemo.collections.speechlm2.parts.packed_sequences import pack_audio_into_text_embeds, prepare_packed_llm_inputs
+from nemo.collections.speechlm2.parts.mtp import iter_mtp_depth_targets
+from nemo.collections.speechlm2.parts.packed_sequences import (
+    _build_packed_mtp_inputs,
+    _shard_packed_for_cp,
+    pack_audio_into_text_embeds,
+    prepare_packed_llm_inputs,
+)
 
 PAD = 0
 AUDIO = 100
@@ -96,6 +104,129 @@ def test_basic_pack_shapes_and_cu_seqlens():
     assert out["inputs_embeds"].shape == (T_total, 2)
     assert out["labels"].shape == (T_total,)
     assert out["position_ids"].shape == (T_total,)
+
+
+def test_mtp_inputs_are_shifted_before_te_context_parallel_partition(monkeypatch):
+    """Each CP rank receives globally shifted MTP inputs and targets."""
+    labels = torch.tensor([10, 11, 12, 13, 20, 21, 22, 23])
+    cu_seqlens = torch.tensor([0, 4, 8], dtype=torch.int32)
+    packed = {
+        "inputs_embeds": torch.arange(16, dtype=torch.float32).reshape(8, 2).requires_grad_(),
+        "labels": labels,
+        "position_ids": torch.tensor([0, 1, 2, 3, 0, 1, 2, 3]),
+        "cu_seqlens": cu_seqlens,
+        "max_seqlen": torch.tensor(4, dtype=torch.int32),
+        "qkv_format": "thd",
+    }
+    global_mtp = _build_packed_mtp_inputs(packed, 2)
+    rank = {"value": 0}
+
+    def _partition_indices(_cu_seqlens, _total_tokens, cp_size, cp_rank):
+        indices = []
+        for seq_start, seq_end in zip(_cu_seqlens[:-1], _cu_seqlens[1:]):
+            seq_start = int(seq_start)
+            seq_end = int(seq_end)
+            chunk = (seq_end - seq_start) // (2 * cp_size)
+            head_start = seq_start + cp_rank * chunk
+            tail_start = seq_start + (2 * cp_size - 1 - cp_rank) * chunk
+            indices.extend(
+                (torch.arange(head_start, head_start + chunk), torch.arange(tail_start, tail_start + chunk))
+            )
+        return torch.cat(indices)
+
+    class _CPMesh:
+        def size(self):
+            return 2
+
+        def get_group(self):
+            return object()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "transformer_engine_torch",
+        SimpleNamespace(thd_get_partitioned_indices=_partition_indices),
+    )
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda group: rank["value"])
+
+    local_results = []
+    for cp_rank in range(2):
+        rank["value"] = cp_rank
+        local_packed, local_mtp = _shard_packed_for_cp(packed, _CPMesh(), global_mtp)
+        indices = _partition_indices(cu_seqlens, labels.numel(), 2, cp_rank)
+
+        assert local_mtp is not None
+        torch.testing.assert_close(local_packed["labels"], labels.index_select(0, indices))
+        for actual, expected in zip(local_mtp.embed_inputs, global_mtp.embed_inputs):
+            torch.testing.assert_close(actual, expected.index_select(0, indices))
+        for actual, expected in zip(local_mtp.position_ids, global_mtp.position_ids):
+            torch.testing.assert_close(actual, expected.index_select(0, indices))
+        for actual, expected in zip(local_mtp.targets, global_mtp.targets):
+            torch.testing.assert_close(actual, expected.index_select(0, indices))
+        local_results.append((indices, local_packed, local_mtp))
+
+    all_indices = torch.cat([indices for indices, _, _ in local_results])
+    restore_global_order = torch.argsort(all_indices)
+    for depth in range(2):
+        reassembled_embeds = torch.cat([mtp.embed_inputs[depth] for _, _, mtp in local_results])
+        reassembled_positions = torch.cat([mtp.position_ids[depth] for _, _, mtp in local_results])
+        reassembled_targets = torch.cat([mtp.targets[depth] for _, _, mtp in local_results])
+        torch.testing.assert_close(
+            reassembled_embeds.index_select(0, restore_global_order), global_mtp.embed_inputs[depth]
+        )
+        torch.testing.assert_close(
+            reassembled_positions.index_select(0, restore_global_order), global_mtp.position_ids[depth]
+        )
+        torch.testing.assert_close(
+            reassembled_targets.index_select(0, restore_global_order), global_mtp.targets[depth]
+        )
+
+    # Future inputs never leak across either packed-document boundary.
+    torch.testing.assert_close(global_mtp.embed_inputs[0][3], torch.zeros(2))
+    torch.testing.assert_close(global_mtp.embed_inputs[0][7], torch.zeros(2))
+    assert global_mtp.targets[0][[3, 7]].tolist() == [-100, -100]
+
+    weights = tuple(
+        torch.arange(value.numel(), dtype=value.dtype).reshape_as(value) + 1 for value in global_mtp.embed_inputs
+    )
+    local_loss = sum(
+        (mtp.embed_inputs[depth] * weights[depth].index_select(0, indices)).sum()
+        for indices, _, mtp in local_results
+        for depth in range(2)
+    )
+    global_loss = sum((global_mtp.embed_inputs[depth] * weights[depth]).sum() for depth in range(2))
+    torch.testing.assert_close(local_loss, global_loss, rtol=0, atol=0)
+    local_grad = torch.autograd.grad(local_loss, packed["inputs_embeds"], retain_graph=True)[0]
+    global_grad = torch.autograd.grad(global_loss, packed["inputs_embeds"])[0]
+    torch.testing.assert_close(local_grad, global_grad, rtol=0, atol=0)
+
+    from nemo.collections.speechlm2.parts import cp_helpers
+
+    monkeypatch.setattr(cp_helpers, "get_cp_mesh", lambda _mesh: (_CPMesh(), 2, 0))
+    rank["value"] = 0
+    input_ids, text_embeds, target_ids, replacements = _basic_batch()
+    prepared = prepare_packed_llm_inputs(
+        input_ids=input_ids,
+        text_embs=text_embeds,
+        audio_embs=replacements,
+        target_ids=target_ids,
+        padding_id=PAD,
+        placeholder_id=AUDIO,
+        device_mesh=SimpleNamespace(mesh_dim_names=()),
+        mtp_num_depths=2,
+    )
+    assert len(prepared["llm_kwargs"]["mtp_embed_inputs"]) == 2
+    assert len(prepared["llm_kwargs"]["mtp_per_depth_position_ids"]) == 2
+    assert len(prepared["mtp_per_depth_targets"]) == 2
+    for value in (
+        *prepared["llm_kwargs"]["mtp_embed_inputs"],
+        *prepared["llm_kwargs"]["mtp_per_depth_position_ids"],
+        *prepared["mtp_per_depth_targets"],
+    ):
+        assert value.shape[0] == prepared["target_ids"].shape[0]
+
+    rank_zero_labels = local_results[0][1]["labels"]
+    rank_zero_wrong_local_targets = list(iter_mtp_depth_targets(rank_zero_labels, 2))
+    assert not torch.equal(local_results[0][2].targets[0], rank_zero_wrong_local_targets[0])
 
 
 def test_position_ids_reset_per_utt():
@@ -379,7 +510,7 @@ def test_prepare_packed_llm_inputs_attention_kwargs_reach_te_preprocessor():
     # layer does: 4D BSHD-shaped Q/K/V plus attention_mask=None plus the
     # llm_kwargs splatted in. ``input_embeds`` is now 2D ``[T, H]`` per the
     # canonical Automodel THD shape contract.
-    B, T, H = 1, int(out["input_embeds"].shape[0]), 2
+    B, T = 1, int(out["input_embeds"].shape[0])
     nh, hd = 2, 4
     q = torch.zeros(B, T, nh, hd)
     k = torch.zeros(B, T, nh, hd)

--- a/tests/collections/speechlm2/test_salm_parallelism_validation.py
+++ b/tests/collections/speechlm2/test_salm_parallelism_validation.py
@@ -68,8 +68,9 @@ def test_thd_cp2_te_with_fused_attn_off_passes():
 # BSHD + CP > 1 — hard error regardless of other knobs.
 
 
+@pytest.mark.parametrize("check_backward", [True, False])
 @pytest.mark.parametrize("cp_size", [2, 4, 8])
-def test_bshd_with_cp_raises(cp_size):
+def test_bshd_with_cp_raises(cp_size, check_backward):
     with pytest.raises(ValueError, match="BSHD .* incompatible with cp_size > 1"):
         validate_parallelism_compatibility(
             packed_sequences=False,
@@ -77,14 +78,16 @@ def test_bshd_with_cp_raises(cp_size):
             attn_backend="te",
             nvte_fused_attn="0",
             device_capability=(9, 0),
+            check_backward=check_backward,
         )
 
 
 # THD + non-TE attention — hard error.
 
 
+@pytest.mark.parametrize("check_backward", [True, False])
 @pytest.mark.parametrize("attn_backend", ["sdpa", "flex"])
-def test_thd_with_non_te_attn_raises(attn_backend):
+def test_thd_with_non_te_attn_raises(attn_backend, check_backward):
     with pytest.raises(ValueError, match=r"THD.*requires.*attn=te"):
         validate_parallelism_compatibility(
             packed_sequences=True,
@@ -92,6 +95,7 @@ def test_thd_with_non_te_attn_raises(attn_backend):
             attn_backend=attn_backend,
             nvte_fused_attn="0",
             device_capability=(9, 0),
+            check_backward=check_backward,
         )
 
 
@@ -135,6 +139,21 @@ def test_thd_te_with_fused_attn_off_does_not_warn_on_sm120():
             attn_backend="te",
             nvte_fused_attn="0",
             device_capability=(12, 0),
+        )
+    assert len(caught) == 0
+
+
+def test_forward_only_thd_te_without_fused_attn_off_passes_on_sm120():
+    """The sm_120 fused-attention issue is backward-only."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        validate_parallelism_compatibility(
+            packed_sequences=True,
+            cp_size=2,
+            attn_backend="te",
+            nvte_fused_attn=None,
+            device_capability=(12, 0),
+            check_backward=False,
         )
     assert len(caught) == 0
 

--- a/tests/collections/speechlm2/test_salm_train.py
+++ b/tests/collections/speechlm2/test_salm_train.py
@@ -28,6 +28,36 @@ with patch("torch.cuda.is_available", return_value=False):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("precision", "use_nemo_automodel", "compile_enabled", "activation_checkpointing_llm", "expected"),
+    [
+        ("bf16-true", True, True, True, True),
+        ("bf16-true", False, True, True, False),
+        ("bf16-true", True, False, True, False),
+        ("bf16-true", True, True, False, False),
+        ("bf16-flash", True, True, True, False),
+    ],
+)
+def test_pin_bf16_default_dtype_only_for_compiled_activation_recompute(
+    precision, use_nemo_automodel, compile_enabled, activation_checkpointing_llm, expected
+):
+    cfg = _SALM_TRAIN.OmegaConf.create(
+        {
+            "model": {
+                "use_nemo_automodel": use_nemo_automodel,
+                "compile": {"enabled": compile_enabled},
+            },
+            "trainer": {
+                "precision": precision,
+                "strategy": {"activation_checkpointing_llm": activation_checkpointing_llm},
+            },
+        }
+    )
+
+    assert _SALM_TRAIN._should_pin_bf16_default_dtype(cfg) is expected
+
+
+@pytest.mark.unit
 def test_create_salm_dataset_omits_unset_multispeaker_config(monkeypatch):
     class LegacySALMDataset:
         def __init__(self, tokenizer):

--- a/tests/collections/speechlm2/test_salm_train.py
+++ b/tests/collections/speechlm2/test_salm_train.py
@@ -28,36 +28,6 @@ with patch("torch.cuda.is_available", return_value=False):
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize(
-    ("precision", "use_nemo_automodel", "compile_enabled", "activation_checkpointing_llm", "expected"),
-    [
-        ("bf16-true", True, True, True, True),
-        ("bf16-true", False, True, True, False),
-        ("bf16-true", True, False, True, False),
-        ("bf16-true", True, True, False, False),
-        ("bf16-flash", True, True, True, False),
-    ],
-)
-def test_pin_bf16_default_dtype_only_for_compiled_activation_recompute(
-    precision, use_nemo_automodel, compile_enabled, activation_checkpointing_llm, expected
-):
-    cfg = _SALM_TRAIN.OmegaConf.create(
-        {
-            "model": {
-                "use_nemo_automodel": use_nemo_automodel,
-                "compile": {"enabled": compile_enabled},
-            },
-            "trainer": {
-                "precision": precision,
-                "strategy": {"activation_checkpointing_llm": activation_checkpointing_llm},
-            },
-        }
-    )
-
-    assert _SALM_TRAIN._should_pin_bf16_default_dtype(cfg) is expected
-
-
-@pytest.mark.unit
 def test_create_salm_dataset_omits_unset_multispeaker_config(monkeypatch):
     class LegacySALMDataset:
         def __init__(self, tokenizer):


### PR DESCRIPTION
## What

- add opt-in MTP training to `SALMAutomodel`
- support checkpoints with native MTP heads and base LLM checkpoints without MTP by constructing a fresh attached head
- add explicit `joint` and `head_only` training modes, plus a disabled path that suppresses native checkpoint MTP construction
- use Automodel's per-depth MTP-loss API and log per-depth losses
- compute verifier-prefix validation agreement metrics
- preserve packed-sequence/THD masking semantics and partial distributed-checkpoint loading
- bound MTP loss memory with fused linear cross-entropy when `cut_cross_entropy` is installed, with a supported unfused fallback
- keep reusable target, metric, loss-selection, and eval-gating helpers in `speechlm2/parts/mtp.py`

## Why

SpeechLM2 recipes need one consistent MTP path across Lightning-backbone and Nemotron Nano-family LLMs, including base checkpoints that do not already contain MTP weights. The feature remains opt-in so existing recipes are unchanged.

## Automodel dependencies and integration boundary

This PR targets a future Speech Automodel pin that contains:

- [#2802](https://github.com/NVIDIA-NeMo/Automodel/pull/2802): native `compute_mtp_in_eval` support
- [#3414](https://github.com/NVIDIA-NeMo/Automodel/pull/3414): gradient-safe sharded LM-weight materialization and related VLM CP fixes
- [#3525](https://github.com/NVIDIA-NeMo/Automodel/pull/3525): optional per-depth return from `calculate_mtp_loss` (merged)
- [#3543](https://github.com/NVIDIA-NeMo/Automodel/pull/3543): caller-precomputed MTP embeddings, position IDs, and targets for context parallelism

The final Speech dependency pin must be updated after #3543 merges. Until then this PR depends on merged #3525 plus open #3543 and is not compatible with the current `ee0b2261` pin.

Automodel owns native/attached MTP modules and generic MTP loss computation. This PR owns SpeechLM2 configuration, training policy, packed-audio masking, checkpoint/export integration, and validation metrics. The eval helper uses #2802's native model gate while keeping child modules in eval mode.

MTP now supports `cp_size>1` for packed THD with Transformer Engine when `tp_size=1`. Speech prepares future-token embeddings, position IDs, and loss targets in global packed order, masks packed-document boundaries, then applies the same interleaved CP partition as the base inputs before passing the rank-local tensors through #3543's interfaces. BSHD+CP remains unsupported, and MTP still requires `tp_size=1` because the MTP head has no tensor-parallel plan. Teacher-forced verifier-prefix metrics remain disabled under CP because rank-local verifier predictions cannot be shifted across CP boundaries without additional communication.

## Validation

### Local

- `59 passed`: focused Speech MTP and packed-sequence tests against a combined Automodel #3525 + #3543 checkout
- `68 passed`: broader pretrained, CP-helper, parallel-strategy, and SALM regression coverage; 8 additional SALM fixture cases were not runnable locally because the sandbox could not acquire the existing Hugging Face cache lock
- Black and isort checks pass on all changed Python files
- `git diff --check` passes
- The existing GPU smoke matrix below predates the CP integration and covers `cp_size=1`; Automodel #3543 carries the distributed packed-THD MTP parity validation for the shared CP contract

### IAD / 8×A100 smoke matrix

All final runs used the updated image `nemo-speech-pr16021-cu12-a100.sqsh`, Automodel #3525 head `2bebedc7` (which includes merged #2802), one real-audio optimizer step, one validation batch, and DCP checkpoint save.

| Job | Coverage | Result |
| --- | --- | --- |
| `11830644` | Lightning checkpoint, native MTP head, joint training | passed; `loss=6.000`, `mtp_loss=0.711`, `val_acc=0.16895` |
| `11830645` | Lightning checkpoint, MTP disabled | passed; `loss=6.000`, `val_acc=0.16797`; no MTP loss |
| `11829786` | Nano checkpoint without native MTP, fresh head, joint training | passed; `loss=5.720`, `mtp_loss=1.330`, `val_acc=0.24219` |
| `11829788` | Nano checkpoint without native MTP, strict head-only training | passed; 37.9M trainable parameters; `loss=5.720`, `mtp_loss=1.310`, `val_acc=0.24023` |
| `11829787` | Nano checkpoint without native MTP, MTP disabled | passed; `loss=5.910`, `val_acc=0.24414`; no MTP loss |
| `11829926` | packed THD, fresh attention+MoE head, joint training | passed; `loss=6.410`, `mtp_loss=0.170`, `val_acc=0.23535` |
| `11829925` | packed THD, fresh attention+MoE head, strict head-only training | passed; 37.9M trainable parameters; `loss=6.440`, `mtp_loss=0.169`, `val_acc=0.23730` |
| `11829923` | packed THD, MTP disabled | passed; `loss=6.440`, `val_acc=0.23730`; no MTP loss |

The updated IAD image still does not contain optional `cut_cross_entropy`; MTP-enabled jobs therefore also exercised the supported unfused loss fallback.

### NRT / 8×H100

Job `6038792` passed with the updated image `nemo-speech-pr16021-cu12-h100plus-v3.sqsh`, Automodel #3525 head `2bebedc7`, one real-audio joint-MTP optimizer step, one validation batch, and DCP checkpoint save. The run used the staged local Lightning snapshot and Canary `.nemo` artifact because NRT is offline; the real MCV 2K manifest was used as the bounded training input.

- training: `loss=6.000`, `mtp_loss=0.711`
- validation: `val_acc=0.16602`
- checkpoint: `step=1.ckpt` saved successfully
- cold-cache first step: 326 seconds due to H100 TorchInductor compilation

The image still lacks optional `cut_cross_entropy`, so this run also exercised the supported unfused MTP-loss fallback.

### NRT context-parallel / 8×H100

Job `6089571` passed against Speech head `7dbca42aa0` plus a clean Automodel #3525 + #3543 integration (`bc423748`). The packed-THD run used CP2/EP4/TP1/DP4, Transformer Engine attention/linear layers, one real MCV 2K joint-MTP optimizer step, one validation batch, and distributed checkpointing.

- training: `loss=5.840`, `mtp_loss=1.580` (`train_step_timing=259.0s`)
- validation: `val_acc=0.21289`; teacher-forced verifier-prefix MTP metrics were intentionally skipped under CP
- checkpoints: both `step=1.ckpt` and `step=1-last.ckpt` contain all eight DCP shards plus metadata
- SLURM: completed `0:0` in 9m50s on one 8×H100 node
- environment caveat: NRT's default `TORCH_NCCL_USE_COMM_NONBLOCKING=1` makes the first Mamba CP `all_to_all_single` return `NCCL Error 7: NCCL operation in progress`; the passing control set it to `0`. The container also required the workspace's compatible Lhotse overlay because its bundled Lhotse predates `ais_force_individual`.

### NRT context-parallel / 16×H100

Job `6091814` passed against Speech head `f6345345e8` plus the same clean Automodel #3525 + #3543 integration (`bc423748`). The two-node packed-THD run used CP2/EP8/TP1/inferred-DP8, Transformer Engine attention/linear layers, one finite MCV 2K joint-MTP optimizer step, one validation batch, and distributed checkpointing.

- training: `loss=5.840`, `mtp_loss=1.400` (`train_step_timing=72.60s`)
- validation: `val_acc=0.22070`; the new one-time warning explicitly reported that teacher-forced verifier-prefix MTP metrics are disabled under CP
- checkpoints: both `step=1.ckpt` and `step=1-last.ckpt` contain all sixteen DCP shards plus `.metadata` and `meta.pt`
- SLURM: completed `0:0` in 5m51s on two 8×H100 nodes
- environment: retained `TORCH_NCCL_USE_COMM_NONBLOCKING=0` and the compatible Lhotse overlay from the passing CP2/EP4 control

An initial allocation (`6091503`) stopped before its first batch on a permission error in the cluster config's default indexed-data mirror. The passing retry changed only the input pipeline to the finite, non-indexed map-style MCV setup already validated by job `6089571`; model sources and CP2/EP8 topology were unchanged.

This supersedes #15791 with a clean implementation based on current Speech `main`; unrelated vLLM inference remains follow-up work.

