### PR TITLE
Fix flow-matching CFG and acoustic bounds

### DIFF
--- a/nemo/collections/tts/models/easy_magpietts_inference.py
+++ b/nemo/collections/tts/models/easy_magpietts_inference.py
@@ -673,6 +673,21 @@ class EasyMagpieTTSInferenceModel(ModelPT):
             stacked_semantic_dim = self.semantic_codec_embedding_dim * self.frame_stacking_factor
             stacked_acoustic_dim = self.acoustic_codec_embedding_dim * self.frame_stacking_factor
             self.flow_acoustic_in_projection = nn.Linear(stacked_acoustic_dim, cfg.embedding_dim)
+            acoustic_min, acoustic_max = self._codec_helper.continuous_fsq_embedding_bounds(
+                num_semantic_codebooks=self.num_semantic_codebooks
+            )
+            self.register_buffer("_codec_acoustic_embedding_min_buffer", acoustic_min, persistent=False)
+            self.register_buffer("_codec_acoustic_embedding_max_buffer", acoustic_max, persistent=False)
+            self.register_buffer(
+                "_codec_stacked_acoustic_embedding_min_buffer",
+                acoustic_min.repeat_interleave(self.frame_stacking_factor, dim=1),
+                persistent=False,
+            )
+            self.register_buffer(
+                "_codec_stacked_acoustic_embedding_max_buffer",
+                acoustic_max.repeat_interleave(self.frame_stacking_factor, dim=1),
+                persistent=False,
+            )
             # This path has no counterpart in the pretrained discrete model. Start it as an
             # exact no-op so loading the pretrained backbone does not inject a random residual.
             nn.init.zeros_(self.flow_acoustic_in_projection.weight)
@@ -700,6 +715,16 @@ class EasyMagpieTTSInferenceModel(ModelPT):
     def codec_sil_acoustic_embedding(self):
         """Return one continuous acoustic codec frame representing silence."""
         return self._codec_sil_acoustic_embedding_buffer
+
+    @property
+    def codec_acoustic_embedding_min(self):
+        """Return per-channel lower limits of the continuous acoustic FSQ representation."""
+        return self._codec_acoustic_embedding_min_buffer
+
+    @property
+    def codec_acoustic_embedding_max(self):
+        """Return per-channel upper limits of the continuous acoustic FSQ representation."""
+        return self._codec_acoustic_embedding_max_buffer
 
     @property
     def local_predictor(self) -> OneShotLocalPredictor:
@@ -1744,17 +1769,40 @@ class EasyMagpieTTSInferenceModel(ModelPT):
         stacked_semantic_embedding = self.stack_codec_embeddings(semantic_embedding, self.frame_stacking_factor)
 
         hidden = last_hidden[:, -1, :]
+        unconditional_condition = None
         if use_cfg:
-            conditional, unconditional = hidden.chunk(2, dim=0)
-            hidden = cfg_scale * conditional + (1.0 - cfg_scale) * unconditional
+            conditional_hidden, unconditional_hidden = hidden.chunk(2, dim=0)
+            if self.local_transformer_type == LocalTransformerType.FLOW_MATCHING:
+                hidden = conditional_hidden
+                unconditional_condition = torch.cat(
+                    [
+                        unconditional_hidden.unsqueeze(-1),
+                        stacked_semantic_embedding.to(unconditional_hidden.dtype),
+                    ],
+                    dim=1,
+                )
+            else:
+                hidden = cfg_scale * conditional_hidden + (1.0 - cfg_scale) * unconditional_hidden
         condition = torch.cat(
             [hidden.unsqueeze(-1), stacked_semantic_embedding.to(hidden.dtype)],
             dim=1,
         )
-        stacked_acoustic_embedding = self.local_predictor.predict(
+        predict_kwargs = dict(
             condition=condition,
             lengths=torch.ones(batch_size, dtype=torch.long, device=condition.device),
             noise_scale=float(self.cfg.get("local_flow_noise_scale", 1.0)),
+        )
+        if self.local_transformer_type == LocalTransformerType.FLOW_MATCHING:
+            predict_kwargs.update(
+                unconditional_condition=unconditional_condition,
+                cfg_scale=cfg_scale,
+            )
+        stacked_acoustic_embedding = self.local_predictor.predict(**predict_kwargs)
+        lower = self._codec_stacked_acoustic_embedding_min_buffer.to(stacked_acoustic_embedding)
+        upper = self._codec_stacked_acoustic_embedding_max_buffer.to(stacked_acoustic_embedding)
+        stacked_acoustic_embedding = torch.maximum(
+            torch.minimum(stacked_acoustic_embedding, upper),
+            lower,
         )
         acoustic_embedding = self.unstack_codec_embeddings(
             stacked_acoustic_embedding,

--- a/nemo/collections/tts/modules/magpietts_flow_matching.py
+++ b/nemo/collections/tts/modules/magpietts_flow_matching.py
@@ -262,15 +262,38 @@ class OneShotLocalFlowMatching(OneShotLocalPredictor):
             "predicted_velocity_abs_max": _masked_abs_max(predicted_velocity)[worst_sample_index],
         }
 
+    def _guided_velocity(
+        self,
+        state: torch.Tensor,
+        condition: torch.Tensor,
+        time: torch.Tensor,
+        mask: torch.Tensor,
+        unconditional_condition: torch.Tensor | None,
+        cfg_scale: float,
+    ) -> torch.Tensor:
+        conditional_velocity = self.estimator(state, condition, time, mask)
+        if unconditional_condition is None or cfg_scale == 1.0:
+            return conditional_velocity
+
+        unconditional_velocity = self.estimator(state, unconditional_condition, time, mask)
+        return cfg_scale * conditional_velocity + (1.0 - cfg_scale) * unconditional_velocity
+
     @torch.no_grad()
     def predict(
         self,
         condition: torch.Tensor,
         lengths: torch.Tensor,
         noise_scale: float = 1.0,
+        unconditional_condition: torch.Tensor | None = None,
+        cfg_scale: float = 1.0,
     ) -> torch.Tensor:
         if noise_scale < 0.0:
             raise ValueError(f"noise_scale must be non-negative, got {noise_scale}")
+        if unconditional_condition is not None and unconditional_condition.shape != condition.shape:
+            raise ValueError(
+                "Conditional and unconditional flow inputs must have the same shape, got "
+                f"{condition.shape} and {unconditional_condition.shape}."
+            )
         mask = self.length_mask(lengths, condition.size(2), condition.dtype)
         state = torch.randn(
             condition.size(0),
@@ -281,18 +304,27 @@ class OneShotLocalFlowMatching(OneShotLocalPredictor):
         )
         state = state * noise_scale * mask
         condition = condition * mask
+        if unconditional_condition is not None:
+            unconditional_condition = unconditional_condition * mask
         step_size = 1.0 / self.inference_steps
 
         for step in range(self.inference_steps):
             start_time = step * step_size
             time = torch.full((state.size(0),), start_time, device=state.device)
-            velocity = self.estimator(state, condition, time, mask)
+            velocity = self._guided_velocity(state, condition, time, mask, unconditional_condition, cfg_scale)
             if self.solver == EULER_SOLVER:
                 state = state + step_size * velocity
             else:
                 midpoint_state = state + 0.5 * step_size * velocity
                 midpoint_time = time + 0.5 * step_size
-                midpoint_velocity = self.estimator(midpoint_state, condition, midpoint_time, mask)
+                midpoint_velocity = self._guided_velocity(
+                    midpoint_state,
+                    condition,
+                    midpoint_time,
+                    mask,
+                    unconditional_condition,
+                    cfg_scale,
+                )
                 state = state + step_size * midpoint_velocity
             state = state * mask
 

--- a/nemo/collections/tts/modules/magpietts_modules.py
+++ b/nemo/collections/tts/modules/magpietts_modules.py
@@ -493,6 +493,35 @@ class CodecHelper:
             )
         return groups
 
+    def continuous_fsq_embedding_bounds(
+        self,
+        num_semantic_codebooks: int = 0,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return normalized continuous FSQ limits for the selected acoustic groups."""
+        if not 0 <= num_semantic_codebooks < self.codec_model.num_codebooks:
+            raise ValueError(
+                f"num_semantic_codebooks must be in [0, {self.codec_model.num_codebooks - 1}], "
+                f"got {num_semantic_codebooks}."
+            )
+
+        lower_bounds = []
+        upper_bounds = []
+        quantizer_groups = self._independent_quantizer_groups()[num_semantic_codebooks:]
+        for quantizer_group in quantizer_groups:
+            num_levels = getattr(quantizer_group, "num_levels", None)
+            if num_levels is None:
+                raise ValueError("Continuous acoustic embeddings require grouped finite scalar quantizers (FSQ).")
+            num_levels_float = num_levels.float()
+            scale = (num_levels // 2).to(num_levels_float)
+            output_scale = (num_levels_float - 1.0) * 0.5 * (1.0 - float(quantizer_group.eps))
+            output_offset = torch.where(num_levels % 2 == 0, 0.5, 0.0).to(num_levels_float)
+            lower_bounds.append(((-output_scale - output_offset) / scale).reshape(-1))
+            upper_bounds.append(((output_scale - output_offset) / scale).reshape(-1))
+
+        lower = torch.cat(lower_bounds).reshape(1, -1, 1)
+        upper = torch.cat(upper_bounds).reshape(1, -1, 1)
+        return lower, upper
+
     def audio_to_semantic_codes_and_embedding(
         self,
         audio: torch.Tensor,

--- a/tests/collections/tts/models/test_easy_magpietts.py
+++ b/tests/collections/tts/models/test_easy_magpietts.py
@@ -816,6 +816,58 @@ def test_one_shot_flow_sampling_returns_semantic_codes_and_continuous_acoustics(
     assert acoustic_embedding.is_floating_point()
 
 
+def test_flow_matching_sampling_uses_separate_cfg_conditions_and_clamps_codec_support():
+    _seed_everything()
+    model = _make_easy_magpie_model(
+        tiny_easy_magpie_cfg(
+            {
+                "local_transformer_type": "flow_matching",
+                "frame_stacking_factor": 2,
+                "local_flow_matching_hidden_dim": 16,
+                "local_flow_matching_n_layers": 2,
+                "local_flow_matching_time_embedding_dim": 8,
+                "local_flow_matching_inference_steps": 2,
+            }
+        )
+    )
+    batch_size = 1
+    semantic_channels = model.num_semantic_codebooks * model.frame_stacking_factor
+    last_hidden = torch.cat(
+        [
+            torch.full((batch_size, 1, model.cfg.hidden_dim), 2.0),
+            torch.ones(batch_size, 1, model.cfg.hidden_dim),
+        ],
+        dim=0,
+    )
+    logits = torch.zeros(batch_size, semantic_channels * model.num_all_tokens_per_codebook)
+    sampled_semantic = torch.zeros(batch_size, semantic_channels, dtype=torch.long)
+    predicted_acoustic = torch.full(
+        (batch_size, model.acoustic_codec_embedding_dim * model.frame_stacking_factor, 1),
+        100.0,
+    )
+
+    with (
+        patch.object(model, "sample_codes_from_logits", return_value=sampled_semantic),
+        patch.object(model.local_predictor, "predict", return_value=predicted_acoustic) as predict_mock,
+    ):
+        _, _, acoustic_embedding = model._sample_audio_codes_with_flow(
+            last_hidden=last_hidden,
+            all_code_logits_t=logits,
+            temperature=0.7,
+            topk=20,
+            use_cfg=True,
+            cfg_scale=2.5,
+        )
+
+    predict_kwargs = predict_mock.call_args.kwargs
+    assert predict_kwargs["cfg_scale"] == 2.5
+    conditional = predict_kwargs["condition"]
+    unconditional = predict_kwargs["unconditional_condition"]
+    torch.testing.assert_close(conditional[:, model.cfg.hidden_dim :], unconditional[:, model.cfg.hidden_dim :])
+    assert torch.all(acoustic_embedding <= model.codec_acoustic_embedding_max)
+    assert torch.all(acoustic_embedding >= model.codec_acoustic_embedding_min)
+
+
 def test_one_shot_flow_teacher_forced_inference_decodes_continuous_acoustics_directly():
     _seed_everything()
     model = _make_easy_magpie_model(
@@ -920,11 +972,22 @@ def test_one_shot_flow_free_running_inference_feeds_generated_acoustics_back():
     feedback_inputs = [
         call.args[1] for call in embed_mock.call_args_list if call.args[1].shape == (1, expected_channels, 1)
     ]
-    assert any(torch.equal(value, torch.ones_like(value)) for value in feedback_inputs)
-    assert torch.equal(
-        output.predicted_acoustic_embeddings,
-        torch.ones_like(output.predicted_acoustic_embeddings),
+    expected_feedback = torch.maximum(
+        torch.minimum(
+            torch.ones_like(feedback_inputs[0]),
+            model._codec_stacked_acoustic_embedding_max_buffer,
+        ),
+        model._codec_stacked_acoustic_embedding_min_buffer,
     )
+    assert any(torch.equal(value, expected_feedback) for value in feedback_inputs)
+    expected_output = torch.maximum(
+        torch.minimum(
+            torch.ones_like(output.predicted_acoustic_embeddings),
+            model.codec_acoustic_embedding_max,
+        ),
+        model.codec_acoustic_embedding_min,
+    )
+    assert torch.equal(output.predicted_acoustic_embeddings, expected_output)
 
 
 def test_one_shot_flow_logs_explicit_wandb_loss_aliases():

--- a/tests/collections/tts/modules/test_magpietts_codec_helper.py
+++ b/tests/collections/tts/modules/test_magpietts_codec_helper.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -109,3 +110,22 @@ def test_codec_helper_returns_and_splits_continuous_fsq_embedding():
     assert not torch.allclose(raw_embedding, embedding)
     assert not torch.allclose(embedding, dequantized)
     assert not hasattr(helper, "acoustic_embedding_to_codes")
+
+
+def test_codec_helper_derives_continuous_fsq_support_for_acoustic_groups():
+    semantic_quantizer = SimpleNamespace(num_levels=torch.tensor([[[5]], [[5]]]), eps=1e-3)
+    acoustic_quantizer = SimpleNamespace(num_levels=torch.tensor([[[4]], [[5]]]), eps=1e-3)
+    vector_quantizer = SimpleNamespace(
+        fsqs=[semantic_quantizer, acoustic_quantizer],
+        num_groups=2,
+        codebook_dim=4,
+    )
+    codec = SimpleNamespace(num_codebooks=2, vector_quantizer=vector_quantizer)
+    helper = CodecHelper(codec)
+
+    lower, upper = helper.continuous_fsq_embedding_bounds(num_semantic_codebooks=1)
+
+    assert lower.shape == (1, 2, 1)
+    assert upper.shape == (1, 2, 1)
+    torch.testing.assert_close(lower.flatten(), torch.tensor([-0.99925, -0.99900]))
+    torch.testing.assert_close(upper.flatten(), torch.tensor([0.49925, 0.99900]))

--- a/tests/collections/tts/modules/test_magpietts_flow_matching.py
+++ b/tests/collections/tts/modules/test_magpietts_flow_matching.py
@@ -90,6 +90,17 @@ class _ConditionVelocity(nn.Module):
         return condition[:, : state.size(1)] * mask
 
 
+class _SquaredConditionVelocity(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.calls = 0
+
+    def forward(self, state, condition, time, mask):
+        del state, time
+        self.calls += 1
+        return condition[:, :12].square() * mask
+
+
 @pytest.mark.parametrize("solver, expected_calls", [("euler", 4), ("midpoint", 8)])
 def test_flow_matching_predict_integrates_inside_one_call(solver, expected_calls):
     predictor = _make_predictor(solver=solver)
@@ -108,6 +119,33 @@ def test_flow_matching_predict_integrates_inside_one_call(solver, expected_calls
     assert torch.allclose(prediction, expected, atol=1e-6, rtol=1e-6)
     assert estimator.calls == expected_calls
     assert torch.count_nonzero(prediction[1, :, 3:]) == 0
+
+
+def test_flow_matching_predict_applies_cfg_to_nonlinear_velocity_fields():
+    predictor = _make_predictor(solver="euler")
+    predictor.inference_steps = 1
+    estimator = _SquaredConditionVelocity()
+    predictor.estimator = estimator
+    condition = torch.full((1, 20, 2), 2.0)
+    unconditional_condition = torch.ones_like(condition)
+    lengths = torch.tensor([2])
+    cfg_scale = 2.5
+
+    torch.manual_seed(42)
+    initial_state = torch.randn(1, 12, 2)
+    torch.manual_seed(42)
+    prediction = predictor.predict(
+        condition,
+        lengths,
+        unconditional_condition=unconditional_condition,
+        cfg_scale=cfg_scale,
+    )
+
+    conditional_velocity = condition[:, :12].square()
+    unconditional_velocity = unconditional_condition[:, :12].square()
+    expected_velocity = cfg_scale * conditional_velocity + (1.0 - cfg_scale) * unconditional_velocity
+    torch.testing.assert_close(prediction, initial_state + expected_velocity)
+    assert estimator.calls == 2
 
 
 def test_flow_matching_diagnostics_are_finite_and_select_worst_sample():


### PR DESCRIPTION
## What changed

- apply classifier-free guidance to conditional and unconditional flow velocities at every ODE solver stage
- preserve the existing hidden-state guidance behavior for non-flow one-shot predictors
- derive continuous FSQ acoustic support bounds and clamp generated acoustic embeddings before feedback and decoding
- add regression coverage for nonlinear velocity guidance, CFG condition routing, FSQ bounds, and clamped free-running feedback

## Root cause

Flow-matching inference previously extrapolated the conditional and unconditional hidden conditions before passing them through the nonlinear velocity estimator. In general, evaluating the estimator on a mixed condition is not equivalent to mixing the conditional and unconditional velocity fields, so this was not classifier-free guidance in flow space.

## Impact

Flow-matching CFG now uses `v_u + scale * (v_c - v_u)` at the current Euler or midpoint state. Generated continuous acoustic embeddings are also kept within the codec's finite-scalar-quantizer support.

## Validation

- `pytest -q tests/collections/tts/modules/test_magpietts_flow_matching.py tests/collections/tts/modules/test_magpietts_codec_helper.py tests/collections/tts/models/test_easy_magpietts.py`
- 38 passed
- step-30k LibriTTS validation-path evaluation reproduced low WER and confirmed acoustic-head guidance improves WER and speaker similarity
