### PR TITLE
Locating the max speaker clamping at NMESC class methods

### DIFF
--- a/nemo/collections/asr/parts/utils/offline_clustering.py
+++ b/nemo/collections/asr/parts/utils/offline_clustering.py
@@ -627,6 +627,7 @@ def getEnhancedSpeakerCount(
     anchor_sample_n: int = 10,
     sigma: float = 50,
     cuda: bool = False,
+    max_num_speakers: int = 8,
 ) -> torch.Tensor:
     """
     Calculate the number of speakers using NME analysis with anchor embeddings. Add dummy speaker
@@ -638,6 +639,8 @@ def getEnhancedSpeakerCount(
             The input embedding from the embedding extractor.
         cuda (bool):
             Use cuda for the operations if cuda==True.
+        max_num_speakers (int):
+            Maximum number of speakers to estimate, excluding anchor speakers.
         random_test_count (int):
             Number of trials of the enhanced counting with randomness.
             The higher the count, the more accurate the enhanced counting is.
@@ -659,13 +662,14 @@ def getEnhancedSpeakerCount(
             number of speakers to factor out the dummy speaker embedding vectors.
     """
     est_num_of_spk_list: List[int] = []
+    max_num_speakers_aug = min(max_num_speakers, emb.shape[0]) + anchor_spk_n
     for seed in range(random_test_count):
         torch.manual_seed(seed)
         emb_aug = addAnchorEmb(emb, anchor_sample_n, anchor_spk_n, sigma)
         mat = getCosAffinityMatrix(emb_aug)
         nmesc = NMESC(
             mat,
-            max_num_speakers=emb.shape[0],
+            max_num_speakers=max_num_speakers_aug,
             max_rp_threshold=0.15,
             sparse_search=True,
             sparse_search_volume=10,
@@ -1371,7 +1375,9 @@ class SpeakerClustering(torch.nn.Module):
         if emb.shape[0] == 1:
             return torch.zeros((1,), dtype=torch.int64)
         elif emb.shape[0] <= max(enhanced_count_thres, self.min_samples_for_nmesc) and oracle_num_speakers < 0:
-            est_num_of_spk_enhanced = getEnhancedSpeakerCount(emb=emb, cuda=self.cuda)
+            est_num_of_spk_enhanced = getEnhancedSpeakerCount(
+                emb=emb, cuda=self.cuda, max_num_speakers=max_num_speakers
+            )
         else:
             est_num_of_spk_enhanced = torch.tensor(-1)
 

--- a/tests/collections/speaker_tasks/utils/test_diar_utils.py
+++ b/tests/collections/speaker_tasks/utils/test_diar_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+
 import numpy as np
 import pytest
 import torch
@@ -839,6 +840,51 @@ class TestSpeakerClustering:
         assert len(set(permuted_Y.tolist())) == n_spks
         assert Y_out.shape[0] == mc[-1]
         assert all(permuted_Y == gt)
+
+    @pytest.mark.run_only_on('GPU')
+    @pytest.mark.unit
+    @pytest.mark.parametrize("max_num_speakers", [2, 3])
+    @pytest.mark.parametrize("jit_script", [False, True])
+    def test_offline_speaker_clustering_enhanced_count_respects_max_num_speakers_gpu(
+        self, max_num_speakers, jit_script, cuda=True
+    ):
+        torch.manual_seed(0)
+        n_spks, samples_per_spk, emb_dim = 8, 3, 16
+        emb = torch.eye(emb_dim)[:n_spks].repeat_interleave(samples_per_spk, dim=0)
+        emb += 0.01 * torch.rand(n_spks * samples_per_spk, emb_dim)
+        segment_starts = torch.arange(emb.shape[0], dtype=torch.float32)
+        timestamps = torch.stack([segment_starts, segment_starts + 1], dim=1)
+
+        offline_speaker_clustering = SpeakerClustering(maj_vote_spk_count=False, min_samples_for_nmesc=0, cuda=cuda)
+        if jit_script:
+            offline_speaker_clustering = torch.jit.script(offline_speaker_clustering)
+
+        Y_out = offline_speaker_clustering.forward_infer(
+            embeddings_in_scales=emb,
+            timestamps_in_scales=timestamps,
+            multiscale_segment_counts=torch.tensor([emb.shape[0]]),
+            multiscale_weights=torch.ones(1, 1),
+            oracle_num_speakers=-1,
+            max_num_speakers=max_num_speakers,
+            enhanced_count_thres=40,
+            sparse_search_volume=5,
+            max_rp_threshold=0.15,
+            fixed_thres=-1.0,
+        )
+
+        assert Y_out.shape[0] == emb.shape[0]
+        assert torch.unique(Y_out).numel() <= max_num_speakers
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    @pytest.mark.parametrize("max_num_speakers", [2, 3])
+    @pytest.mark.parametrize("jit_script", [False, True])
+    def test_offline_speaker_clustering_enhanced_count_respects_max_num_speakers_cpu(
+        self, max_num_speakers, jit_script
+    ):
+        self.test_offline_speaker_clustering_enhanced_count_respects_max_num_speakers_gpu(
+            max_num_speakers=max_num_speakers, jit_script=jit_script, cuda=False
+        )
 
     @pytest.mark.run_only_on('GPU')
     @pytest.mark.unit


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed on very rare occasions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do?

Fix enhanced speaker counting for short-session diarization so that `max_num_speakers` is enforced organically during NMESC estimation instead of clamping the final cluster count.

This PR is initiated by the PR [#15835](https://github.com/NVIDIA-NeMo/Speech/pull/15835). Fixing the max speaker capping location and adding propoer tests with CPU and GPU, plus torchscript-enabled tests.

**Collection**: ASR — speaker diarization and offline clustering

# Changelog

- Pass the configured `max_num_speakers` value into `getEnhancedSpeakerCount`.
- Express the speaker limit in the anchor-augmented NMESC space as `min(max_num_speakers, emb.shape[0]) + anchor_spk_n`.
- Apply the limit during NMESC eigengap analysis rather than after selecting the oracle, enhanced, or standard speaker count.
- Preserve the existing oracle-speaker behavior in `SpeakerClustering.forward_unit_infer`.
- Add deterministic CPU and GPU regression tests for `max_num_speakers` values of 2 and 3.
- Test both eager and TorchScript execution paths.

# Usage

No usage or configuration changes are required. Existing `max_num_speakers` settings are now respected by the enhanced speaker-counting path used for short sessions.

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI, remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? The affected function's parameter documentation was updated; no user-facing documentation changes are required.
- [x] Does the PR affect components that are optional to install? No.
  - [x] Reviewer: Import guards are not applicable because this PR does not introduce or modify optional dependencies.

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items, you can still open a draft PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md) contains specific people who can review PRs in various areas.

# Additional Information

- Related to [#15835](https://github.com/NVIDIA-NeMo/Speech/pull/15835).