### PR TITLE
Update NeMo Speech release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Project Status: Active -- The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
-[![CodeQL](https://github.com/nvidia/nemo/actions/workflows/codeql.yml/badge.svg?branch=main&event=push)](https://github.com/nvidia/nemo/actions/workflows/codeql.yml)
-[![NeMo core license and license for collections in this repo](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](https://github.com/NVIDIA/NeMo/blob/master/LICENSE)
+[![CodeQL](https://github.com/NVIDIA-NeMo/Speech/actions/workflows/codeql.yml/badge.svg?branch=main&event=push)](https://github.com/NVIDIA-NeMo/Speech/actions/workflows/codeql.yml)
+[![NeMo Speech license](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](https://github.com/NVIDIA-NeMo/Speech/blob/main/LICENSE)
 [![Release version](https://badge.fury.io/py/nemo-toolkit.svg)](https://badge.fury.io/py/nemo-toolkit)
 [![Python version](https://img.shields.io/pypi/pyversions/nemo-toolkit.svg)](https://badge.fury.io/py/nemo-toolkit)
 [![PyPi total downloads](https://static.pepy.tech/personalized-badge/nemo-toolkit?period=total&units=international_system&left_color=grey&right_color=brightgreen&left_text=downloads)](https://pepy.tech/project/nemo-toolkit)
@@ -12,8 +12,11 @@ weight checkpoints and demos!
 
 ## Updates
 
-> The first release of NeMo Speech after NeMo repository split is scheduled for June 2026, as the repo undergoes transformation.
-> For the latest stable released version, please use [the 26.02 NGC container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo?version=26.02).
+> NeMo Speech 3.0 is now available as [release v3.0.0](https://github.com/NVIDIA-NeMo/Speech/releases/tag/v3.0.0)
+> and in the [26.07.00 NeMo Speech NGC container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-speech?version=26.07.00).
+> The final NeMo release before the repository split was
+> [v2.7.3](https://github.com/NVIDIA-NeMo/Speech/releases/tag/v2.7.3), available in the
+> [26.04 NeMo NGC container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo?version=26.04).
 
 - 2026-07: [MagpieTTS v2607](https://huggingface.co/nvidia/magpie_tts_multilingual_357m) has been released with support
     for 3 new languages (Ar, Ko, Pt) + 9 existing languages (En, Es, De, Fr, Vi, It, Zh, Hi, Ja). Try out
@@ -30,8 +33,8 @@ weight checkpoints and demos!
 - 2026-01: Nemotron-Speech-Streaming was released: One checkpoint that enables users to pick their optimal point
     on the latency-accuracy Pareto curve!
 - 2026-01: [MagpieTTS v2512](https://huggingface.co/nvidia/magpie_tts_multilingual_357m/tree/v2512) was released.
-- 2026: This repo has pivoted to focus on audio, speech, and multimodal LLM. For the last NeMo release with support for more
-    modalities, see [v2.7.0](https://github.com/NVIDIA-NeMo/NeMo/releases/tag/v2.7.0)
+- 2026: This repo has pivoted to focus on audio, speech, and multimodal LLMs. For the final pre-split NeMo release with
+    support for additional modalities, see [v2.7.3](https://github.com/NVIDIA-NeMo/Speech/releases/tag/v2.7.3).
 - 2025-08: [Parakeet V3](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) and
     [Canary V2](https://huggingface.co/nvidia/canary-1b-v2) have been released with speech recognition and translation
     support for 25 European languages.
@@ -45,7 +48,7 @@ Recognition (ASR), Text to Speech (TTS), and Speech LLMs. It is designed to help
 deploy new AI models by leveraging existing code and pre-trained model checkpoints.
 
 For technical documentation, please see the
-[NeMo Framework User Guide](https://docs.nvidia.com/nemo/speech/nightly/).
+[NeMo Speech Developer Documentation](https://docs.nvidia.com/nemo/speech/nightly/).
 
 ## Requirements
 
@@ -65,36 +68,42 @@ can have the risk of arbitrary code execution.
 
 ## Developer Documentation
 
-| Version |  Description                                                                                     |
-| ------- | ------------------------------------------------------------------------------------------------ |
-| Latest  | [Documentation of the latest (i.e. main) branch.](https://docs.nvidia.com/nemo/speech/nightly/)  |
-| Stable  | Documentation of the stable (i.e. most recent release) - To be added                             |
+| Version | Description |
+| ------- | ----------- |
+| 3.0.0 (latest release) | [NeMo Speech 3.0.0 documentation](https://docs.nvidia.com/nemo/speech/3.0.0/) |
+| Nightly | [Documentation for the latest `main` branch](https://docs.nvidia.com/nemo/speech/nightly/) |
 
 ## Install NeMo Speech
 
-The recommended way to install NeMo Speech is from source with [uv](https://docs.astral.sh/uv/), which reproduces our actively-tested stack from the committed `uv.lock`. If you need different Python/PyTorch/CUDA versions, NeMo also installs over your existing environment via pip — see the [pip fallback](#from-pypi-with-pip-fallback--bring-your-own-versions) below.
+The recommended way to install NeMo Speech is from source with [uv](https://docs.astral.sh/uv/), which reproduces our actively-tested stack from the committed `uv.lock`. If you need different Python/PyTorch/CUDA versions, NeMo Speech also installs over your existing environment via pip — see the [pip fallback](#from-pypi-with-pip-fallback--bring-your-own-versions) below.
 
 ### From source with uv (recommended)
 
 ```bash
-git clone https://github.com/NVIDIA-NeMo/NeMo.git
-cd NeMo
+git clone https://github.com/NVIDIA-NeMo/Speech.git
+cd Speech
 uv sync --extra all --extra cu13     # CUDA 13.x (recommended) — use --extra cu12 for CUDA 12.x
 ```
 
-This installs our supported stack (Python 3.13, PyTorch 2.12, CUDA 13.2) into `.venv/` with NeMo editable. Add `--group test` for the test suite or `--group docs` to build the docs; run tools via `uv run <cmd>` or activate with `source .venv/bin/activate`. On Linux, `cu12` and `cu13` are mutually exclusive — pass exactly one (`cu13` is the default). For the **exact** container baseline, add `--locked --python 3.13` (the path the Dockerfile and CI use).
+This installs our supported stack (Python 3.13, PyTorch 2.12, CUDA 13.2) into `.venv/` with NeMo Speech editable. Add `--group test` for the test suite or `--group docs` to build the docs; run tools via `uv run <cmd>` or activate with `source .venv/bin/activate`. On Linux, `cu12` and `cu13` are mutually exclusive — pass exactly one (`cu13` is the default). For the **exact** container baseline, add `--locked --python 3.13` (the path the Dockerfile and CI use).
 
 > **SpeechLM2 / Automodel:** the Automodel backend runs **without** any compiled dependencies. It can *optionally* benefit from dedicated accelerated backends (Transformer Engine, FlashAttention, Mamba, grouped-GEMM/MoE, DeepEP) for better performance — these source-built kernels come from the `compiled` (Hopper/Blackwell) or `compiled-a100` (A100) extras, built by `docker/Dockerfile` (`GPU_TARGET=h100plus` / `a100`). See the [installation guide](https://docs.nvidia.com/nemo/speech/nightly/) for the full list and build details.
 
 ### Docker (turnkey, our supported stack)
 
-> **NGC container:** _Coming soon — the pull command for the prebuilt NeMo Speech container image will be published here._
+The latest prebuilt NeMo Speech image is the
+[26.07.00 NGC container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-speech?version=26.07.00):
+
+```bash
+docker pull nvcr.io/nvidia/nemo-speech:26.07.00
+docker run --rm -it --gpus all -v "$PWD:/workspace" nvcr.io/nvidia/nemo-speech:26.07.00 bash
+```
 
 To build the container from source (CUDA 13 / H100+ by default):
 
 ```bash
-git clone https://github.com/NVIDIA-NeMo/NeMo.git
-cd NeMo
+git clone https://github.com/NVIDIA-NeMo/Speech.git
+cd Speech
 docker buildx build -f docker/Dockerfile -t nemo-speech .          # CUDA 13 / H100+ (default)
 docker run --rm -it --gpus all -v "$PWD:/workspace" nemo-speech bash
 ```
@@ -103,7 +112,7 @@ For A100, set `GPU_TARGET=a100` — A100 works with **both CUDA 12 and CUDA 13**
 
 ### From PyPI with pip (fallback — bring your own versions)
 
-Prefer your own Python/PyTorch/CUDA? Install your PyTorch first (any version ≥ 2.7 for your CPU/CUDA/etc. target — see the [PyTorch install matrix](https://pytorch.org/get-started/locally/)), then add NeMo and it **keeps your build**. `uv pip` (uv's fast, pip-compatible installer) works like `pip`:
+Prefer your own Python/PyTorch/CUDA? Install your PyTorch first (any version ≥ 2.7 for your CPU/CUDA/etc. target — see the [PyTorch install matrix](https://pytorch.org/get-started/locally/)), then add NeMo Speech and it **keeps your build**. `uv pip` (uv's fast, pip-compatible installer) works like `pip`:
 
 ```bash
 uv pip install 'nemo-toolkit[asr,tts]'   # or plain: pip install 'nemo-toolkit[asr,tts]'
@@ -118,11 +127,11 @@ pip install 'nemo-toolkit[asr,tts,cu13]' --extra-index-url https://download.pyto
 pip install 'nemo-toolkit[asr,tts,cu12]' --extra-index-url https://download.pytorch.org/whl/cu129   # CUDA 12.x
 ```
 
-## Contribute to NeMo
+## Contribute to NeMo Speech
 
 We welcome community contributions! Please refer to
-[CONTRIBUTING.md](https://github.com/NVIDIA-NeMo/NeMo/blob/main/CONTRIBUTING.md) for the process.
+[CONTRIBUTING.md](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md) for the process.
 
 ## Licenses
 
-NeMo is licensed under the [Apache License 2.0](https://github.com/NVIDIA/NeMo?tab=Apache-2.0-1-ov-file).
+NeMo Speech is licensed under the [Apache License 2.0](https://github.com/NVIDIA-NeMo/Speech/blob/main/LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Documentation Process for NeMo
+# Documentation Process for NeMo Speech
 
 ## Building the Documentation
 

--- a/docs/source/apis.rst
+++ b/docs/source/apis.rst
@@ -1,15 +1,15 @@
 :orphan:
 
-=========
-NeMo APIs
-=========
+================
+NeMo Speech APIs
+================
 
-You can learn more about the underlying principles of the NeMo codebase in this section.
+You can learn more about the underlying principles of the NeMo Speech codebase in this section.
 
-The `NeMo Toolkit codebase <https://github.com/NVIDIA-NeMo/Speech>`__ is composed of a `core <https://github.com/NVIDIA-NeMo/Speech/tree/main/nemo/core>`__ section which contains the main building blocks of the framework, and various `collections <https://github.com/NVIDIA-NeMo/Speech/tree/main/nemo/collections>`__ which help you
+The `NeMo Speech codebase <https://github.com/NVIDIA-NeMo/Speech>`__ is composed of a `core <https://github.com/NVIDIA-NeMo/Speech/tree/main/nemo/core>`__ section which contains the main building blocks of the framework, and various `collections <https://github.com/NVIDIA-NeMo/Speech/tree/main/nemo/collections>`__ which help you
 build specialized AI models.
 
-You can learn more about aspects of the NeMo "core" by following the links below:
+You can learn more about aspects of the NeMo Speech "core" by following the links below:
 
 .. toctree::
    :maxdepth: 1
@@ -22,7 +22,7 @@ You can learn more about aspects of the NeMo "core" by following the links below
    core/neural_types
    core/adapters/intro
 
-You can learn more about aspects of the NeMo APIs by following the links below:
+You can learn more about aspects of the NeMo Speech APIs by following the links below:
 
 .. toctree::
    :maxdepth: 1
@@ -45,4 +45,3 @@ Alternatively, you can jump straight to the documentation for the individual col
 * :doc:`Audio Processing <../audio/intro>`
 
 * :doc:`SpeechLM2 <../speechlm2/intro>`
-

--- a/docs/source/collections.rst
+++ b/docs/source/collections.rst
@@ -1,8 +1,8 @@
 :orphan:
 
-================
-NeMo Collections
-================
+=======================
+NeMo Speech Collections
+=======================
 
 Documentation for the individual collections
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,10 +47,10 @@ NVIDIA NeMo Speech Developer Docs
    </div>
 
 
-What is NeMo?
---------------
+What is NeMo Speech?
+--------------------
 
-`NVIDIA NeMo <https://github.com/NVIDIA-NeMo/Speech>`_ is an open-source toolkit for building, customizing, and deploying speech, audio, and multimodal language models. It provides:
+`NVIDIA NeMo Speech <https://github.com/NVIDIA-NeMo/Speech>`_ is an open-source toolkit for building, customizing, and deploying speech, audio, and multimodal language models. It provides:
 
 - **Pretrained models** — production-ready checkpoints on `NGC <https://catalog.ngc.nvidia.com/models?query=nemo&orderBy=weightPopularDESC>`__ and `HuggingFace Hub <https://huggingface.co/nvidia>`__
 - **Modular architecture** — neural modules you can mix, match, and extend

--- a/docs/source/starthere/choosing_a_model.rst
+++ b/docs/source/starthere/choosing_a_model.rst
@@ -3,7 +3,7 @@
 Choosing a Model
 ================
 
-NeMo offers many pretrained speech models. This guide helps you pick the right one for your use case.
+NeMo Speech offers many pretrained speech models. This guide helps you pick the right one for your use case.
 
 ASR: Which Model Should I Use?
 ------------------------------
@@ -101,11 +101,10 @@ Speech Language Models: Which Model Should I Use?
 Where to Find Models
 --------------------
 
-All pretrained NeMo models are available on:
+All pretrained NeMo Speech models are available on:
 
 - `HuggingFace Hub (nvidia) <https://huggingface.co/nvidia>`_ — search for "nemo" or specific model names
 - `NGC Model Catalog <https://catalog.ngc.nvidia.com/models?query=nemo&orderBy=weightPopularDESC>`_ — NVIDIA's model registry
 - :doc:`Featured Community Checkpoints </asr/featured_community_checkpoints>` — fine-tunes from external users
 
 See :doc:`../checkpoints/intro` for instructions on loading pretrained models.
-

--- a/docs/source/starthere/install.rst
+++ b/docs/source/starthere/install.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-This page covers how to install NVIDIA NeMo for speech AI tasks (ASR, TTS, speaker tasks, audio processing, and speech language models).
+This page covers how to install NVIDIA NeMo Speech for speech AI tasks (ASR, TTS, speaker tasks, audio processing, and speech language models).
 
 Prerequisites
 -------------
@@ -36,7 +36,7 @@ The recommended way to install NeMo Speech is from source with `uv <https://docs
 .. code-block:: bash
 
    git clone https://github.com/NVIDIA-NeMo/Speech.git
-   cd NeMo
+   cd Speech
 
    # CUDA 13.x (recommended). Use --extra cu12 for CUDA 12.x. uv resolves the
    # matching PyTorch CUDA wheel automatically from the pinned indexes.
@@ -46,7 +46,7 @@ The recommended way to install NeMo Speech is from source with `uv <https://docs
    # uv sync --extra all --extra cu13 --group test
    # uv sync --group docs
 
-``uv sync`` creates a virtual environment in ``.venv/`` with NeMo installed in editable mode, matching our supported stack (Python 3.13, PyTorch 2.12, CUDA 13.2 by default). Run commands with ``uv run <cmd>`` or activate the environment with ``source .venv/bin/activate``. For the **exact** container baseline, add ``--locked --python 3.13`` (i.e. ``uv sync --locked --python 3.13 --extra all --extra cu13``) — this is the path the Dockerfile and CI use.
+``uv sync`` creates a virtual environment in ``.venv/`` with NeMo Speech installed in editable mode, matching our supported stack (Python 3.13, PyTorch 2.12, CUDA 13.2 by default). Run commands with ``uv run <cmd>`` or activate the environment with ``source .venv/bin/activate``. For the **exact** container baseline, add ``--locked --python 3.13`` (i.e. ``uv sync --locked --python 3.13 --extra all --extra cu13``) — this is the path the Dockerfile and CI use.
 
 On Linux, pass exactly one of ``--extra cu13`` (recommended) or ``--extra cu12`` — they are mutually exclusive. If you omit both, uv installs the generic PyPI PyTorch wheel instead of NVIDIA's CUDA-matched build.
 
@@ -125,16 +125,20 @@ Choose the variant that matches your GPU (the two are mutually exclusive):
 Using Docker (turnkey, our supported stack)
 --------------------------------------------
 
-.. note::
+The latest prebuilt NeMo Speech image is the
+`26.07.00 NGC container <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-speech?version=26.07.00>`_:
 
-   **NGC container:** *Coming soon — the pull command for the prebuilt NeMo Speech container image will be published here.*
+.. code-block:: bash
+
+   docker pull nvcr.io/nvidia/nemo-speech:26.07.00
+   docker run --rm -it --gpus all -v "$PWD:/workspace" nvcr.io/nvidia/nemo-speech:26.07.00 bash
 
 To build the container from source, use the provided ``docker/Dockerfile`` (CUDA 13 / H100+ by default):
 
 .. code-block:: bash
 
    git clone https://github.com/NVIDIA-NeMo/Speech.git
-   cd NeMo
+   cd Speech
    docker buildx build -f docker/Dockerfile -t nemo-speech .          # CUDA 13 / H100+ (default)
    docker run --rm -it --gpus all -v "$PWD:/workspace" nemo-speech bash
 
@@ -157,7 +161,7 @@ See the header of ``docker/Dockerfile`` for all build arguments (``BASE_IMAGE``,
 Install from PyPI with pip (fallback — bring your own versions)
 ---------------------------------------------------------------
 
-Prefer your own Python/PyTorch/CUDA? Install your preferred PyTorch first (any version ≥ 2.7 for your CPU/CUDA/etc. target — see `PyTorch's install matrix <https://pytorch.org/get-started/locally/>`_), then add NeMo. Your pre-installed PyTorch is kept, not replaced. ``uv pip`` (uv's fast, pip-compatible installer) works just like ``pip``:
+Prefer your own Python/PyTorch/CUDA? Install your preferred PyTorch first (any version ≥ 2.7 for your CPU/CUDA/etc. target — see `PyTorch's install matrix <https://pytorch.org/get-started/locally/>`_), then add NeMo Speech. Your pre-installed PyTorch is kept, not replaced. ``uv pip`` (uv's fast, pip-compatible installer) works just like ``pip``:
 
 .. code-block:: bash
 
@@ -167,7 +171,7 @@ Prefer your own Python/PyTorch/CUDA? Install your preferred PyTorch first (any v
    # 1) Your choice of PyTorch (example: CUDA 12.9 build). Skip if you already have one.
    uv pip install torch --index-url https://download.pytorch.org/whl/cu129
 
-   # 2) NeMo — your PyTorch above is kept (plain `pip install` works identically)
+   # 2) NeMo Speech — your PyTorch above is kept (plain `pip install` works identically)
    uv pip install 'nemo-toolkit[asr,tts]'        # also: [asr,tts,audio], [speechlm2], etc.
 
 .. warning::
@@ -192,7 +196,7 @@ After installing, verify that the chosen collection imports:
 
 .. code-block:: bash
 
-   python -c "import nemo.collections.asr as nemo_asr; print('NeMo ASR installed')"
+   python -c "import nemo.collections.asr as nemo_asr; print('NeMo Speech ASR installed')"
 
 If you installed with ``uv sync`` and have not activated ``.venv``, run the check through ``uv run python``. To also exercise a model download:
 
@@ -205,6 +209,6 @@ If you installed with ``uv sync`` and have not activated ``.venv``, run the chec
 What's Next?
 ------------
 
-- :doc:`ten_minutes` — A quick tour of NeMo's speech capabilities
+- :doc:`ten_minutes` — A quick tour of NeMo Speech's capabilities
 - :doc:`key_concepts` — Understand the fundamentals of speech AI
 - :doc:`choosing_a_model` — Find the right model for your use case

--- a/docs/source/starthere/key_concepts.rst
+++ b/docs/source/starthere/key_concepts.rst
@@ -3,16 +3,16 @@
 Key Concepts in Speech AI
 =========================
 
-This page introduces the fundamental concepts you'll encounter when working with speech models in NeMo. No prior NeMo experience is required — we start from the basics of audio and work up to how NeMo structures its models.
+This page introduces the fundamental concepts you'll encounter when working with speech models in NeMo Speech. No prior NeMo Speech experience is required — we start from the basics of audio and work up to how NeMo Speech structures its models.
 
-Audio Conventions in NeMo
--------------------------
+Audio Conventions in NeMo Speech
+--------------------------------
 
 **Sampling rate** — ASR models often use **16 kHz**; TTS and audio processing models may use higher rates (e.g. 22.05 kHz, 44.1 kHz). Check each model's or preprocessor's config for the expected sample rate.
 
 **Channels** — Most models use mono input, but some support **multi-channel** audio (e.g. for spatial or multi-mic setups). See the model and preprocessor documentation for your use case.
 
-**Preprocessing** — NeMo models typically include a **preprocessor** that converts waveform input into features (e.g. mel-spectrogram). For most setups, you should provide audio that already matches the model's expected **sample rate** and **channel layout** (often mono); automatic resampling or stereo→mono is not guaranteed and depends on the collection, dataset, and preprocessor config. Check the model and preprocessor documentation for your use case.
+**Preprocessing** — NeMo Speech models typically include a **preprocessor** that converts waveform input into features (e.g. mel-spectrogram). For most setups, you should provide audio that already matches the model's expected **sample rate** and **channel layout** (often mono); automatic resampling or stereo→mono is not guaranteed and depends on the collection, dataset, and preprocessor config. Check the model and preprocessor documentation for your use case.
 
 **Mel-spectrogram** — For models that use it, the preprocessor turns raw waveform into mel-spectrogram features; this is handled inside the model, not as a separate offline step.
 
@@ -20,7 +20,7 @@ Audio Conventions in NeMo
 Speech AI Tasks
 ---------------
 
-NeMo supports several speech AI tasks, each solving a different problem:
+NeMo Speech supports several speech AI tasks, each solving a different problem:
 
 .. list-table::
    :widths: 20 40 40
@@ -55,19 +55,19 @@ Encoder Architectures
 The *encoder* converts audio features into a sequence of high-level representations:
 
 **Transformer**
-   The standard encoder from `Vaswani et al. (2017) <https://arxiv.org/abs/1706.03762>`_ — stacked self-attention and feed-forward layers with no convolutions. Used in NeMo as an encoder or decoder in encoder-decoder models (e.g. Canary).
+   The standard encoder from `Vaswani et al. (2017) <https://arxiv.org/abs/1706.03762>`_ — stacked self-attention and feed-forward layers with no convolutions. Used in NeMo Speech as an encoder or decoder in encoder-decoder models (e.g. Canary).
 
 **Conformer**
    The original architecture from `Gulati et al. (2020) <https://arxiv.org/abs/2005.08100>`_ that combines self-attention with convolutions for both global and local patterns.
 
 **FastConformer**
-   A faster variant of Conformer (`Rekesh et al. (2023) <https://arxiv.org/abs/2305.05084>`_) with 8× subsampling and optimized attention. NeMo's default choice for ASR; recommended for new projects.
+   A faster variant of Conformer (`Rekesh et al. (2023) <https://arxiv.org/abs/2305.05084>`_) with 8× subsampling and optimized attention. NeMo Speech's default choice for ASR; recommended for new projects.
 
 
-How NeMo Models Work
----------------------
+How NeMo Speech Models Work
+----------------------------
 
-Every NeMo model wraps these components into a single, cohesive unit:
+Every NeMo Speech model wraps these components into a single, cohesive unit:
 
 .. raw:: html
 
@@ -111,12 +111,12 @@ Every NeMo model wraps these components into a single, cohesive unit:
 Overview of NeMo Speech
 ========================
 
-NeMo models are PyTorch modules that also integrate with `PyTorch Lightning <https://lightning.ai/>`__ for training and `Hydra <https://hydra.cc/>`__ + `OmegaConf <https://omegaconf.readthedocs.io/>`__ for configuration.
+NeMo Speech models are PyTorch modules that also integrate with `PyTorch Lightning <https://lightning.ai/>`__ for training and `Hydra <https://hydra.cc/>`__ + `OmegaConf <https://omegaconf.readthedocs.io/>`__ for configuration.
 
 Configuration with YAML
 ------------------------
 
-NeMo experiments are configured with YAML files. A typical config has three main sections:
+NeMo Speech experiments are configured with YAML files. A typical config has three main sections:
 
 .. code-block:: yaml
 
@@ -159,7 +159,7 @@ You can override any value from the command line:
 Manifest Files
 --------------
 
-NeMo uses **manifest files** (JSONL format) to describe datasets. Each line is one training example:
+NeMo Speech uses **manifest files** (JSONL format) to describe datasets. Each line is one training example:
 
 .. code-block:: json
 
@@ -178,7 +178,7 @@ See :doc:`../asr/datasets` for details on preparing datasets.
 Model Checkpoints
 -----------------
 
-NeMo models are saved as ``.nemo`` files — tar archives containing model weights, configuration, and tokenizer files. You can load models in two ways:
+NeMo Speech models are saved as ``.nemo`` files — tar archives containing model weights, configuration, and tokenizer files. You can load models in two ways:
 
 .. code-block:: python
 
@@ -189,4 +189,3 @@ NeMo models are saved as ``.nemo`` files — tar archives containing model weigh
    model = nemo_asr.models.ASRModel.restore_from("path/to/model.nemo")
 
 See :doc:`../checkpoints/intro` for more details on checkpoint formats.
-

--- a/docs/source/starthere/ten_minutes.rst
+++ b/docs/source/starthere/ten_minutes.rst
@@ -3,17 +3,17 @@
 NeMo Speech Inference in 5 Minutes
 ===================================
 
-This guide gives you a quick, hands-on tour of NeMo's core speech capabilities. By the end, you'll have transcribed audio, synthesized speech, identified speakers, and used a speech language model — all in about 50 lines of code.
+This guide gives you a quick, hands-on tour of NeMo Speech's core capabilities. By the end, you'll have transcribed audio, synthesized speech, identified speakers, and used a speech language model — all in about 50 lines of code.
 
 .. note::
 
-   Make sure you have :doc:`installed NeMo <install>` before starting.
+   Make sure you have :doc:`installed NeMo Speech <install>` before starting.
 
 
 1. Transcribe Speech (ASR)
 --------------------------
 
-Automatic Speech Recognition converts audio to text. NeMo's Parakeet model sits at the top of the `HuggingFace OpenASR Leaderboard <https://huggingface.co/spaces/hf-audio/open_asr_leaderboard>`_.
+Automatic Speech Recognition converts audio to text. NeMo Speech's Parakeet model sits at the top of the `HuggingFace OpenASR Leaderboard <https://huggingface.co/spaces/hf-audio/open_asr_leaderboard>`_.
 
 **Basic transcription** — 3 lines of code:
 
@@ -45,7 +45,7 @@ Automatic Speech Recognition converts audio to text. NeMo's Parakeet model sits 
 2. Synthesize Speech (TTS)
 --------------------------
 
-Text-to-Speech generates natural audio from text. NeMo's **Magpie TTS** is a multilingual, codec-based model that supports multiple speakers and languages:
+Text-to-Speech generates natural audio from text. NeMo Speech's **Magpie TTS** is a multilingual, codec-based model that supports multiple speakers and languages:
 
 .. code-block:: python
 
@@ -58,7 +58,7 @@ Text-to-Speech generates natural audio from text. NeMo's **Magpie TTS** is a mul
 
    # Generate speech
    audio, audio_len = model.do_tts(
-       transcript="Hello! Welcome to NeMo speech AI.",
+       transcript="Hello! Welcome to NeMo Speech AI.",
        language="en",
    )
 
@@ -117,4 +117,3 @@ Now that you've seen the basics, dive deeper:
 - :doc:`../tts/intro` — Full TTS documentation
 - :doc:`../asr/speaker_diarization/intro` — Speaker diarization and recognition
 - :doc:`../starthere/tutorials` — Tutorial notebooks
-

--- a/docs/source/starthere/tutorials.rst
+++ b/docs/source/starthere/tutorials.rst
@@ -3,12 +3,12 @@
 Tutorials
 =========
 
-The best way to get started with NeMo is to start with one of our tutorials. These tutorials cover various domains and provide both introductory and advanced topics. They are designed to help you understand and use the NeMo toolkit effectively.
+The best way to get started with NeMo Speech is to start with one of our tutorials. These tutorials cover various domains and provide both introductory and advanced topics. They are designed to help you understand and use NeMo Speech effectively.
 
 Running Tutorials on Colab
 --------------------------
 
-Most NeMo tutorials can be run on `Google's Colab <https://colab.research.google.com/notebooks/intro.ipynb>`_.
+Most NeMo Speech tutorials can be run on `Google's Colab <https://colab.research.google.com/notebooks/intro.ipynb>`_.
 
 To run a tutorial:
 
@@ -181,4 +181,3 @@ Tutorial Overview
    * - Utility Tools
      - Utility Tools for Speech and Text: CTC Segmentation
      - `CTC Segmentation <https://colab.research.google.com/github/NVIDIA-NeMo/Speech/blob/main/tutorials/tools/CTC_Segmentation_Tutorial.ipynb>`_
-


### PR DESCRIPTION
## Summary

- replace the pre-release repository-split notice with the current NeMo Speech 3.0 release status
- link the versioned NeMo Speech 3.0.0 documentation and latest 26.07.00 NGC Speech container
- identify NeMo v2.7.3 and the 26.04 NGC container as the final pre-split release
- add NGC pull/run commands and fix stale repository links in the README and installation guide
- use "NeMo Speech" consistently across top-level and getting-started documentation

## Why

The README and installation documentation still described the first post-split release and Speech container as forthcoming. This update directs users to the released documentation and supported container while preserving a clear path to the final pre-split NeMo release.

## User impact

Users can now find the correct released docs, pull the current NeMo Speech container directly, and distinguish the current speech-focused project from the final pre-split NeMo release.

## Validation

- Sphinx HTML documentation build (succeeded; existing optional-dependency autodoc warnings remain)
- `git diff --check`
- verified the versioned documentation, NGC container, and release links against NVIDIA and GitHub sources
