### PR TITLE
Coalesce missing batch_size in ClusteringDiarizer dataloader configs

### DIFF
--- a/nemo/collections/asr/models/clustering_diarizer.py
+++ b/nemo/collections/asr/models/clustering_diarizer.py
@@ -69,6 +69,12 @@ class ClusteringDiarizer(torch.nn.Module, Model, DiarizationMixin):
     All the parameters are passed through config file
     """
 
+    # Fallback batch size used for the VAD and speaker-embedding dataloaders when the config does
+    # not specify a (top-level) ``batch_size``. Must be a positive int so DataLoader keeps automatic
+    # batching enabled (``batch_size=None`` would feed un-batched 0-d tensor samples to the collate
+    # function and raise ``TypeError: iteration over a 0-d tensor``).
+    _DEFAULT_BATCH_SIZE = 64
+
     def __init__(self, cfg: Union[DictConfig, Any], speaker_model=None):
         super().__init__()
         if isinstance(cfg, DictConfig):
@@ -156,11 +162,26 @@ class ClusteringDiarizer(torch.nn.Module, Model, DiarizationMixin):
             self._diarizer_params.speaker_embeddings.parameters.multiscale_weights,
         )
 
+    def _get_batch_size(self):
+        """
+        Resolve the batch size used for VAD and speaker-embedding dataloaders.
+
+        The batch size may legitimately be absent from the config (e.g. when only ``diarizer.*``
+        keys are provided). A missing or ``None`` value must not be forwarded to
+        ``torch.utils.data.DataLoader``, because ``batch_size=None`` disables automatic batching and
+        feeds raw un-batched (0-d tensor) samples to the collate function, raising
+        ``TypeError: iteration over a 0-d tensor``. Coalesce to a sensible positive default instead.
+        """
+        batch_size = self._cfg.get('batch_size')
+        if batch_size is None:
+            batch_size = self._DEFAULT_BATCH_SIZE
+        return batch_size
+
     def _setup_vad_test_data(self, manifest_vad_input):
         vad_dl_config = {
             'manifest_filepath': manifest_vad_input,
             'sample_rate': self._cfg.sample_rate,
-            'batch_size': self._cfg.get('batch_size'),
+            'batch_size': self._get_batch_size(),
             'vad_stream': True,
             'labels': [
                 'infer',
@@ -176,7 +197,7 @@ class ClusteringDiarizer(torch.nn.Module, Model, DiarizationMixin):
         spk_dl_config = {
             'manifest_filepath': manifest_file,
             'sample_rate': self._cfg.sample_rate,
-            'batch_size': self._cfg.get('batch_size'),
+            'batch_size': self._get_batch_size(),
             'trim_silence': False,
             'labels': None,
             'num_workers': self._cfg.num_workers,

--- a/tests/collections/speaker_tasks/test_clustering_diarizer_batch_size.py
+++ b/tests/collections/speaker_tasks/test_clustering_diarizer_batch_size.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for the ClusteringDiarizer batch_size=None defect.
+
+Reproduces the bug reported as ``TypeError: iteration over a 0-d tensor`` in
+``audio_to_label._fixed_seq_collate_fn``. The underlying cause is that a missing
+top-level ``batch_size`` in the diarizer config was forwarded to
+``torch.utils.data.DataLoader`` as ``None``, which disables automatic batching and
+feeds un-batched 0-d tensor samples to the collate function.
+"""
+
+import pytest
+import torch
+from omegaconf import OmegaConf
+
+from nemo.collections.asr.data.audio_to_label import _fixed_seq_collate_fn
+from nemo.collections.asr.models.clustering_diarizer import ClusteringDiarizer
+
+
+def _single_unbatched_sample():
+    """Mimic AudioToSpeechLabelDataset.__getitem__: (feat, feat_len, label, label_len).
+
+    ``feat_len``, ``label`` and ``label_len`` are 0-d scalar tensors, exactly the shape
+    that triggered ``TypeError: iteration over a 0-d tensor`` under ``batch_size=None``.
+    """
+    feat = torch.randn(16000)
+    feat_len = torch.tensor(16000).long()
+    label = torch.tensor(0).long()
+    label_len = torch.tensor(1).long()
+    return feat, feat_len, label, label_len
+
+
+@pytest.mark.unit
+def test_zero_d_tensor_reproduces_original_bug():
+    """A raw un-batched 4-tuple must raise the exact reported TypeError."""
+    sample = _single_unbatched_sample()
+    with pytest.raises(TypeError):
+        # zip(*sample) iterates the 0-d feat_len tensor.
+        _fixed_seq_collate_fn(self=None, batch=sample)
+
+
+@pytest.mark.unit
+def test_batched_input_collates_without_error():
+    """A proper list-of-samples batch collates fine (sanity check the fix target)."""
+    batch = [_single_unbatched_sample() for _ in range(3)]
+    audio_signal, audio_lengths, tokens, tokens_lengths = _fixed_seq_collate_fn(self=None, batch=batch)
+    assert audio_signal.shape[0] == 3
+    assert audio_lengths.shape[0] == 3
+    assert tokens.shape[0] == 3
+    assert tokens_lengths.shape[0] == 3
+
+
+@pytest.mark.unit
+def test_get_batch_size_coalesces_none_to_positive_default():
+    """When the config has no top-level batch_size, a positive int default is used."""
+    diarizer = ClusteringDiarizer.__new__(ClusteringDiarizer)
+    diarizer._cfg = OmegaConf.create({'sample_rate': 16000})  # no batch_size key
+
+    resolved = diarizer._get_batch_size()
+
+    assert resolved is not None
+    assert isinstance(resolved, int)
+    assert resolved > 0
+
+
+@pytest.mark.unit
+def test_get_batch_size_respects_explicit_value():
+    """An explicit top-level batch_size is preserved unchanged."""
+    diarizer = ClusteringDiarizer.__new__(ClusteringDiarizer)
+    diarizer._cfg = OmegaConf.create({'sample_rate': 16000, 'batch_size': 7})
+
+    assert diarizer._get_batch_size() == 7


### PR DESCRIPTION
# What does this PR do ?

Fixes the `TypeError: iteration over a 0-d tensor` crash during speaker-embedding extraction when the diarizer config has no top-level `batch_size`. Fixes #15566.

**Collection**: ASR (speaker diarization)

# Changelog

- `ClusteringDiarizer`: resolve the dataloader batch size once via a `_get_batch_size()` helper that coalesces a missing/`None` top-level `batch_size` to a positive default, and use it at both read points (`_setup_vad_test_data`, `_setup_spkr_test_data`).
- Add a regression test covering the reporter's config shape (`batch_size` present only under `diarizer.*`).

# Details

The reporter's config carries `batch_size` under `diarizer.*`, but `_setup_spkr_test_data` reads the top-level key, gets `None`, and forwards it verbatim. `DataLoader(batch_size=None)` disables PyTorch automatic batching, so `_fixed_seq_collate_fn` receives one bare sample instead of a list and `zip(*batch)` iterates a 0-d length tensor. The VAD stage was unaffected only because it hardcodes its batch size, which is why the pipeline died halfway. The issue reports this as macOS-specific; it reproduces identically on Linux x86_64, it is config-dependent.

Behaviour on the issue's recipe, before and after:

| Scenario | main | this PR |
|---|---|---|
| reporter's config (`batch_size` under `diarizer.*` only) | TypeError, pipeline dies | completes |
| explicit top-level `batch_size` | completes | completes, unchanged |
| VAD stage | completes | completes, unchanged |

The fix was found by Artemis Discovery (TurinTech) working from this issue's text: it isolated the `None`-propagation and produced this change autonomously (6 of 8 candidates converged on coalescing the config read). I reviewed every line and verified the issue recipe end to end; the diarization run completes after the fix.

@tango4j this has been assigned to you for a while, so happy to defer if you have a fix in flight, or to adjust this one to review.
