### PR TITLE
Derive word-confidence boundaries from the decoded text itself

### DIFF
--- a/nemo/collections/asr/parts/submodules/rnnt_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_decoding.py
@@ -1752,8 +1752,13 @@ class RNNTBPEDecoding(AbstractRNNTDecoding):
         Returns:
             A list of word-level confidence scores.
         """
+        # ``words`` comes from ``hypothesis.text``, which strips the space before punctuation, so
+        # the boundary oracle has to apply the same transform or a token lands on the wrong word.
         return self._aggregate_token_confidence_subwords_sentencepiece(
-            hypothesis.words, hypothesis.token_confidence, hypothesis.y_sequence
+            hypothesis.words,
+            hypothesis.token_confidence,
+            hypothesis.y_sequence,
+            self.decode_tokens_to_str_with_strip_punctuation,
         )
 
     def decode_tokens_to_str(self, tokens: List[str]) -> str:

--- a/nemo/collections/asr/parts/utils/asr_confidence_utils.py
+++ b/nemo/collections/asr/parts/utils/asr_confidence_utils.py
@@ -448,24 +448,93 @@ class ConfidenceMixin(ABC):
         word_confidence = []
         # run only if there are final words
         if len(words) > 0:
-            j = 0
+            # Bucket each token's confidence into the word it belongs to, using the decode-and-split
+            # operation itself as the boundary oracle so the produced count matches
+            # ``len(words) == tokenizer.ids_to_text(...).split()`` by construction.
+            #
+            # Motivation: ``words`` is ``self.text.split()`` where ``text`` is the *full*
+            # SentencePiece decode of the token ids. ``str.split()`` breaks on ANY Unicode
+            # whitespace, which includes characters produced only by byte-fallback decoding
+            # (e.g. non-breaking space U+00A0, thin space U+2009 — very common in German text such
+            # as ``z. B.`` or grouped numbers) that carry no ``▁`` word-boundary marker. Heuristics
+            # that reconstruct words from individual token pieces (the previous
+            # ``token != token_text`` proxy, or a ``▁``-prefix check) cannot see those boundaries and
+            # drift from ``text.split()``, which is what triggered the
+            # ``len(words) != len(word_confidence)`` RuntimeError on some transcripts.
+            #
+            # Instead we walk the tokens left to right and track how many whitespace-delimited words
+            # the decoded prefix contains. ``decode_ids_to_str`` routes through the same tokenizer
+            # path that built ``text`` (``tokenizer.ids_to_text``), so ``prev_count`` below is exactly
+            # the running word count of ``text``. A token opens a new word whenever the decoded
+            # prefix gains a word; otherwise it continues the current word. Byte-fallback bytes that
+            # only complete into a character (or whitespace) once the next byte arrives are handled
+            # naturally, because the word count only advances once the decoded text actually gains a
+            # whitespace-delimited token.
+            num_words = len(words)
+            int_token_ids = [int(t) for t in token_ids]
+
+            # Fast path (O(n), a single ``decode_ids_to_tokens`` call): group tokens using the
+            # canonical SentencePiece word-start marker ``▁`` (U+2581). A token starts a new word iff
+            # its piece begins with ``▁`` (or is / follows ``<unk>``, which ``ids_to_text`` renders as
+            # its own whitespace-delimited token). Pure ``▁`` separator groups are dropped. This
+            # reproduces ``text.split()`` for the overwhelming majority of transcripts.
+            underline = '\u2581'  # '▁'
+            pieces = self.decode_ids_to_tokens(int_token_ids)
+            fast_groups: List[List[int]] = []
             prev_unk = False
-            prev_underline = False
-            for i, token_id in enumerate(token_ids):
-                token = self.decode_ids_to_tokens([int(token_id)])[0]
-                token_text = self.decode_ids_to_str([int(token_id)])
-                # treat `<unk>` as a separate word regardless of the next token
-                # to match the result of `tokenizer.ids_to_text`
-                if (token != token_text or prev_unk) and i > j:
-                    # do not add confidence for `▁` if the current token starts with `▁`
-                    # to match the result of `tokenizer.ids_to_text`
-                    if not prev_underline:
-                        word_confidence.append(self._aggregate_confidence(token_confidence[j:i]))
-                    j = i
-                prev_unk = token == '<unk>'
-                prev_underline = token == '▁'
-            if not prev_underline:
-                word_confidence.append(self._aggregate_confidence(token_confidence[j : len(token_ids)]))
+            for i, piece in enumerate(pieces):
+                is_unk = piece == '<unk>'
+                starts_word = piece.startswith(underline) or is_unk or prev_unk
+                if not fast_groups or starts_word:
+                    fast_groups.append([i, i + 1])
+                else:
+                    fast_groups[-1][1] = i + 1
+                prev_unk = is_unk
+            fast_groups = [
+                g for g in fast_groups if not all(pieces[k] == underline for k in range(g[0], g[1]))
+            ]
+
+            if len(fast_groups) == num_words:
+                # Fast path already agrees with ``text.split()`` — no per-token re-decode needed.
+                groups: List[List[int]] = fast_groups
+            else:
+                # Slow, exact path: use the decode-and-split operation itself as the boundary oracle.
+                # This handles byte-fallback whitespace characters (non-breaking space U+00A0, thin
+                # space U+2009 — common in German such as ``z. B.`` or grouped numbers) that carry no
+                # ``▁`` marker and are therefore invisible to the fast path, yet split ``text`` into
+                # extra words. ``decode_ids_to_str`` routes through the same tokenizer path that built
+                # ``text``, so this reproduces ``text.split()`` exactly, by construction.
+                groups = []
+                prev_count = 0
+                for i in range(len(int_token_ids)):
+                    cur_count = len(self.decode_ids_to_str(int_token_ids[: i + 1]).split())
+                    # Clamp so re-segmentation across the truncation boundary can never let the
+                    # running count exceed the final word count.
+                    if cur_count > num_words:
+                        cur_count = num_words
+
+                    if cur_count > prev_count:
+                        while len(groups) < cur_count - 1:
+                            groups.append([i, i + 1])
+                        groups.append([i, i + 1])
+                        prev_count = cur_count
+                    elif groups:
+                        groups[-1][1] = i + 1
+                    # else: leading separator / empty-decode tokens — absorbed once the first word opens.
+
+                # Reconcile in case the running oracle lagged (e.g. a trailing word produced only when
+                # the final token completed a whitespace character).
+                while len(groups) < num_words:
+                    if groups:
+                        groups.append(list(groups[-1]))
+                    else:
+                        groups.append([0, len(int_token_ids)])
+                groups = groups[:num_words]
+
+            for start, end in groups:
+                # Guard against an empty range (possible for a back-filled bucket).
+                lo, hi = (start, end) if end > start else (start, start + 1)
+                word_confidence.append(self._aggregate_confidence(token_confidence[lo:hi]))
         if len(words) != len(word_confidence):
             raise RuntimeError(
                 f"""Something went wrong with word-level confidence aggregation.\n

--- a/nemo/collections/asr/parts/utils/asr_confidence_utils.py
+++ b/nemo/collections/asr/parts/utils/asr_confidence_utils.py
@@ -16,7 +16,7 @@ import math
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from functools import partial
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 import torch
 from omegaconf import DictConfig, OmegaConf
@@ -431,7 +431,11 @@ class ConfidenceMixin(ABC):
         return word_confidence
 
     def _aggregate_token_confidence_subwords_sentencepiece(
-        self, words: List[str], token_confidence: List[float], token_ids: List[int]
+        self,
+        words: List[str],
+        token_confidence: List[float],
+        token_ids: List[int],
+        decode_prefix: Optional[Callable[[List[int]], str]] = None,
     ) -> List[float]:
         """Implementation of token confidence aggregation for subword-based models.
 
@@ -441,6 +445,9 @@ class ConfidenceMixin(ABC):
             words: List of words of a hypothesis.
             token_confidence: List of token-level confidence scores of a hypothesis.
             token_ids: List of token ids of a hypothesis.
+            decode_prefix: Ids-to-text call used to locate word boundaries. Must be the one that
+                produced ``words``, or a token can be attributed to the wrong word. Defaults to
+                ``decode_ids_to_str``.
 
         Returns:
             A list of word-level confidence scores.
@@ -448,36 +455,12 @@ class ConfidenceMixin(ABC):
         word_confidence = []
         # run only if there are final words
         if len(words) > 0:
-            # Bucket each token's confidence into the word it belongs to, using the decode-and-split
-            # operation itself as the boundary oracle so the produced count matches
-            # ``len(words) == tokenizer.ids_to_text(...).split()`` by construction.
-            #
-            # Motivation: ``words`` is ``self.text.split()`` where ``text`` is the *full*
-            # SentencePiece decode of the token ids. ``str.split()`` breaks on ANY Unicode
-            # whitespace, which includes characters produced only by byte-fallback decoding
-            # (e.g. non-breaking space U+00A0, thin space U+2009 — very common in German text such
-            # as ``z. B.`` or grouped numbers) that carry no ``▁`` word-boundary marker. Heuristics
-            # that reconstruct words from individual token pieces (the previous
-            # ``token != token_text`` proxy, or a ``▁``-prefix check) cannot see those boundaries and
-            # drift from ``text.split()``, which is what triggered the
-            # ``len(words) != len(word_confidence)`` RuntimeError on some transcripts.
-            #
-            # Instead we walk the tokens left to right and track how many whitespace-delimited words
-            # the decoded prefix contains. ``decode_ids_to_str`` routes through the same tokenizer
-            # path that built ``text`` (``tokenizer.ids_to_text``), so ``prev_count`` below is exactly
-            # the running word count of ``text``. A token opens a new word whenever the decoded
-            # prefix gains a word; otherwise it continues the current word. Byte-fallback bytes that
-            # only complete into a character (or whitespace) once the next byte arrives are handled
-            # naturally, because the word count only advances once the decoded text actually gains a
-            # whitespace-delimited token.
+            decode = decode_prefix if decode_prefix is not None else self.decode_ids_to_str
             num_words = len(words)
             int_token_ids = [int(t) for t in token_ids]
 
-            # Fast path (O(n), a single ``decode_ids_to_tokens`` call): group tokens using the
-            # canonical SentencePiece word-start marker ``▁`` (U+2581). A token starts a new word iff
-            # its piece begins with ``▁`` (or is / follows ``<unk>``, which ``ids_to_text`` renders as
-            # its own whitespace-delimited token). Pure ``▁`` separator groups are dropped. This
-            # reproduces ``text.split()`` for the overwhelming majority of transcripts.
+            # Fast path: group on the SentencePiece word-start marker, and trust it only if the
+            # group count matches the decoded text's own word count.
             underline = '\u2581'  # '▁'
             pieces = self.decode_ids_to_tokens(int_token_ids)
             fast_groups: List[List[int]] = []
@@ -490,29 +473,18 @@ class ConfidenceMixin(ABC):
                 else:
                     fast_groups[-1][1] = i + 1
                 prev_unk = is_unk
-            fast_groups = [
-                g for g in fast_groups if not all(pieces[k] == underline for k in range(g[0], g[1]))
-            ]
+            fast_groups = [g for g in fast_groups if not all(pieces[k] == underline for k in range(g[0], g[1]))]
 
             if len(fast_groups) == num_words:
-                # Fast path already agrees with ``text.split()`` — no per-token re-decode needed.
                 groups: List[List[int]] = fast_groups
             else:
-                # Slow, exact path: use the decode-and-split operation itself as the boundary oracle.
-                # This handles byte-fallback whitespace characters (non-breaking space U+00A0, thin
-                # space U+2009 — common in German such as ``z. B.`` or grouped numbers) that carry no
-                # ``▁`` marker and are therefore invisible to the fast path, yet split ``text`` into
-                # extra words. ``decode_ids_to_str`` routes through the same tokenizer path that built
-                # ``text``, so this reproduces ``text.split()`` exactly, by construction.
+                # Exact path: a token opens a word whenever the decoded prefix gains one. Byte-fallback
+                # whitespace and punctuation the decode re-spaces carry no marker in the pieces, so only
+                # the decode itself knows where the boundaries are.
                 groups = []
                 prev_count = 0
                 for i in range(len(int_token_ids)):
-                    cur_count = len(self.decode_ids_to_str(int_token_ids[: i + 1]).split())
-                    # Clamp so re-segmentation across the truncation boundary can never let the
-                    # running count exceed the final word count.
-                    if cur_count > num_words:
-                        cur_count = num_words
-
+                    cur_count = min(len(decode(int_token_ids[: i + 1]).split()), num_words)
                     if cur_count > prev_count:
                         while len(groups) < cur_count - 1:
                             groups.append([i, i + 1])
@@ -520,15 +492,9 @@ class ConfidenceMixin(ABC):
                         prev_count = cur_count
                     elif groups:
                         groups[-1][1] = i + 1
-                    # else: leading separator / empty-decode tokens — absorbed once the first word opens.
 
-                # Reconcile in case the running oracle lagged (e.g. a trailing word produced only when
-                # the final token completed a whitespace character).
                 while len(groups) < num_words:
-                    if groups:
-                        groups.append(list(groups[-1]))
-                    else:
-                        groups.append([0, len(int_token_ids)])
+                    groups.append(list(groups[-1]) if groups else [0, len(int_token_ids)])
                 groups = groups[:num_words]
 
             for start, end in groups:

--- a/tests/collections/asr/confidence/test_word_confidence_aggregation.py
+++ b/tests/collections/asr/confidence/test_word_confidence_aggregation.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for subword word-confidence aggregation.
+
+The aggregation must produce exactly one confidence per whitespace-delimited word of the decoded
+text (``len(word_confidence) == len(words)`` where ``words = text.split()``), including for
+vocabularies that emit word-initial punctuation pieces, ``<unk>``, and byte-fallback whitespace
+characters that carry no SentencePiece word-boundary marker.
+"""
+
+import pytest
+
+from nemo.collections.asr.parts.utils.asr_confidence_utils import ConfidenceMixin
+
+UNDERLINE = '▁'  # SentencePiece word-boundary marker
+
+
+class _FakeAgg:
+    """Minimal stand-in exposing the surface ``_aggregate_token_confidence_subwords_sentencepiece``
+    uses: a vocabulary of ``token_id -> (piece, token_text)`` where ``piece`` is the SentencePiece
+    piece (as ``decode_ids_to_tokens`` returns it) and ``token_text`` is that token's contribution
+    to the decoded text (empty for partial byte-fallback bytes)."""
+
+    _aggregate_token_confidence_subwords_sentencepiece = (
+        ConfidenceMixin._aggregate_token_confidence_subwords_sentencepiece
+    )
+
+    def __init__(self, vocab):
+        self._vocab = vocab
+
+    def decode_ids_to_tokens(self, ids):
+        return [self._vocab[int(i)][0] for i in ids]
+
+    def decode_ids_to_str(self, ids):
+        text = ''.join(self._vocab[int(i)][1] for i in ids)
+        return text.replace(UNDERLINE, ' ').strip()
+
+    def _aggregate_confidence(self, confidences):
+        return sum(confidences) / max(len(confidences), 1)
+
+
+def _run(vocab, ids, confidences=None):
+    agg = _FakeAgg(vocab)
+    text = agg.decode_ids_to_str(ids)
+    words = text.split()
+    wc = agg._aggregate_token_confidence_subwords_sentencepiece(
+        words, confidences or [1.0] * len(ids), ids
+    )
+    return words, wc
+
+
+@pytest.mark.unit
+def test_plain_words_one_confidence_each():
+    vocab = {
+        1: (f"{UNDERLINE}Hallo", f"{UNDERLINE}Hallo"),
+        2: (f"{UNDERLINE}Welt", f"{UNDERLINE}Welt"),
+    }
+    words, wc = _run(vocab, [1, 2])
+    assert words == ["Hallo", "Welt"]
+    assert len(wc) == len(words)
+
+
+@pytest.mark.unit
+def test_word_initial_punctuation_piece():
+    # ▁CDU ▁- ▁CSU: a word-initial punctuation piece must not desynchronize the count
+    # from the decoded text's whitespace-delimited words.
+    vocab = {
+        1: (f"{UNDERLINE}CDU", f"{UNDERLINE}CDU"),
+        2: (f"{UNDERLINE}-", f"{UNDERLINE}-"),
+        3: (f"{UNDERLINE}CSU", f"{UNDERLINE}CSU"),
+    }
+    words, wc = _run(vocab, [1, 2, 3])
+    assert len(wc) == len(words)
+
+
+@pytest.mark.unit
+def test_standalone_separator_piece_is_not_a_word():
+    # A pure ▁ separator piece contributes whitespace only and must not open an extra word.
+    vocab = {
+        1: (f"{UNDERLINE}Hallo", f"{UNDERLINE}Hallo"),
+        2: (UNDERLINE, UNDERLINE),
+        3: (",", ","),
+        4: (f"{UNDERLINE}Welt", f"{UNDERLINE}Welt"),
+    }
+    words, wc = _run(vocab, [1, 2, 3, 4])
+    assert len(wc) == len(words)
+
+
+@pytest.mark.unit
+def test_unk_adjacency():
+    # <unk> renders as its own whitespace-delimited token in the decoded text.
+    vocab = {
+        1: (f"{UNDERLINE}Hallo", f"{UNDERLINE}Hallo"),
+        2: ("<unk>", f"{UNDERLINE}<unk>"),
+        3: (f"{UNDERLINE}Welt", f"{UNDERLINE}Welt"),
+    }
+    words, wc = _run(vocab, [1, 2, 3])
+    assert len(wc) == len(words)
+
+
+@pytest.mark.unit
+def test_punctuation_attaches_to_word():
+    # ▁Hallo , ▁Welt -> "Hallo, Welt" (comma has no ▁, must stay with previous word)
+    vocab = {
+        1: (f"{UNDERLINE}Hallo", f"{UNDERLINE}Hallo"),
+        2: (",", ","),
+        3: (f"{UNDERLINE}Welt", f"{UNDERLINE}Welt"),
+    }
+    words, wc = _run(vocab, [1, 2, 3])
+    assert words == ["Hallo,", "Welt"]
+    assert len(wc) == len(words)
+
+
+class _CountingAgg(_FakeAgg):
+    """Fake aggregator that counts how often the expensive decode+split oracle is invoked."""
+
+    def __init__(self, vocab):
+        super().__init__(vocab)
+        self.oracle_calls = 0
+
+    def decode_ids_to_str(self, ids):
+        # The exact oracle re-decodes growing prefixes; every such call is what we want to avoid on
+        # the common (fast) path. Count only the multi-token prefix decodes that the oracle makes.
+        if len(ids) > 1:
+            self.oracle_calls += 1
+        return super().decode_ids_to_str(ids)
+
+
+@pytest.mark.unit
+def test_large_plain_sequence_uses_fast_path_only():
+    # Thousands of plain ▁-words (a realistic ~10-min chunk) must be handled by the O(n) fast path
+    # WITHOUT ever falling back to the O(n^2) decode+split oracle.
+    n = 800
+    vocab = {i: (f"{UNDERLINE}w{i}", f"{UNDERLINE}w{i}") for i in range(1, n + 1)}
+    ids = list(range(1, n + 1))
+
+    agg = _CountingAgg(vocab)
+    text = agg.decode_ids_to_str(ids)
+    words = text.split()
+    assert len(words) == n
+    agg.oracle_calls = 0  # reset: ignore the setup decode above
+
+    wc = agg._aggregate_token_confidence_subwords_sentencepiece(words, [1.0] * n, ids)
+    assert len(wc) == len(words)
+    # The fast path must have carried the whole sequence: no per-prefix oracle re-decodes.
+    assert agg.oracle_calls == 0
+
+
+@pytest.mark.unit
+def test_large_sequence_with_byte_fallback_whitespace_oracle_scales():
+    # A large sequence that DOES contain a byte-fallback-whitespace word forces the oracle path;
+    # the count invariant must still hold at scale.
+    vocab = {}
+    ids = []
+    tid = 1
+    for i in range(200):
+        vocab[tid] = (f"{UNDERLINE}w{i}", f"{UNDERLINE}w{i}")
+        ids.append(tid)
+        tid += 1
+    # Insert a NBSP-joined "z. B." in the middle (byte-fallback whitespace, no ▁ marker).
+    vocab[tid] = (f"{UNDERLINE}z.", f"{UNDERLINE}z.")
+    ids.append(tid)
+    tid += 1
+    vocab[tid] = ("<0xC2>", "")
+    ids.append(tid)
+    tid += 1
+    vocab[tid] = ("<0xA0>", " ")
+    ids.append(tid)
+    tid += 1
+    vocab[tid] = ("B.", "B.")
+    ids.append(tid)
+    tid += 1
+    for i in range(200, 400):
+        vocab[tid] = (f"{UNDERLINE}w{i}", f"{UNDERLINE}w{i}")
+        ids.append(tid)
+        tid += 1
+
+    words, wc = _run(vocab, ids)
+    assert len(wc) == len(words)

--- a/tests/collections/asr/confidence/test_word_confidence_aggregation.py
+++ b/tests/collections/asr/confidence/test_word_confidence_aggregation.py
@@ -20,6 +20,8 @@ vocabularies that emit word-initial punctuation pieces, ``<unk>``, and byte-fall
 characters that carry no SentencePiece word-boundary marker.
 """
 
+import re
+
 import pytest
 
 from nemo.collections.asr.parts.utils.asr_confidence_utils import ConfidenceMixin
@@ -121,6 +123,47 @@ def test_punctuation_attaches_to_word():
     words, wc = _run(vocab, [1, 2, 3])
     assert words == ["Hallo,", "Welt"]
     assert len(wc) == len(words)
+
+
+class _StripPunctAgg(_FakeAgg):
+    """Stand-in for the RNNT path, where ``hypothesis.text`` removes the space before punctuation,
+    so ``words`` and the raw decode disagree on where the words are."""
+
+    def decode_with_strip_punctuation(self, ids):
+        return re.sub(r' +([\-,.!?;:])', r'\1', self.decode_ids_to_str(ids))
+
+
+@pytest.mark.unit
+def test_stripped_punctuation_attributes_confidence_to_the_right_word():
+    # ▁CDU ▁- ▁CSU decodes raw as "CDU - CSU" (3 words) but the hypothesis text is "CDU- CSU"
+    # (2 words). The dash belongs to the first word, so its confidence must land there.
+    vocab = {
+        1: (f"{UNDERLINE}CDU", f"{UNDERLINE}CDU"),
+        2: (f"{UNDERLINE}-", f"{UNDERLINE}-"),
+        3: (f"{UNDERLINE}CSU", f"{UNDERLINE}CSU"),
+    }
+    agg = _StripPunctAgg(vocab)
+    ids = [1, 2, 3]
+    words = agg.decode_with_strip_punctuation(ids).split()
+    assert words == ["CDU-", "CSU"]
+
+    wc = agg._aggregate_token_confidence_subwords_sentencepiece(
+        words, [0.9, 0.1, 0.8], ids, agg.decode_with_strip_punctuation
+    )
+    assert wc == pytest.approx([0.5, 0.8])
+
+
+@pytest.mark.unit
+def test_default_oracle_still_follows_the_raw_decode():
+    # Callers whose text is the plain decode must keep the raw boundaries: three words here.
+    vocab = {
+        1: (f"{UNDERLINE}CDU", f"{UNDERLINE}CDU"),
+        2: (f"{UNDERLINE}-", f"{UNDERLINE}-"),
+        3: (f"{UNDERLINE}CSU", f"{UNDERLINE}CSU"),
+    }
+    words, wc = _run(vocab, [1, 2, 3], [0.9, 0.1, 0.8])
+    assert words == ["CDU", "-", "CSU"]
+    assert wc == pytest.approx([0.9, 0.1, 0.8])
 
 
 class _CountingAgg(_FakeAgg):


### PR DESCRIPTION
# What does this PR do ?

Fixes the `RuntimeError: Something went wrong with word-level confidence aggregation` (`len(words) != len(word_confidence)`) crash in subword confidence aggregation with parakeet-tdt-0.6b-v3. Fixes #15143.

**Collection**: ASR

# Changelog

- `ConfidenceMixin._aggregate_token_confidence_subwords_sentencepiece`: group tokens into words using the decode-and-split operation itself as the boundary oracle, so the group count matches `words = text.split()` by construction; an O(n) fast path handles the common case with a single `decode_ids_to_tokens` call and the oracle only runs when the fast path disagrees.
- Add tests covering word-initial punctuation pieces, byte-fallback whitespace, `<unk>` adjacency, and count invariants at scale.

# Details

`words` comes from splitting the fully decoded text, but word confidence was aggregated by re-deriving boundaries with a per-piece heuristic (a piece starting with `▁` opens a word). The v3 multilingual vocabulary breaks that assumption two ways: punctuation-initial pieces (`▁-`, `▁¿`, standalone `▁`) where the decoded text has its space stripped, and byte-fallback whitespace (U+00A0, U+2009, common in German like `z. B.`) that splits the text without any `▁` marker. Each occurrence puts the heuristic one word out of step with `text.split()`, which is exactly the off-by-small mismatches in the report (1202 vs 1201). The prior fixes in #15128 and #15249 addressed a benchmarking helper and two other mismatch sources respectively; the boundary heuristic itself was untouched, which is why the reporter still hits this on 2.7.0.

Consistency of `len(words) == len(word_confidence)` on the v3 tokenizer, before and after:

| Text case | main | this PR |
|---|---|---|
| unpunctuated controls (2) | consistent | consistent |
| "Für die CDU-CSU-Fraktion..." (reporter's fragment, unspaced) | consistent | consistent |
| comma text | consistent | consistent |
| "Für die CDU - CSU" (spaced dash) | RuntimeError | consistent |
| spaced dashes mid-sentence | RuntimeError | consistent |
| "Hola¿Qué tal?" (inverted marks) | RuntimeError | consistent |

The fix was found by Artemis Discovery (TurinTech) working from this issue's text, scored on exactly that consistency check (57 on main, 100 with this change). I reviewed every line, and the byte-fallback-whitespace failure family in the code comment was its finding, not mine.

One known approximation worth stating: when the oracle path reconciles a count difference caused by punctuation-space stripping, the confidence bucket boundaries can shift by one token around the stripped punctuation (counts are exact; the per-word attribution near such punctuation is approximate). Happy to tighten that in a follow-up if wanted.
