### PR TITLE
Preserve Nemotron-H Mamba cache precision in SpeechLM vLLM

### DIFF
--- a/nemo/collections/speechlm2/vllm/salm/__init__.py
+++ b/nemo/collections/speechlm2/vllm/salm/__init__.py
@@ -44,3 +44,9 @@ def register():
         "NeMoSpeechLMForConditionalGeneration",
         f"{_PKG}.model:NeMoSpeechLMForConditionalGeneration",
     )
+
+    from vllm.model_executor.models.config import MODELS_CONFIG_MAP
+
+    from nemo.collections.speechlm2.vllm.salm.config_hook import NeMoSpeechLMForConditionalGenerationConfig
+
+    MODELS_CONFIG_MAP["NeMoSpeechLMForConditionalGeneration"] = NeMoSpeechLMForConditionalGenerationConfig

--- a/nemo/collections/speechlm2/vllm/salm/config_hook.py
+++ b/nemo/collections/speechlm2/vllm/salm/config_hook.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""vLLM model-config updates for the composed SpeechLM architecture."""
+
+from vllm.model_executor.models.config import NemotronHForCausalLMConfig, VerifyAndUpdateConfig
+
+
+class NeMoSpeechLMForConditionalGenerationConfig(VerifyAndUpdateConfig):
+    """Delegate hybrid-backbone cache defaults through the Speech wrapper."""
+
+    @classmethod
+    def verify_and_update_config(cls, vllm_config) -> None:
+        hf_config = vllm_config.model_config.hf_config
+        if not getattr(hf_config, "is_hybrid", False):
+            return
+
+        NemotronHForCausalLMConfig.update_mamba_ssm_cache_dtype(
+            cache_config=vllm_config.cache_config,
+            hf_config=hf_config.text_config,
+        )

--- a/tests/collections/speechlm2/test_vllm_plugin.py
+++ b/tests/collections/speechlm2/test_vllm_plugin.py
@@ -677,6 +677,50 @@ class TestPluginRegistration:
         assert "NeMoSpeechLMForConditionalGeneration" in ModelRegistry.get_supported_archs()
         assert NeMoSpeechLMForConditionalGeneration is not None
 
+    def test_register_model_config_hook(self, monkeypatch):
+        """The outer Speech architecture must delegate Nemotron-H cache defaults."""
+        from transformers import AutoConfig
+        from vllm.model_executor.models.config import MODELS_CONFIG_MAP
+
+        from nemo.collections.speechlm2.vllm.salm import register
+        from nemo.collections.speechlm2.vllm.salm.config_hook import NeMoSpeechLMForConditionalGenerationConfig
+
+        monkeypatch.setattr(
+            AutoConfig,
+            "from_pretrained",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError()),
+        )
+
+        register()
+
+        assert MODELS_CONFIG_MAP["NeMoSpeechLMForConditionalGeneration"] is NeMoSpeechLMForConditionalGenerationConfig
+
+    @pytest.mark.parametrize(
+        ("is_hybrid", "backbone_dtype", "initial_dtype", "expected_dtype"),
+        [
+            (True, None, "auto", "float32"),
+            (True, "float16", "auto", "float16"),
+            (True, "float32", "float16", "float16"),
+            (False, None, "auto", "auto"),
+        ],
+    )
+    def test_model_config_hook_sets_only_hybrid_auto_cache_dtype(
+        self, is_hybrid, backbone_dtype, initial_dtype, expected_dtype
+    ):
+        from nemo.collections.speechlm2.vllm.salm.config_hook import NeMoSpeechLMForConditionalGenerationConfig
+
+        text_config = SimpleNamespace()
+        if backbone_dtype is not None:
+            text_config.mamba_ssm_cache_dtype = backbone_dtype
+        vllm_config = SimpleNamespace(
+            cache_config=SimpleNamespace(mamba_ssm_cache_dtype=initial_dtype),
+            model_config=SimpleNamespace(hf_config=SimpleNamespace(is_hybrid=is_hybrid, text_config=text_config)),
+        )
+
+        NeMoSpeechLMForConditionalGenerationConfig.verify_and_update_config(vllm_config)
+
+        assert vllm_config.cache_config.mamba_ssm_cache_dtype == expected_dtype
+
     def test_register_does_not_patch_fast_tokenizer(self, monkeypatch):
         from transformers import AutoConfig, PreTrainedTokenizerFast
 


### PR DESCRIPTION
## Summary

- register a vLLM model-config verifier for `NeMoSpeechLMForConditionalGeneration`
- delegate hybrid SpeechLM cache defaults to vLLM's built-in Nemotron-H verifier
- preserve explicit cache-dtype overrides and leave transformer backbones unchanged
- add focused registration and cache-dtype regression tests

## Motivation

Nemotron Transcribe 3.5 uses a Nemotron-H language model behind the outer
`NeMoSpeechLMForConditionalGeneration` multimodal architecture. vLLM selects
model-config verification by that outer architecture name, so its existing
`NemotronHForCausalLMConfig` hook is not reached through the SpeechLM wrapper.

Consequently, an automatic Mamba SSM cache dtype is not resolved from the
wrapped Nemotron-H config. The new SpeechLM hook delegates exactly that update
to vLLM's existing Nemotron-H implementation.

## Scope

This PR contains only the vLLM-specific integration delta required by the
Nemotron Transcribe 3.5 target model. It deliberately excludes MTP, PEE,
decoded-word repetition stopping, and post-processing changes. Nemotron 3.5
prompt-format support is already carried by #16053.

## Impact

Hybrid SpeechLM checkpoints inherit the same Mamba cache precision behavior as
native Nemotron-H models. Non-hybrid SpeechLM checkpoints remain a no-op, and
user-provided cache dtype values are preserved.

## Validation

- `tests/collections/speechlm2/test_vllm_plugin.py`: 59 passed, 1 skipped
- focused new config-hook tests: 5 passed
- isort check passed on all changed files
- Black 24.10 check passed on all changed files
- tested with the project's vLLM 0.23.0 / CUDA 12.9 runtime container

The combined internal integration was also exercised with the Hero5
Transformer-encoder checkpoint in target-only BF16 inference. The full
corrected ASR leaderboard completed 74,842 rows at 660.77x RTFx and 5.98%
macro WER; that combined environment also contained the prompt support from
#16053, while this PR intentionally isolates only the vLLM config hook.

