### PR TITLE
fix(asr): accumulate chunk offsets in raw frames to stop timestamp drift

### DIFF
--- a/nemo/collections/asr/parts/utils/chunking_utils.py
+++ b/nemo/collections/asr/parts/utils/chunking_utils.py
@@ -219,8 +219,12 @@ def join_char_level_timestamps(
     subsamp = subsampling_factor
     stride = window_stride  # sec per raw frame
     for i, h in enumerate(hypotheses):
-        chunk_frame_offset = chunk_offsets[i] // subsamp
-        cumulative_offset += chunk_frame_offset
+        # accumulate in raw frames and divide once below: the 1 s chunk overlap (100 raw frames)
+        # subtracted from every chunk offset is not divisible by the default subsampling factor of
+        # 8, so dividing per chunk would truncate in the same direction on every chunk and the
+        # error would accumulate over long audios
+        cumulative_offset += chunk_offsets[i]
+        chunk_frame_offset = cumulative_offset // subsamp  # global shift of this chunk, in subsampled frames
 
         # 1) figure out how much of the *front* of this chunk we will drop
         for char in h.timestamp['char']:
@@ -234,9 +238,9 @@ def join_char_level_timestamps(
             # adjust offsets: chunk start + global chunk shift − total removed
             upd = dict(char)
             if char['start_offset'] != -1:
-                upd['start_offset'] = char['start_offset'] + cumulative_offset  # place chunk globally
+                upd['start_offset'] = char['start_offset'] + chunk_frame_offset  # place chunk globally
             if char['end_offset'] != -1:
-                upd['end_offset'] = char['end_offset'] + cumulative_offset
+                upd['end_offset'] = char['end_offset'] + chunk_frame_offset
 
             if char_timestamps:
                 if upd['start_offset'] != -1 and upd['start_offset'] < char_timestamps[-1]['end_offset']:

--- a/tests/collections/asr/utils/test_chunking_utils.py
+++ b/tests/collections/asr/utils/test_chunking_utils.py
@@ -70,7 +70,7 @@ def test_join_char_level_timestamps_without_filter():
     )
 
     assert len(out) == 4
-    shift = chunk_offsets[1] // subsampling_factor
+    shift = 4  # (0 + 32) raw frames // 8
 
     assert out[0]["start_offset"] == 0 and out[0]["end_offset"] == 1
     assert out[1]["start_offset"] == 2 and out[1]["end_offset"] == 3
@@ -143,6 +143,46 @@ def test_join_char_level_timestamps_with_filter():
 
     assert [d["start"] for d in out] == pytest.approx(expected_starts)
     assert [d["end"] for d in out] == pytest.approx(expected_ends)
+
+
+@pytest.mark.unit
+def test_join_char_level_timestamps_no_drift_over_many_chunks():
+    # Chunk offsets are raw frames built as `encoded_len * subsampling_factor - 100`, where -100
+    # removes the 1 s chunk overlap. 100 is not divisible by the default subsampling factor of 8,
+    # so dividing each chunk offset before accumulating truncates half a subsampled frame per
+    # chunk, always in the same direction, and the timestamps drift earlier over long audio.
+    subsampling_factor = 8
+    window_stride = 0.01
+    num_chunks = 60  # 60 chunks of ~60 s == 1 hour of audio
+    encoded_len = 750
+    chunk_offsets = [0] + [(encoded_len * subsampling_factor - 100)] * (num_chunks - 1)
+
+    hypotheses = [
+        Hypothesis(
+            score=0.0,
+            y_sequence=torch.tensor([]),
+            timestamp={"char": [_make_char("a", 1, 0, 1)]},
+        )
+        for _ in range(num_chunks)
+    ]
+
+    out = join_char_level_timestamps(
+        hypotheses=hypotheses,
+        chunk_offsets=chunk_offsets,
+        subsampling_factor=subsampling_factor,
+        window_stride=window_stride,
+        merged_tokens=None,
+    )
+
+    assert len(out) == num_chunks
+    # 59 * 5900 == 348100 raw frames; 348100 // 8 == 43512 subsampled frames (exact value 43512.5).
+    # Dividing per chunk instead gives 59 * (5900 // 8) == 43483, i.e. 29 frames == 2.32 s too early.
+    expected_shift = 43512
+    assert out[-1]["start_offset"] == expected_shift
+    assert out[-1]["end_offset"] == 1 + expected_shift
+
+    # 43512 subsampled frames * 0.08 s per subsampled frame
+    assert out[-1]["start"] == pytest.approx(3480.96)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
# What does this PR do ?

Fixes monotonic drift in chunked long-audio timestamps by accumulating chunk offsets in raw frames and dividing by the subsampling factor once, instead of floor-dividing every chunk offset before summing.

**Collection**: ASR

# Changelog

- `nemo/collections/asr/parts/utils/chunking_utils.py`, `join_char_level_timestamps`: accumulate `chunk_offsets[i]` in raw (pre-subsampling) frames and compute the chunk's global shift as `cumulative_offset // subsampling_factor` once per chunk, rather than `cumulative_offset += chunk_offsets[i] // subsampling_factor`. Added a comment explaining why the division cannot be done per chunk (the 1 s overlap of 100 raw frames is not divisible by the default subsampling factor of 8).
- `tests/collections/asr/utils/test_chunking_utils.py`: new `test_join_char_level_timestamps_no_drift_over_many_chunks` regression test — 60 chunks of ~60 s (1 hour of audio) with the offsets `merge_parallel_chunks` actually builds.
- `tests/collections/asr/utils/test_chunking_utils.py`: in `test_join_char_level_timestamps_without_filter`, replaced `shift = chunk_offsets[1] // subsampling_factor` with the literal expected value `4` (`(0 + 32) raw frames // 8`). The old expression mirrored the implementation line being fixed; it happened to be correct here only because the test's offsets (0, 32) are divisible by 8, so it could never have caught this bug. Assertion values are unchanged.

## Root cause

`chunk_offsets` are raw frames, built in `merge_parallel_chunks` (chunking_utils.py:77-80) as `encoded_len * subsampling_factor - 100`, where the `-100` removes the 1 s chunk overlap. With the FastConformer/Canary default `subsampling_factor = 8`, 100 is not divisible by 8, so floor-dividing each chunk offset discarded exactly 0.5 subsampled frames per chunk, always in the same direction. The error accumulated linearly with the number of chunks, moving word- and segment-level timestamps monotonically earlier through a long file.

`FrameBatchMultiTaskAED._join_timestamp` in `streaming_utils.py:2003-2013` already does it the right way, with an inline comment naming this exact hazard ("dividing here to avoid error accumulation over long audios"). This change brings `chunking_utils.py` in line with it.

The bug only appears when `subsampling_factor` does not divide 100 — the default 8. With `subsampling_factor = 4` the division is exact, which is likely why it went unnoticed. See the algebra below for exactly when old and new behaviour coincide.

## Before / after

Reproduction from #16072 — 60 chunks of ~60 s, `encoded_len = 750`, `subsampling_factor = 8`, `window_stride = 0.01`:

| | last char `start_offset` (subsampled frames) | time |
| --- | --- | --- |
| before | 43483 | 3478.64 s |
| after | 43512 | 3480.96 s |
| exact (`sum(chunk_offsets) / 8`) | 43512.5 | 3481.00 s |

Drift removed: 29 subsampled frames = **2.32 s** on a one-hour file, previously growing without bound with duration.

(#16072 quotes the total error against the exact value, 29.5 frames = 2.36 s. Of that, 29 frames = 2.32 s is the accumulating part this PR removes. The remaining 0.5 frame = 40 ms is the single unavoidable floor division at the end — bounded by one subsampled frame, 80 ms, regardless of audio length, since `start_offset` is an integer frame index.)

# Usage

```python
import torch

from nemo.collections.asr.parts.utils.chunking_utils import join_char_level_timestamps
from nemo.collections.asr.parts.utils.rnnt_utils import Hypothesis

SUB, STRIDE, NCHUNK, ENC_LEN = 8, 0.01, 60, 750  # 60 chunks of ~60 s == 1 hour of audio
chunk_offsets = [0] + [(ENC_LEN * SUB - 100)] * (NCHUNK - 1)  # cf. merge_parallel_chunks

hyps = [
    Hypothesis(
        score=0.0,
        y_sequence=torch.tensor([1]),
        timestamp={"char": [{"token_id": 1, "start_offset": 0, "end_offset": 1, "char": "a"}]},
    )
    for _ in range(NCHUNK)
]

out = join_char_level_timestamps(hyps, chunk_offsets, SUB, STRIDE, merged_tokens=None)
print(out[-1]["start_offset"])  # 43483 before, 43512 after; exact value is 43512.5
```

# Blast radius

`cumulative_offset` and the new `chunk_frame_offset` appear on exactly five lines — init, accumulate, derive, and the two `start_offset` / `end_offset` uses — and nowhere else in the file, so there is no second consumer that could now see the wrong unit. (The pre-existing comment on the initialiser, `# raw (pre-subsampling) frames already emitted`, already described the units this change restores.) Everything downstream stays consistent:

- `upd['start']` / `upd['end']` are derived from the (already shifted) subsampled offsets as `offset * window_stride * subsampling_factor`, so the seconds move with the offsets and stay correct — no double conversion is introduced.
- The monotonicity clamp against `char_timestamps[-1]['end_offset']` compares subsampled offsets to subsampled offsets, unchanged.
- Word- and segment-level timestamps come from `get_words_offsets` / `get_segment_offsets` applied to these char offsets, so they inherit the correction without any change of units.
- The only caller of the affected path is `merge_parallel_chunks` (via `join_timestamp_and_add_word_and_segment_level_timestamps`), used from `aed_multitask_models.py:1110`. Its `chunk_offsets` are raw frames, which is what the corrected accumulation expects.
- `merge_hypotheses_of_same_audio` (hour-level chunk merging) computes its own `frame_offset` and does not touch `cumulative_offset`; it is untouched here.

## Why this is not a behaviour change for anyone who was already exact

Writing `o_i` for the raw-frame chunk offsets and `s` for the subsampling factor, the old code produced `Σ ⌊o_i / s⌋` and the new code produces `⌊Σ o_i / s⌋`. Splitting each offset as `o_i = s·⌊o_i / s⌋ + r_i` with `r_i = o_i mod s`:

```
⌊Σ o_i / s⌋ = Σ ⌊o_i / s⌋ + ⌊Σ r_i / s⌋
```

so `new − old = ⌊Σ r_i / s⌋ ≥ 0`, i.e. the new value is never smaller and the two differ only by the remainders that were previously thrown away one chunk at a time.

If `s` divides every `o_i` then every `r_i = 0` and `new = old` exactly — bit-identical, for any number of chunks. That covers `subsampling_factor = 4` (`750·4 − 100 = 2900 = 4·725`), a single chunk (`⌊o_0/s⌋` either way), an empty chunk list, and the leading `chunk_offsets[0] = 0`. It also covers both pre-existing tests, whose offsets are `(0, 32)` and `(0, 200)` — exact multiples of 8, which is why neither of them changes and why the bug survived them.

For `s = 8` with the real offsets, `r_i = (750·8 − 100) mod 8 = 4` for each of the 59 shifting chunks, so `new − old = ⌊59·4 / 8⌋ = 29` — matching the observed 43512 vs 43483 exactly.

The identity was also checked numerically over ~100k randomly generated offset lists for `s ∈ {2,3,4,5,7,8,16}` — including negative offsets, where Python's floor semantics keep `r_i ∈ [0, s)` so the identity still holds — with zero violations.

# Verified locally (macOS arm64, CPU only, Python 3.13, PyTorch 2.7.1)

```
$ pytest tests/collections/asr/utils/test_chunking_utils.py -m "not pleasefixme" -v --noconftest
```

- Before the fix (this test file against unmodified `main`): `1 failed, 5 passed` — `test_join_char_level_timestamps_no_drift_over_many_chunks` fails with `assert 43483 == 43512`.
- After the fix: `6 passed`.
- `isort --check` and `black --check` (black 24.10.0, matching the `required_version = "24"` pin in `pyproject.toml` and the `24.10.0` pre-commit rev) are clean on both changed files. No imports were added or reordered.

Caveat on `--noconftest`: `tests/conftest.py` downloads the release test-data archive at collection time, which this machine cannot reach, so the run above bypasses it. `test_chunking_utils.py` uses no fixtures from that conftest and no test data — it constructs `Hypothesis` objects inline — so nothing relevant is skipped, but the flag means these results are not a substitute for a normal CI run.

Deferred to CI: the full `tests/collections/asr` suite and anything requiring the downloaded test-data archive or a GPU — this machine has no GPU and no access to the test-data tarball, so only the `chunking_utils` unit tests were executed here. To run CI, please comment `/ok to test 24e7a962fcfdff62b2a5b2c8ceafced2863c3576`.

# GitHub Actions CI

Trusted PRs run automatically through copy-pr-bot. For an untrusted PR, a maintainer can trigger CI by commenting
`/ok to test <head-sha>`; repeat this after a new push if the PR remains untrusted.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? (n/a — no user-facing API or behaviour surface changes beyond the corrected values)
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc) — no
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries? — n/a, no new imports

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.

# Additional Information

- Fixes #16072
- Overlap with open PR #15186 ("Parallel chunking feature for RNNT and TDT models"), flagged only so reviewers can sequence the two — this PR does not touch it and makes no request of it:
  - #15186 does not modify the accumulation lines changed here, so the fix is still needed after it lands.
  - Its new word-level joining code uses the same divide-then-accumulate shape (`chunk_frame_offset = chunk_offsets[chunk_idx] // subsamp` accumulated into `cumulative_frame_offset`, with `cumulative_time_offset` derived from that), so the same arithmetic would apply there. Noting it in case it is useful; the call is entirely that PR's to make.
  - Whichever lands second needs a small textual merge: #15186 edits the `keep = ...` block a few lines below the changed lines in `join_char_level_timestamps`, and rewrites the region of `test_chunking_utils.py` where the new test is added. No semantic conflict either way.

