### PR TITLE
fix(asr): make DALI window name validation reachable

### DIFF
--- a/nemo/collections/asr/data/audio_to_text_dali.py
+++ b/nemo/collections/asr/data/audio_to_text_dali.py
@@ -17,7 +17,7 @@ import operator
 import os.path
 import time
 from collections.abc import Iterator
-from typing import Callable, List, Optional, Union
+from typing import Any, Callable, List, Optional, Union
 
 import torch
 from omegaconf import DictConfig
@@ -246,28 +246,8 @@ class _AudioTextDALIDataset(Iterator):
                     f" It must be either 'per_feature' or 'all_features'."
                 )
 
-            self.window = None
             window_name = params['window'] if 'window' in params else 'hann'
-            torch_windows = {
-                'hann': torch.hann_window,
-                'hamming': torch.hamming_window,
-                'blackman': torch.blackman_window,
-                'bartlett': torch.bartlett_window,
-                'none': None,
-            }
-
-            if window_name == 'ones':
-                window_tensor = torch.ones(self.window_size)
-            else:
-                try:
-                    window_fn = torch_windows.get(window_name, None)
-                except:
-                    raise ValueError(
-                        f"{self} received '{window_name}' for the window parameter."
-                        f" It must be one of: ('hann', 'ones', 'hamming', 'blackman', 'bartlett', None)."
-                        f" None is equivalent to 'hann'."
-                    )
-                window_tensor = window_fn(self.window_size, periodic=False) if window_fn else None
+            window_tensor = _resolve_window_tensor(window_name, self.window_size, context=self)
             self.window = window_tensor.numpy().tolist() if window_tensor is not None else None
 
             self.n_fft = params['n_fft'] if 'n_fft' in params else 2 ** math.ceil(math.log2(self.window_size))
@@ -775,3 +755,49 @@ class AudioToBPEDALIDataset(_AudioTextDALIDataset):
             preprocessor_cfg=preprocessor_cfg,
             return_sample_id=return_sample_id,
         )
+
+
+def _resolve_window_tensor(
+    window_name: Optional[str], window_size: int, context: Optional[Any] = None
+) -> Optional[torch.Tensor]:
+    """
+    Resolves a preprocessor's `window` configuration value into the window tensor passed to DALI.
+
+    Args:
+        window_name: Name of the window function. One of: 'hann', 'ones', 'hamming', 'blackman',
+            'bartlett', 'none' or None.
+        window_size: Length of the window, in samples.
+        context: Optional object prepended to the error message, so that the raised `ValueError`
+            identifies the dataset that received the bad configuration, like the other
+            configuration errors raised in `_AudioTextDALIDataset.__init__`.
+
+    Returns:
+        The window tensor, or None if no explicit window should be passed to DALI. DALI applies
+        a Hann window by default, so 'none' and None are equivalent to 'hann'.
+
+    Raises:
+        ValueError: If `window_name` is not one of the supported window names.
+    """
+    torch_windows = {
+        'hann': torch.hann_window,
+        'hamming': torch.hamming_window,
+        'blackman': torch.blackman_window,
+        'bartlett': torch.bartlett_window,
+        'none': None,
+    }
+
+    if window_name == 'ones':
+        return torch.ones(window_size)
+
+    # `not isinstance(..., str)` is checked first so that an unhashable value (e.g. a list from a
+    # malformed config) reports the same error instead of a bare `TypeError` from the lookup.
+    if window_name is not None and (not isinstance(window_name, str) or window_name not in torch_windows):
+        prefix = f"{context} received" if context is not None else "Received"
+        raise ValueError(
+            f"{prefix} '{window_name}' for the window parameter."
+            f" It must be one of: ('hann', 'ones', 'hamming', 'blackman', 'bartlett', 'none', None)."
+            f" 'none' and None are equivalent to 'hann', since DALI applies a Hann window by default."
+        )
+
+    window_fn = torch_windows.get(window_name, None)
+    return window_fn(window_size, periodic=False) if window_fn is not None else None

--- a/tests/collections/asr/test_asr_datasets.py
+++ b/tests/collections/asr/test_asr_datasets.py
@@ -37,6 +37,7 @@ from nemo.collections.asr.data.audio_to_text_dali import (
     __DALI_MINIMUM_VERSION__,
     AudioToBPEDALIDataset,
     AudioToCharDALIDataset,
+    _resolve_window_tensor,
     is_dali_supported,
 )
 from nemo.collections.asr.data.audio_to_text_dataset import inject_dataloader_value_from_model_config
@@ -613,6 +614,54 @@ class TestASRDatasets:
                 err = np.abs(a - b)
                 assert np.mean(err) < 0.0001
                 assert np.max(err) < 0.01
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize('window_name', ['hanning', 'Hann', 'blackmanharris', 'not_a_window', ''])
+    def test_dali_window_validation_rejects_unknown_name(self, window_name):
+        # Unknown window names used to fall through to `window_fn=None`, silently making DALI
+        # substitute its own default Hann window instead of raising.
+        with pytest.raises(ValueError, match=f"Received '{window_name}' for the window parameter"):
+            _resolve_window_tensor(window_name, window_size=320)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize('window_name', [5, ['hann'], {'window': 'hann'}])
+    def test_dali_window_validation_rejects_non_string(self, window_name):
+        # Unhashable values must not escape as a bare TypeError from the dict lookup.
+        with pytest.raises(ValueError, match="for the window parameter"):
+            _resolve_window_tensor(window_name, window_size=320)
+
+    @pytest.mark.unit
+    def test_dali_window_validation_error_reports_context(self):
+        # The dataset passes itself as the context, so the message keeps the same
+        # "<dataset> received ..." prefix as the other config errors raised in __init__.
+        with pytest.raises(ValueError, match="a-dali-dataset received 'hanning' for the window parameter"):
+            _resolve_window_tensor('hanning', window_size=320, context='a-dali-dataset')
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        'window_name,expected_fn',
+        [
+            ('hann', torch.hann_window),
+            ('hamming', torch.hamming_window),
+            ('blackman', torch.blackman_window),
+            ('bartlett', torch.bartlett_window),
+        ],
+    )
+    def test_dali_window_resolution_known_names(self, window_name, expected_fn):
+        window_size = 320
+        window_tensor = _resolve_window_tensor(window_name, window_size)
+        assert torch.allclose(window_tensor, expected_fn(window_size, periodic=False))
+
+    @pytest.mark.unit
+    def test_dali_window_resolution_ones(self):
+        window_size = 320
+        assert torch.allclose(_resolve_window_tensor('ones', window_size), torch.ones(window_size))
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize('window_name', ['none', None])
+    def test_dali_window_resolution_no_window(self, window_name):
+        # 'none' (and None) means no window is passed to DALI, which then applies its default.
+        assert _resolve_window_tensor(window_name, window_size=320) is None
 
     @pytest.mark.unit
     def test_feature_to_text_char_dataset(self):


### PR DESCRIPTION
> [!IMPORTANT]
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Makes the DALI dataset's `window` validation actually run, so an unrecognised window name raises the `ValueError` the code already intended to raise instead of being silently replaced by DALI's default Hann window.

**Collection**: ASR

# Changelog

- `nemo/collections/asr/data/audio_to_text_dali.py`
  - Replace the effectively unreachable `try`/`except` around `torch_windows.get(window_name, None)` with an explicit membership check. `dict.get(key, default)` never raises on a missing key, so for every string value the `except` branch — and the `ValueError` inside it — was dead code. Unknown names fell through to `window_fn = None`, and `dali.fn.spectrogram(..., window_fn=None)` then applied DALI's own default Hann window, so `window: hanning`, `window: Hann` or `window: blackmanharris` were accepted silently and produced features other than the ones configured.
  - Keep the one case in which the old `except` *did* fire: an unhashable value (a plain `list`/`dict`, e.g. from a malformed config) made the lookup raise `TypeError`, which the bare `except` converted into the intended `ValueError`. The membership check is guarded with `not isinstance(window_name, str)` first, so those values still produce the informative `ValueError` rather than a bare `TypeError`.
  - Extract the resolution into a module-level private helper `_resolve_window_tensor(window_name, window_size, context=None)` (placed at the bottom of the file per the repo's helper-placement convention). This keeps the DALI pipeline construction unchanged and makes the validation reachable from tests without DALI installed, since the module imports fine when `HAVE_DALI` is `False`. The call site passes `context=self`, so the raised error keeps the same `"<dataset> received ..."` prefix as the neighbouring configuration errors in `_AudioTextDALIDataset.__init__`.
  - Correct the error message: it advertised `None`, but the key the dict actually holds is the string `'none'`. The message now lists `'none'` (and `None`, which is accepted as its equivalent) and explains that both mean DALI applies its default Hann window.
  - Drop the dead `self.window = None` assignment that was immediately overwritten on the next lines.
- `tests/collections/asr/test_asr_datasets.py`
  - Add six unit tests (16 parametrized cases) in `TestASRDatasets` covering the reproduction from the issue and the surrounding behaviour: unknown names raise; non-string values raise a `ValueError` rather than a `TypeError`; the error carries the dataset context; `'hann'`/`'hamming'`/`'blackman'`/`'bartlett'` produce the matching `torch.*_window(size, periodic=False)` tensor; `'ones'` produces `torch.ones(size)`; `'none'` and `None` produce `None`.

## Backwards compatibility

No behaviour changes for any value that was valid before: `'hann'`, `'ones'`, `'hamming'`, `'blackman'`, `'bartlett'`, `'none'` and literal `None` all resolve to exactly the same tensor (or to `None`) as they did, and an absent `window` key still defaults to `'hann'`. The only difference is that names outside that set now raise instead of silently degrading to DALI's default — which is the point of the fix, and does mean a run that was previously training on unintentionally Hann-windowed features will now fail at construction with a clear message.

Literal `None` — what a config written as `window: null` deserialises to — is deliberately still accepted rather than being rejected as "not a supported name". It was accepted before this PR (`torch_windows.get(None, None)` returns `None`, so no window is passed to DALI), it is accepted by the non-DALI preprocessors, and rejecting it would break working configs. The membership check therefore short-circuits on `None`, and the message documents `None` alongside `'none'`.

# Usage

Before this PR, a typo in a DALI dataset's preprocessor config was accepted silently:

```yaml
model:
  preprocessor:
    _target_: nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor
    window: hanning   # not a supported name — silently became DALI's default Hann window
```

After this PR the same config fails fast:

```
ValueError: <nemo.collections.asr.data.audio_to_text_dali.AudioToCharDALIDataset object at 0x...>
received 'hanning' for the window parameter. It must be one of: ('hann', 'ones', 'hamming',
'blackman', 'bartlett', 'none', None). 'none' and None are equivalent to 'hann', since DALI
applies a Hann window by default.
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

Trusted PRs run automatically through copy-pr-bot. For an untrusted PR, a maintainer can trigger CI by commenting
`/ok to test <head-sha>`; repeat this after a new push if the PR remains untrusted.

## What was verified locally vs. deferred to CI

NVIDIA DALI is not installable on the machine used for this change (macOS, arm64), so the DALI-gated tests in `tests/collections/asr/test_asr_datasets.py` skip locally, exactly as they do in any environment without DALI.

Verified locally (`pytest tests/collections/asr/test_asr_datasets.py -m "not pleasefixme"`):

- The 16 new window-validation cases pass. They exercise `_resolve_window_tensor` directly, which is the whole of the changed logic, and they run without DALI and without a skip marker.
- The same cases were re-run against a temporarily restored pre-fix body: 7 of the 16 fail (the 5 unknown-name cases and the non-string `5` case with `DID NOT RAISE`, plus the context-prefix case), confirming the tests reproduce the reported bug rather than merely asserting current behaviour. The two unhashable non-string cases pass against the pre-fix body too — that is the one path on which the old `except` was live, and it is intentionally preserved.
- The rest of the file is unchanged relative to `main`: the same 3 failures (`test_tarred_dataset`, `test_tarred_dataset_filter`, `test_feature_to_text_char_dataset`) and the same 6 skips occur with and without this change, and are caused by the `tests/.data` archive not being available on this machine. Whole-file result on `main`: 3 failed, 6 passed, 6 skipped; with this PR: 3 failed, 22 passed, 6 skipped.
- `isort --check` and `black --check` (black 24.10.0, line length 119) pass on both changed files.

Deferred to CI, which has DALI:

- The five existing DALI end-to-end tests (`test_dali_char_dataset`, `test_dali_bpe_dataset`, `test_dali_char_vs_ref_dataset`, `test_tarred_dali_char_dataset`, `test_dali_tarred_char_vs_ref_dataset`) — these instantiate `AudioToCharDALIDataset`/`AudioToBPEDALIDataset` and therefore cover the refactored call site inside `_AudioTextDALIDataset.__init__`, including the `preprocessor_cfg` path that builds `self.window` and feeds it to `dali.fn.spectrogram(window_fn=...)`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

The touched file is DALI-gated. The existing `try: import nvidia.dali ... except (ImportError, ModuleNotFoundError): HAVE_DALI = False` guard is unchanged, and the new helper depends only on `torch`, so importing the module and running the new tests still works without DALI installed.

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Fixes #16073
- Scope note: the closest existing validation is in `AudioToMFCCPreprocessor` (`nemo/collections/asr/modules/audio_preprocessing.py:393-397`), which raises on an unsupported `window`. The mel-spectrogram path does **not** validate: `AudioToMelSpectrogramPreprocessor` delegates to `FilterbankFeatures`, which runs the same unguarded `torch_windows.get(window, None)` at `nemo/collections/asr/parts/preprocessing/features.py:317` and silently falls back to no window. That is the non-DALI twin of this bug, but fixing it changes the behaviour of the default (non-DALI) training path for anyone currently relying on the silent fallback, so it is deliberately left out of this PR and noted here as a follow-up for maintainers to weigh in on.

