### PR TITLE
fix(common): reach the max_open_streams guard instead of crashing on to_shards

### DIFF
--- a/nemo/collections/common/data/lhotse/cutset.py
+++ b/nemo/collections/common/data/lhotse/cutset.py
@@ -1738,7 +1738,10 @@ def read_nemo_manifest(config) -> tuple[CutSet, bool]:
                 # if it's in option 3
                 manifest_path = manifest_info
             # First, convert manifest_path[+tar_path] to an iterator.
-            if is_tarred and not metadata_only:
+            # Note: only the tarred iterator is shardable; ``metadata_only`` reads the manifests
+            #   without any audio I/O and therefore always yields a non-shardable iterator.
+            is_shardable = is_tarred and not metadata_only
+            if is_shardable:
                 nemo_iter = LazyNeMoTarredIterator(
                     manifest_path=manifest_path,
                     tar_paths=tar_path,
@@ -1768,7 +1771,10 @@ def read_nemo_manifest(config) -> tuple[CutSet, bool]:
             #   split the manifest to individual shards if applicable.
             #   This helps the multiplexing achieve closer data distribution
             #   to the one desired in spite of the limit.
-            if config.get("max_open_streams") is not None:
+            #   Non-shardable iterators are passed through as a single stream instead, so that
+            #   ``mux`` below can validate the option combination and raise a meaningful error
+            #   (e.g. max_open_streams together with metadata_only/force_finite).
+            if config.get("max_open_streams") is not None and is_shardable:
                 for subiter in nemo_iter.to_shards():
                     cutsets.append(CutSet(subiter))
                     weights.append(weight)

--- a/tests/collections/common/test_lhotse_dataloading.py
+++ b/tests/collections/common/test_lhotse_dataloading.py
@@ -31,6 +31,7 @@ from lhotse.testing.random import deterministic_rng
 from omegaconf import OmegaConf
 
 from nemo.collections.common.data.lhotse import get_lhotse_dataloader_from_config
+from nemo.collections.common.data.lhotse.cutset import read_nemo_manifest
 from nemo.collections.common.data.lhotse.text_adapters import SourceTargetTextExample, TextExample
 from nemo.collections.common.tokenizers.sentencepiece_tokenizer import SentencePieceTokenizer, create_spt_model
 from nemo.utils.dependency import is_module_available
@@ -767,6 +768,43 @@ def test_dataloader_from_tarred_nemo_manifest_multi_max_open_streams(nemo_tarred
     )
 
     _ = next(iter(dl))
+
+
+def test_read_tarred_nemo_manifest_multi_max_open_streams_metadata_only(
+    nemo_tarred_manifest_path_multi: tuple[str, str]
+):
+    """
+    ``metadata_only`` iterates manifests without audio I/O, which yields a non-shardable iterator.
+    Combining it with ``max_open_streams`` must raise the dedicated error from ``mux``
+    (it used to fail earlier with ``AttributeError: 'LazyNeMoIterator' object has no attribute 'to_shards'``).
+    """
+    json_mft, tar_mft = nemo_tarred_manifest_path_multi
+    config = OmegaConf.create(
+        {
+            "manifest_filepath": [[json_mft], [json_mft]],
+            "tarred_audio_filepaths": [[tar_mft], [tar_mft]],
+            "max_open_streams": 1,
+            "metadata_only": True,
+        }
+    )
+
+    with pytest.raises(AssertionError, match="max_open_streams and metadata_only/force_finite"):
+        read_nemo_manifest(config)
+
+
+def test_read_nemo_manifest_multi_max_open_streams_non_tarred(nemo_manifest_path: Path):
+    """Non-tarred manifests are a single stream each; ``max_open_streams`` must not crash on them."""
+    config = OmegaConf.create(
+        {
+            "manifest_filepath": [[str(nemo_manifest_path)], [str(nemo_manifest_path)]],
+            "max_open_streams": 1,
+        }
+    )
+
+    cuts, is_tarred = read_nemo_manifest(config)
+
+    assert not is_tarred
+    assert len(list(islice(cuts, 5))) == 5
 
 
 @pytest.mark.skipif(not is_module_available("pyloudnorm"), reason="pyloudnorm is required to concatenate samples")


### PR DESCRIPTION
# What does this PR do ?

Stops `read_nemo_manifest()` from calling `LazyNeMoTarredIterator.to_shards()` on iterators that don't have it, so that the existing `max_open_streams` / `metadata_only` guard in `mux()` can actually fire instead of being pre-empted by a raw `AttributeError`.

**Collection**: common (`nemo.collections.common.data.lhotse`)

# Changelog

- `nemo/collections/common/data/lhotse/cutset.py`: in `read_nemo_manifest()`, hoist the tarred-vs-non-tarred branch decision into `is_shardable = is_tarred and not metadata_only`, and require `is_shardable` before splitting a manifest with `nemo_iter.to_shards()`. Non-shardable iterators are appended as a single stream, exactly like the `max_open_streams is None` branch.
- `tests/collections/common/test_lhotse_dataloading.py`: two regression tests —
  - `test_read_tarred_nemo_manifest_multi_max_open_streams_metadata_only` asserts that `metadata_only` + `max_open_streams` raises the intended `AssertionError` from `mux()`;
  - `test_read_nemo_manifest_multi_max_open_streams_non_tarred` asserts that non-tarred multi-manifest configs with `max_open_streams` build a usable `CutSet`.

## Why this preserves the assert's intent

The guard in `mux()` is:

```python
assert not force_finite, "max_open_streams and metadata_only/force_finite options are not compatible"
```

It exists because `max_open_streams` is implemented via `CutSet.infinite_mux`, which is infinite by construction and therefore incompatible with a finite (`metadata_only` / `force_finite`) read. The fix does not suppress or weaken that: it removes the earlier crash so the guard is reached and raised, with its message unchanged. Verified — the `metadata_only` repro now terminates with the `AssertionError`, not the `AttributeError`.

The `to_shards()` call it guards is a *tarred-only optimisation*: splitting one sharded tarred manifest into per-shard sub-streams so that `infinite_mux`'s open-stream cap still yields a good data distribution. A non-tarred manifest has no shards to split, so passing it through as a single stream is the semantically correct fallback, not a workaround. This also matches `parse_and_combine_datasets()`, which already calls `mux(..., max_open_streams=...)` on arbitrary (including non-tarred) cutsets with no sharding step.

Deliberately *not* done here: making `metadata_only` silently ignore `max_open_streams` so that `estimate_duration_bins.py` runs unmodified against a real training config. That is arguably the nicer end-state (`max_open_streams` is only an open-FD limit, and `metadata_only` does no audio I/O), but it changes the policy the existing assert encodes and should be a maintainer decision.

# Usage

```python
from omegaconf import OmegaConf
from nemo.collections.common.data.lhotse.cutset import read_nemo_manifest

# Before: AttributeError: 'LazyNeMoIterator' object has no attribute 'to_shards'
# After:  AssertionError: max_open_streams and metadata_only/force_finite options are not compatible
read_nemo_manifest(OmegaConf.create({
    "type": "nemo_tarred",
    "manifest_filepath": [["m1.json"], ["m2.json"]],
    "tarred_audio_filepaths": [["a1.tar"], ["a2.tar"]],
    "max_open_streams": 4,
    "metadata_only": True,
}))
```

# Verification

Interpreter: a local virtualenv (Python 3.10.18, torch 2.12.0 CPU, lhotse 2.0.0a3), run with `PYTHONPATH` pointed at the repository checkout; `cutset.__file__` was confirmed to resolve into that checkout.

### Reproduction, before the fix

`scripts/speech_recognition/estimate_duration_bins.py input_cfg=input_cfg.yaml -b 2`:

```
  File ".../nemo/collections/common/data/lhotse/cutset.py", line 313, in parse_group
    cuts, is_tarred = parser_fn(grp_cfg)
  File ".../nemo/collections/common/data/lhotse/cutset.py", line 1772, in read_nemo_manifest
    for subiter in nemo_iter.to_shards():
AttributeError: 'LazyNeMoIterator' object has no attribute 'to_shards'
```

`scripts/speech_recognition/estimate_data_weights.py input_cfg.yaml out.yaml`:

```
  File ".../scripts/speech_recognition/estimate_data_weights.py", line 88, in count
    iterable, is_tarred = get_parser_fn(entry.type)(entry)
  File ".../nemo/collections/common/data/lhotse/cutset.py", line 1772, in read_nemo_manifest
    for subiter in nemo_iter.to_shards():
AttributeError: 'LazyNeMoIterator' object has no attribute 'to_shards'
```

### After the fix

Both scripts on the same config:

```
  File ".../nemo/collections/common/data/lhotse/cutset.py", line 1784, in read_nemo_manifest
    cuts = mux(
  File ".../nemo/collections/common/data/lhotse/cutset.py", line 1829, in mux
    assert not force_finite, "max_open_streams and metadata_only/force_finite options are not compatible"
AssertionError: max_open_streams and metadata_only/force_finite options are not compatible
```

Non-tarred training config repro: `OK` (previously `AttributeError`).

### Tests

Pre-fix (the two new tests applied to an otherwise unmodified `main`):

```
FAILED tests/collections/common/test_lhotse_dataloading.py::test_read_tarred_nemo_manifest_multi_max_open_streams_metadata_only
FAILED tests/collections/common/test_lhotse_dataloading.py::test_read_nemo_manifest_multi_max_open_streams_non_tarred
=========== 2 failed, 1 passed, 67 deselected, 43 warnings in 4.62s ============
```

(failure reason on both: `AttributeError: 'LazyNeMoIterator' object has no attribute 'to_shards'` at `cutset.py:1772`)

Post-fix:

```
pytest tests/collections/common/test_lhotse_dataloading.py -k max_open_streams --noconftest
================ 3 passed, 67 deselected, 43 warnings in 4.24s =================
```

Wider regression run:

```
pytest tests/collections/common/test_lhotse_dataloading.py \
       tests/collections/common/test_lhotse_temperature_reweighting.py \
       tests/collections/common/test_lhotse_index_pack.py --noconftest
================= 116 passed, 1 skipped, 59 warnings in 49.32s =================
```

### Lint

```
isort --check nemo/collections/common/data/lhotse/cutset.py tests/collections/common/test_lhotse_dataloading.py   -> clean
black 24.10.0 --check ... (repo pyproject: line-length 119, skip-string-normalization)  -> 2 files would be left unchanged
```

# GitHub Actions CI

Trusted PRs run automatically through copy-pr-bot. For an untrusted PR, a maintainer can trigger CI by commenting
`/ok to test <head-sha>`; repeat this after a new push if the PR remains untrusted.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? — not needed, no user-facing API change
- [ ] Does the PR affect components that are optional to install? — no

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.

# Additional Information

- Fixes #16081
- Long-standing: both the `to_shards()` sharding step and the `mux()` guard predate the NVIDIA-NeMo/Speech repo split, so `git log -S` on this repo points at the split commit rather than the original change. The closest historical reference found is the OOMptimizer PR (#9763), which is where `max_open_streams` tooling originates.

