### PR TITLE
fix(tts): report phoneme dictionary entries dropped by the alphabet filter

### DIFF
--- a/nemo/collections/tts/g2p/models/i18n_ipa.py
+++ b/nemo/collections/tts/g2p/models/i18n_ipa.py
@@ -15,6 +15,7 @@
 import pathlib
 import random
 import re
+import unicodedata
 from collections import defaultdict
 from typing import Callable, Dict, List, Optional, Set, Tuple, Union
 
@@ -34,6 +35,11 @@ from nemo.utils import logging
 # Compiled regex pattern for Indic scripts (used in dictionary parsing)
 _INDIC_PATTERN = re.compile(f'^[{INDIC_CHARS_ALL}]')
 _KOREAN_PATTERN = re.compile(f'^[{KOREAN_CHARS}]')
+
+# How many skipped dictionary entries to name in the warning emitted by `IpaG2p._parse_phoneme_dict`, and how many
+# characters of each to show (a malformed line can carry a very long first field).
+_MAX_SKIPPED_SHOWN = 5
+_MAX_SKIPPED_WORD_LEN = 30
 
 
 class IpaG2p(BaseG2p):
@@ -201,10 +207,11 @@ class IpaG2p(BaseG2p):
             # represents the pronunciation variant of that word.
             phoneme_dict_obj = defaultdict(list)
             _alt_re = re.compile(r"\([0-9]+\)")
+            skipped_entries = []
             with open(phoneme_dict, "r", encoding="utf-8") as fdict:
-                for line in fdict:
-                    # skip the empty lines
-                    if len(line) == 0:
+                for line_number, line in enumerate(fdict, start=1):
+                    # skip the blank lines and the ";;;"-prefixed comment header of CMUdict-format files
+                    if not line.strip() or line.startswith(";;;"):
                         continue
 
                     # Note that latin character pattern should be consistent with
@@ -227,6 +234,26 @@ class IpaG2p(BaseG2p):
                         word = re.sub(_alt_re, "", parts[0])
                         prons = re.sub(r"\s+", "", parts[1])
                         phoneme_dict_obj[word].append(list(prons))
+                    elif unicodedata.category(line[0]).startswith('L'):
+                        # Only entries starting with a letter are reported: the accepted first characters above cover
+                        # accented letters up to U+00FF only, so a word such as 'ŒUVRE' (U+0152) or Vietnamese
+                        # 'ĐƯỜNG' (U+0110) is lost here purely because of that bound. Entries starting with anything
+                        # else are rejected by design (CMUdict's '!EXCLAMATION-POINT' pseudo-entries, for instance).
+                        skipped_entries.append((line_number, line.strip().split(maxsplit=1)[0]))
+
+            if skipped_entries:
+                preview = ", ".join(
+                    f"line {number}: '{word[:_MAX_SKIPPED_WORD_LEN]}'"
+                    for number, word in skipped_entries[:_MAX_SKIPPED_SHOWN]
+                )
+                if len(skipped_entries) > _MAX_SKIPPED_SHOWN:
+                    preview += f", ... ({len(skipped_entries) - _MAX_SKIPPED_SHOWN} more)"
+                logging.warning(
+                    f"Skipped {len(skipped_entries)} entries of the phoneme dictionary '{phoneme_dict}' because they "
+                    f"start with a letter outside the supported alphabet (ASCII letters, accented latin letters up to "
+                    f"U+00FF, Indic letters and Korean letters). Those words are absent from the loaded dictionary "
+                    f"and will be handled as out-of-vocabulary. Skipped entries: {preview}."
+                )
         else:
             # Load phoneme_dict as dictionary object
             logging.info("Loading phoneme_dict as a Dict object, and validating its entry format.")

--- a/tests/collections/tts/g2p/test_modules.py
+++ b/tests/collections/tts/g2p/test_modules.py
@@ -14,6 +14,7 @@
 
 import os
 import unicodedata
+from unittest.mock import patch
 
 import pytest
 
@@ -208,6 +209,43 @@ class TestIpaG2p:
         phonemes_dict = g2p_dict(input_text)
         assert phonemes_dict == expected_output
         assert phonemes_file == phonemes_dict
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_parse_phoneme_dict_warns_about_skipped_entries(self, tmp_path):
+        # `_parse_phoneme_dict` only accepts entries whose first character is an ASCII letter, an accented latin
+        # letter up to U+00FF, an Indic or Korean letter, or an apostrophe. Anything else is dropped, which must
+        # not happen quietly: the words simply vanish from the dictionary and become OOV at training time.
+        phoneme_dict_path = tmp_path / "test_dict_skipped.txt"
+        phoneme_dict_path.write_text("MAISON  mɛzˈɔ̃\nŒUVRE  ˈœvʁ\nŒUF  ˈœf\nĐƯỜNG  dɨəŋ\n", encoding="utf-8")
+
+        with patch("nemo.collections.tts.g2p.models.i18n_ipa.logging.warning") as mock_warning:
+            phoneme_dict_obj = IpaG2p._parse_phoneme_dict(str(phoneme_dict_path))
+
+        assert set(phoneme_dict_obj) == {"MAISON"}
+
+        mock_warning.assert_called_once()
+        warning_msg = mock_warning.call_args[0][0]
+        assert "Skipped 3 entries" in warning_msg
+        for skipped_word in ["ŒUVRE", "ŒUF", "ĐƯỜNG"]:
+            assert skipped_word in warning_msg
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_parse_phoneme_dict_does_not_warn_about_non_letter_entries(self, tmp_path):
+        # The ";;;" header of CMUdict-format dictionaries, blank lines, and entries that do not start with a letter
+        # (such as CMUdict's "!EXCLAMATION-POINT") are skipped on purpose, so they must not be reported as lost
+        # entries: only a word starting with an unsupported *letter* signals a gap in the accepted alphabet.
+        phoneme_dict_path = tmp_path / "test_dict_comments.txt"
+        phoneme_dict_path.write_text(
+            ";;; # CMUdict\n;;;\n\nHELLO  həˈɫoʊ\n!EXCLAMATION-POINT  ɛkskləmˈeɪʃənpˈɔɪnt\n\n", encoding="utf-8"
+        )
+
+        with patch("nemo.collections.tts.g2p.models.i18n_ipa.logging.warning") as mock_warning:
+            phoneme_dict_obj = IpaG2p._parse_phoneme_dict(str(phoneme_dict_path))
+
+        assert set(phoneme_dict_obj) == {"HELLO"}
+        mock_warning.assert_not_called()
 
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit


### PR DESCRIPTION
# What does this PR do ?

Reports the phoneme-dictionary entries that `IpaG2p` currently discards without any log record, so
that silent lexicon data loss becomes visible at load time.

**Collection**: tts (`nemo/collections/tts/g2p`)

# Changelog

- `nemo/collections/tts/g2p/models/i18n_ipa.py`
  - `IpaG2p._parse_phoneme_dict` now collects the dictionary lines it rejects and emits a single
    aggregated `logging.warning` naming the count and the first few entries with their line
    numbers, instead of dropping them in silence (the `if` had no `else`).
  - Only lines starting with a **letter** are reported. Lines starting with anything else are
    rejected by design — CMUdict's `;;;` header and its `!EXCLAMATION-POINT` style pseudo-entries —
    so the common en-US path stays quiet.
  - Blank lines and `;;;` comments are now skipped explicitly. This replaces the `if len(line) == 0`
    check, which was dead code: iterating a file never yields an empty string.
- `tests/collections/tts/g2p/test_modules.py`
  - `test_parse_phoneme_dict_warns_about_skipped_entries` — a dictionary with `ŒUVRE`, `ŒUF` and
    `ĐƯỜNG` entries must warn, naming all three. Fails before this change (`Expected 'warning' to
    have been called once. Called 0 times.`).
  - `test_parse_phoneme_dict_does_not_warn_about_non_letter_entries` — CMUdict headers, blank lines
    and `!EXCLAMATION-POINT` must not be reported.

# Background

`IpaG2p._parse_phoneme_dict` accepts a line only if its first character is an ASCII letter, an
accented latin letter **up to U+00FF**, an Indic or Korean letter, or an apostrophe. The U+00FF
bound is inherited from `ACCENTED_CHARS = "À-ÖØ-öø-ÿ"`
(`nemo/collections/common/tokenizers/text_to_speech/tokenizer_utils.py:57`), which stops at the end
of Latin-1 Supplement. Words starting with `Œ` (U+0152), `ẞ` (U+1E9E) or Vietnamese `Đ` (U+0110)
are therefore dropped — including real entries in dictionaries shipped in this repository:

```
scripts/tts_dataset_files/es_ES/es_ES_nv230301.dict:1-3   Ꝇ (U+A746), 2 pronunciations
scripts/tts_dataset_files/es_LA/es_LA_nv230301.dict:1-4   Ꝇ, 3 pronunciations
scripts/tts_dataset_files/de/de_nv230119.dict:145672      Œuvre
scripts/tts_dataset_files/hi_IN/hi_prondict-v0.3_nostress_fixed.dict:120478-120481   4 malformed lines
```

Before this PR none of those produced any output at all.

# Scope

**This PR deliberately does not widen `ACCENTED_CHARS`.** Doing so would be a compatibility change:
`IPATokenizer` builds its vocabulary as `sorted(set(g2p.symbols))` and `g2p.symbols` comes from the
parsed dictionary, so admitting new letters adds symbols, shifts every token index and invalidates
checkpoints trained against the same lexicon; tokenization of already-working text changes as well,
since those characters move from the punctuation group into the word group. That belongs with the
maintainers, plausibly behind a `VERSIONED_TOKENIZER_FIELDS` entry, and is described in the issue.

**Parsing behaviour is unchanged by this PR.** Every dictionary under `scripts/tts_dataset_files/`
parses to a byte-identical result before and after (entry counts and pronunciation counts compared
for all 9 files); the only difference is the new log line.

# Usage

```python
from nemo.collections.tts.g2p.models.i18n_ipa import IpaG2p

IpaG2p._parse_phoneme_dict("scripts/tts_dataset_files/es_ES/es_ES_nv230301.dict")
```

```
[NeMo W] Skipped 3 entries of the phoneme dictionary 'scripts/tts_dataset_files/es_ES/es_ES_nv230301.dict'
because they start with a letter outside the supported alphabet (ASCII letters, accented latin letters up to
U+00FF, Indic letters and Korean letters). Those words are absent from the loaded dictionary and will be
handled as out-of-vocabulary. Skipped entries: line 1: 'Ꝇ', line 2: 'Ꝇ(1)', line 3: 'Ꝇ(2)'.
```

Loading `ipa_cmudict-0.7b_nv26.07.txt` produces no warning.

# Tests

```
$ pytest tests/collections/tts/g2p tests/collections/common/tokenizers/text_to_speech
69 passed
```

Before the fix, `test_parse_phoneme_dict_warns_about_skipped_entries` fails:

```
>       mock_warning.assert_called_once()
E       AssertionError: Expected 'warning' to have been called once. Called 0 times.
1 failed, 1 passed
```

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? — n/a, no API change
- [ ] Does the PR affect components that are optional to install? — no

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

# Additional Information

- Fixes #16083
- Same class of defect as #15936 (canary-1b-v2 drops word-final Greek `ς`, absent from the
  tokenizer vocabulary).

---

## Validation

- Base: `main` at `d0a07c056`. Python 3.10.18, torch 2.12.0 (CPU), tests run with `--noconftest`.
- `isort` and `black` (pinned to the 24.x series required by the repo config, line length 119) are
  both clean on the two touched files.
- Parse results compared before and after for all nine dictionaries under
  `scripts/tts_dataset_files/`: entry counts and pronunciation counts are identical, so the only
  observable difference is the new log line.

