### PR TITLE
fix(configs): point SALM and beamforming _target_ entries at classes that exist

### DIFF
--- a/examples/audio/conf/beamforming_flex_channels.yaml
+++ b/examples/audio/conf/beamforming_flex_channels.yaml
@@ -33,7 +33,7 @@ model:
     pin_memory: true
 
   channel_augment:
-    _target_: nemo.collections.asr.parts.submodules.multichannel_modules.ChannelAugment
+    _target_: nemo.collections.audio.parts.submodules.multichannel.ChannelAugment
     num_channels_min: 2 # minimal number of channels selected for each batch
     num_channels_max: null # max number of channels is determined by the batch size
     permute_channels: true

--- a/examples/speechlm2/conf/salm_asr_decoder_multilayerproj.yaml
+++ b/examples/speechlm2/conf/salm_asr_decoder_multilayerproj.yaml
@@ -31,7 +31,7 @@ model:
      target: nemo.collections.speechlm2.modules.perception.AudioTranscriptionPerceptionModule
      output_dim: 4096
      modality_adapter:
-       _target_: nemo.collections.asr.modules.QformerConnector
+       _target_: nemo.collections.speechlm2.modules.perception.MultiLayerProjectionConnector
        target_layer_ids: [0, 5, 11, 17, 23]
        input_dim: 1024
        output_dim: 4096

--- a/examples/speechlm2/conf/salm_asr_decoder_qformer.yaml
+++ b/examples/speechlm2/conf/salm_asr_decoder_qformer.yaml
@@ -31,7 +31,7 @@ model:
      target: nemo.collections.speechlm2.modules.perception.AudioTranscriptionPerceptionModule
      output_dim: 4096
      modality_adapter:
-       _target_: nemo.collections.asr.modules.QformerConnector
+       _target_: nemo.collections.speechlm2.modules.perception.QformerConnector
        prompt_size: 64
        target_layer_ids: [0, 5, 11, 17, 23]
        qformer_num_hidden_layers: 6

--- a/tests/collections/audio/test_example_configs.py
+++ b/tests/collections/audio/test_example_configs.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+
+import pytest
+from omegaconf import OmegaConf
+
+from nemo.collections.audio.parts.submodules.multichannel import ChannelAugment
+from nemo.core.classes.common import Serialization
+
+
+REPO_ROOT = Path(__file__).parents[3]
+
+
+@pytest.mark.unit
+def test_beamforming_flex_channels_channel_augment_is_instantiable():
+    """`EncMaskDecAudioToAudioModel.__init__` instantiates this block, so its `_target_` must resolve."""
+    cfg = OmegaConf.load(REPO_ROOT / "examples/audio/conf/beamforming_flex_channels.yaml")
+
+    channel_augment = Serialization.from_config_dict(cfg.model.channel_augment)
+
+    assert isinstance(channel_augment, ChannelAugment)

--- a/tests/collections/speechlm2/test_example_configs.py
+++ b/tests/collections/speechlm2/test_example_configs.py
@@ -13,7 +13,11 @@
 # limitations under the License.
 from pathlib import Path
 
+import pytest
 from omegaconf import OmegaConf
+
+from nemo.collections.speechlm2.modules.perception import MultiLayerProjectionConnector, QformerConnector
+from nemo.core.classes.common import Serialization
 
 
 REPO_ROOT = Path(__file__).parents[3]
@@ -23,3 +27,19 @@ def test_salm_automodel_uses_portable_moe_dispatcher():
     cfg = OmegaConf.load(REPO_ROOT / "examples/speechlm2/conf/salm_automodel.yaml")
 
     assert cfg.model.automodel_backend.dispatcher == "torch"
+
+
+@pytest.mark.parametrize(
+    "config_name,expected_type",
+    [
+        ("salm_asr_decoder_qformer", QformerConnector),
+        ("salm_asr_decoder_multilayerproj", MultiLayerProjectionConnector),
+    ],
+)
+def test_salm_asr_decoder_modality_adapter_is_instantiable(config_name, expected_type):
+    """The shipped modality_adapter block must name a real class that accepts the arguments beside it."""
+    cfg = OmegaConf.load(REPO_ROOT / f"examples/speechlm2/conf/{config_name}.yaml")
+
+    adapter = Serialization.from_config_dict(cfg.model.perception.modality_adapter)
+
+    assert isinstance(adapter, expected_type)


### PR DESCRIPTION

> [!IMPORTANT]
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Corrects the `_target_` path in three shipped example configs that name a module or class which does
not exist, so that the configs can be used at all instead of raising during model construction.

**Collection**: SpeechLM2, Audio

# Changelog

- `examples/speechlm2/conf/salm_asr_decoder_qformer.yaml`
  - `model.perception.modality_adapter._target_`:
    `nemo.collections.asr.modules.QformerConnector` →
    `nemo.collections.speechlm2.modules.perception.QformerConnector`.
    `nemo.collections.asr.modules` contains no class with `Connector` in its name; `QformerConnector`
    is defined at `nemo/collections/speechlm2/modules/perception.py:377`.
- `examples/speechlm2/conf/salm_asr_decoder_multilayerproj.yaml`
  - `model.perception.modality_adapter._target_`:
    `nemo.collections.asr.modules.QformerConnector` →
    `nemo.collections.speechlm2.modules.perception.MultiLayerProjectionConnector`.
    This file had two defects, not one. Besides the non-existent module path, it named the wrong
    class: it passes `target_layer_ids`, `input_dim`, `output_dim`, which is
    `MultiLayerProjectionConnector.__init__` (`perception.py:445-453`), whereas `QformerConnector`
    requires `prompt_size`, `qformer_num_hidden_layers`, `encoder_config` and `llm_config`
    (`perception.py:377-385`). Correcting only the path leaves it failing with
    `TypeError: QformerConnector.__init__() got an unexpected keyword argument 'input_dim'`. The
    class chosen here is the one the repo's own test for this model already uses
    (`tests/collections/speechlm2/test_salm_asr_decoder_multilayerproj.py:103`).
- `examples/audio/conf/beamforming_flex_channels.yaml`
  - `model.channel_augment._target_`:
    `nemo.collections.asr.parts.submodules.multichannel_modules.ChannelAugment` →
    `nemo.collections.audio.parts.submodules.multichannel.ChannelAugment`.
    There is no `nemo/collections/asr/parts/submodules/multichannel_modules.py`; `ChannelAugment` is
    defined at `nemo/collections/audio/parts/submodules/multichannel.py:29`. Every other `_target_`
    in this file already uses the migrated `nemo.collections.audio.*` namespace (lines 42, 47, 52,
    70, 81), so this reads as one path missed during the ASR→audio collection move. This YAML is the
    only file in the tree that sets `channel_augment`, so `ChannelAugment` was unreachable from any
    shipped configuration.
- `tests/collections/speechlm2/test_example_configs.py`
  - Add `test_salm_asr_decoder_modality_adapter_is_instantiable`, parametrized over both SALM
    ASR-decoder configs, asserting each `modality_adapter` block instantiates to the expected class.
- `tests/collections/audio/test_example_configs.py` (new)
  - Add `test_beamforming_flex_channels_channel_augment_is_instantiable`, mirroring the speechlm2
    file's pattern for the audio collection.

No argument values were changed in any config — the keyword arguments already present in each block
match the corrected class's `__init__`.

## Why the tests instantiate rather than just resolve the path

A test that only checked that the dotted `_target_` resolves would pass on
`salm_asr_decoder_multilayerproj.yaml` as soon as the module path was corrected, and would silently
miss the wrong-class defect. Instantiating binds the keyword arguments and catches both. All three
blocks construct on CPU with no data, no checkpoints and no network access, so the tests are cheap
(0.25 s for the slowest) and have no external dependencies.

## Backwards compatibility

None of these configs could be loaded before this PR — each raised
`hydra.errors.InstantiationException` at model construction — so there is no working behaviour to
preserve and nothing that can regress. Checkpoints are unaffected: the change is confined to example
YAML under `examples/` and to tests.

# Usage

Before this PR:

```console
$ python examples/audio/audio_to_audio_train.py --config-path=conf --config-name=beamforming_flex_channels ...
ModuleNotFoundError: No module named 'nemo.collections.asr.parts.submodules.multichannel_modules'
hydra.errors.InstantiationException: Error locating target
'nemo.collections.asr.parts.submodules.multichannel_modules.ChannelAugment'
```

```console
$ python examples/speechlm2/salm_asr_decoder_train.py --config-path=conf --config-name=salm_asr_decoder_multilayerproj
hydra.errors.InstantiationException: Error locating target
'nemo.collections.asr.modules.QformerConnector'
```

After this PR both configs build their modality adapter / channel augmentation and proceed to the
normal data and checkpoint requirements.

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

Trusted PRs run automatically through copy-pr-bot. For an untrusted PR, a maintainer can trigger CI by commenting
`/ok to test <head-sha>`; repeat this after a new push if the PR remains untrusted.

## What was verified locally

Python 3.10.18 / PyTorch 2.12.0, macOS 26.5.1 arm64, CPU only, no network.

- `pytest tests/collections/speechlm2/test_example_configs.py tests/collections/audio/test_example_configs.py`
  → **4 passed** (3 new + 1 pre-existing).
- The same three tests were re-run against the configs restored to `main`: **3 failed, 1 passed**,
  confirming they reproduce the reported failure rather than merely asserting current behaviour.
- A third state was checked: with `salm_asr_decoder_multilayerproj.yaml` set to the correct module
  path but the original class name, the test still fails with
  `TypeError: QformerConnector.__init__() got an unexpected keyword argument 'input_dim'` — pinning
  the second, easily-missed half of that config's defect.
- `isort --check` and `black --check` (black 24.10.0, line length 119) pass on both test files.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Fixes #16089
- **Scope note / follow-up lead.** Resolving every `nemo.*` `_target_` under
  `examples/**/conf/**/*.yaml` gives 768 resolvable and 13 unresolvable targets on `main`; this PR
  fixes three of them. The remaining ten all come from the wav2vec example configs
  (`examples/asr/conf/ssl/wav2vec/*.yaml`, `examples/asr/conf/wav2vec_ctc/*.yaml`). Those are not a
  stale-path problem of the same kind: `nemo/collections/asr/modules/wav2vec_modules.py` does exist,
  but is unimportable because line 30 imports
  `nemo.collections.asr.modules.common.transformer.transformer_encoders_nlp` (there is no
  `nemo.collections.asr.modules.common`), and the module that path presumably refers to,
  `nemo/collections/asr/modules/transformer/transformer_encoders_nlp.py`, itself imports
  `nemo.collections.nlp`, which no longer exists in this repository. Those five configs and that
  module look orphaned by the NLP collection removal, and deciding whether to repair or retire them
  is a maintainer call rather than something to bundle here. Flagging it so the gap is on record.
- A blanket unit test asserting that *every* `_target_` under `examples/**/conf/` resolves would be a
  cheap guard against this whole class of rot, and would have caught all three of these. It is
  deliberately not included here because it cannot pass until the wav2vec question above is settled.
  Happy to add it in a follow-up if maintainers want it.


