### PR TITLE
docs(asr): use the MultiTask metrics key the model actually reads

### DIFF
--- a/docs/source/asr/configs.rst
+++ b/docs/source/asr/configs.rst
@@ -244,7 +244,7 @@ Multiple metrics can be configured simultaneously using a ``MultiTaskMetric`` co
 .. code-block:: yaml
 
   model:
-    multitask_metrics_config:
+    multitask_metrics_cfg:
       log_prediction: true
       metrics:
         wer:
@@ -265,7 +265,7 @@ Each metric within ``MultiTaskMetric`` can be configured with an optional boolea
 .. code-block:: yaml
 
   model:
-    multitask_metrics_config:
+    multitask_metrics_cfg:
       metrics:
         pnc_wer:
           _target_: nemo.collections.asr.metrics.wer.WER

--- a/nemo/collections/asr/metrics/multitask.py
+++ b/nemo/collections/asr/metrics/multitask.py
@@ -233,8 +233,8 @@ class MultiTaskMetric(Serialization):
     Usage Example:
         ```python
         # In model initialization
-        if hasattr(cfg, 'multitask_metrics'):
-            self.multitask_metrics = MultiTaskMetric(self, cfg.multitask_metrics)
+        if hasattr(cfg, 'multitask_metrics_cfg'):
+            self.multitask_metrics = MultiTaskMetric(self, cfg.multitask_metrics_cfg)
 
         # During training/validation
         if hasattr(self, 'multitask_metrics'):


### PR DESCRIPTION

> [!IMPORTANT]
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Documents the MultiTask metrics block under the key `EncDecMultiTaskModel` actually reads, so that
copying the example from the docs configures the metrics instead of silently doing nothing.

**Collection**: ASR

# Changelog

- `docs/source/asr/configs.rst`
  - Rename `multitask_metrics_config:` → `multitask_metrics_cfg:` in both YAML examples in the
    "MultiTask Metrics" section (lines 247 and 268). `EncDecMultiTaskModel.__init__` reads
    `cfg.get("multitask_metrics_cfg")` (`nemo/collections/asr/models/aed_multitask_models.py:237`)
    and falls back to a hardcoded default when it is absent. Because that fallback is a *valid*
    config (unconstrained WER + BLEU with default parameters), a user who copies the documented block
    gets no error — training just proceeds with the defaults, discarding every documented
    `constraint`, `use_cer`, `bleu_tokenizer`, `lowercase`, `check_cuts_for_bleu_tokenizers` and
    `log_prediction` setting.
- `nemo/collections/asr/metrics/multitask.py`
  - Correct a third spelling in the `MultiTaskMetric` class docstring's usage example, which showed
    `hasattr(cfg, 'multitask_metrics')` / `cfg.multitask_metrics`. Docstring text only.

`multitask_metrics_config` appeared nowhere else in the repository. The shipped config
`examples/asr/conf/speech_multitask/fast-conformer_aed.yaml:48` already uses `multitask_metrics_cfg`,
so the documentation was the outlier and the code key is the one to keep.

## Backwards compatibility

Documentation only. No behavior change, no code path altered, no config or checkpoint affected. The
key the model reads is unchanged, so every existing config and every checkpoint carrying a stored
`model` config keeps working exactly as before.

# Usage

Concretely, what the documented spelling produced versus what the block asked for:

```yaml
model:
  multitask_metrics_config:      # <- documented; never read
    metrics:
      wer:
        _target_: nemo.collections.asr.metrics.wer.WER
        use_cer: true
        constraint: ".task==transcribe"
```

```
wer.use_cer                       : False      <- config asked for True
wer constraint fires on translate : True       <- config asked for transcribe-only
```

With `multitask_metrics_cfg:`, the same block yields `use_cer: True` and a WER constraint that does
not fire on translation cuts.

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

Trusted PRs run automatically through copy-pr-bot. For an untrusted PR, a maintainer can trigger CI by commenting
`/ok to test <head-sha>`; repeat this after a new push if the PR remains untrusted.

## What was verified locally

Python 3.10.18 / PyTorch 2.12.0, macOS 26.5.1 arm64.

- Fed the documented block and the corrected block through the exact `aed_multitask_models.py:237`
  lookup and inspected the resulting `MultiTaskMetric`. Documented spelling → lookup returns `None`,
  `use_cer=False`, WER constraint fires on a `translate` cut, `BLEU.check_cuts=False`. Corrected
  spelling → `use_cer=True`, WER constraint does not fire on `translate`, `BLEU.check_cuts=True`.
- `pytest tests/collections/asr/test_asr_metrics.py -k "MultiTaskMetric or multitask"` →
  `29 passed, 55 deselected` (unchanged; this commit only edits a docstring and an `.rst`).
- `isort --check` and `black --check` (black 24.10.0, line length 119) pass on
  `nemo/collections/asr/metrics/multitask.py`.

No regression test is included. A documentation key rename has no runtime behavior to assert; the
only testable form would be scraping `configs.rst` for the key inside the MultiTask Metrics section
and comparing it against the literal in `aed_multitask_models.py`, which would be brittle against any
reformatting of the `.rst` for very little benefit. Happy to add something along those lines if
maintainers would prefer it.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [x] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Fixes #16091
- Kept deliberately separate from the companion PR that corrects stale `_target_` paths in three
  example configs. That one changes shipped configs and adds instantiation tests; this one changes
  no behavior at all, so bundling them would have mixed two unrelated review questions.
- Separate, unrelated observation while verifying this, flagged rather than fixed here: the metric
  classes' keyword is `log_prediction` (`wer.py:231`, `bleu.py:111`) — which is what the docs example
  correctly uses — but the `MultiTaskMetric` docstring's YAML example (`multitask.py:202`) and the
  shipped `examples/asr/conf/speech_multitask/fast-conformer_aed.yaml:48` both spell it
  `log_predictions`. Global keys in the block are inherited by every sub-metric, and `WER.__init__`
  ends in a `**kwargs` that is never forwarded to `super().__init__`, so the plural form is accepted
  and discarded silently. Verified: building the shipped block succeeds, but the resulting metric has
  `log_prediction=True` (the default) and no `log_predictions` attribute at all. Harmless today
  because the config sets `true` and the default is already `True`; a user setting it to `false`
  would be ignored without warning. Out of scope for this PR.

