### PR TITLE
fix(asr): compute corpus cpWER with the per-speaker algorithm

### DIFF
--- a/nemo/collections/asr/metrics/cpwer.py
+++ b/nemo/collections/asr/metrics/cpwer.py
@@ -20,6 +20,7 @@ from kaldialign import edit_distance
 from scipy.optimize import linear_sum_assignment as scipy_linear_sum_assignment
 
 __all__ = [
+    'calculate_corpus_cpWER',
     'calculate_session_cpWER',
     'calculate_session_cpWER_bruteforce',
     'concat_perm_word_error_rate',
@@ -118,41 +119,7 @@ def calculate_session_cpWER(spk_hypothesis: List[str], spk_reference: List[str])
         ref_trans (str):
             Reference transcript in an arbitrary permutation. Words are separated by spaces.
     """
-    num_hyp = len(spk_hypothesis)
-    num_ref = len(spk_reference)
-
-    if num_hyp == 0 and num_ref == 0:
-        return 0.0, "", ""
-
-    num_speakers_padded = max(num_hyp, num_ref)
-
-    ref_word_lists = [
-        spk_reference[ref_idx].split() if ref_idx < num_ref else [] for ref_idx in range(num_speakers_padded)
-    ]
-    hyp_word_lists = [
-        spk_hypothesis[hyp_idx].split() if hyp_idx < num_hyp else [] for hyp_idx in range(num_speakers_padded)
-    ]
-
-    cost_matrix = np.zeros((num_speakers_padded, num_speakers_padded), dtype=np.float64)
-    for ref_idx in range(num_speakers_padded):
-        for hyp_idx in range(num_speakers_padded):
-            cost_matrix[ref_idx, hyp_idx] = edit_distance(ref_word_lists[ref_idx], hyp_word_lists[hyp_idx])['total']
-
-    row_ind, col_ind = scipy_linear_sum_assignment(cost_matrix)
-
-    total_errors = 0
-    total_ref_length = 0
-    hyp_texts = []
-    for ref_idx, hyp_idx in zip(row_ind, col_ind):
-        total_errors += int(cost_matrix[ref_idx, hyp_idx])
-        total_ref_length += len(ref_word_lists[ref_idx])
-        hyp_texts.append(spk_hypothesis[hyp_idx] if hyp_idx < num_hyp else "")
-
-    cpWER = total_errors / total_ref_length if total_ref_length > 0 else float('inf')
-
-    min_perm_hyp_trans = " ".join(hyp_texts)
-    ref_trans = " ".join(spk_reference)
-
+    cpWER, _, _, min_perm_hyp_trans, ref_trans = _calculate_session_cpWER_detail(spk_hypothesis, spk_reference)
     return cpWER, min_perm_hyp_trans, ref_trans
 
 
@@ -194,3 +161,112 @@ def concat_perm_word_error_rate(
         hyps_spk.append(min_hypothesis)
         refs_spk.append(concat_reference)
     return cpWER_values, hyps_spk, refs_spk
+
+
+def calculate_corpus_cpWER(
+    spk_hypotheses: List[List[str]], spk_references: List[List[str]]
+) -> Tuple[float, List[float]]:
+    """
+    Calculate a corpus-level cpWER over multiple sessions, matching MeetEval's corpus aggregation:
+    the errors and the reference word counts of every session are summed first, and the ratio is
+    taken once at the end.
+
+    Note that this is *not* the unweighted mean of the session cpWER values: longer sessions
+    contribute proportionally more, exactly as `word_error_rate` aggregates the regular WER over a
+    list of utterances. Each session is still scored per `(ref_speaker, hyp_speaker)` pair, so an
+    edit can never cross a speaker boundary.
+
+    Args:
+        spk_hypotheses (list):
+            List containing the lists of speaker-separated hypothesis transcripts.
+        spk_references (list):
+            List containing the lists of speaker-separated reference transcripts.
+
+    Returns:
+        corpus_cpWER (float):
+            Corpus-level cpWER value. `float('inf')` if the references contain no words at all.
+        cpWER_values (list):
+            List containing the cpWER value of each session, in input order.
+    """
+    if len(spk_hypotheses) != len(spk_references):
+        raise ValueError(
+            "In concatenated-minimum permutation word error rate calculation, "
+            "hypotheses and reference lists must have the same number of elements. But got arguments:"
+            f"{len(spk_hypotheses)} and {len(spk_references)} correspondingly"
+        )
+    corpus_errors, corpus_ref_length = 0, 0
+    cpWER_values = []
+    for spk_hypothesis, spk_reference in zip(spk_hypotheses, spk_references):
+        cpWER, session_errors, session_ref_length, _, _ = _calculate_session_cpWER_detail(
+            spk_hypothesis, spk_reference
+        )
+        corpus_errors += session_errors
+        corpus_ref_length += session_ref_length
+        cpWER_values.append(cpWER)
+    corpus_cpWER = corpus_errors / corpus_ref_length if corpus_ref_length > 0 else float('inf')
+    return corpus_cpWER, cpWER_values
+
+
+def _calculate_session_cpWER_detail(
+    spk_hypothesis: List[str], spk_reference: List[str]
+) -> Tuple[float, int, int, str, str]:
+    """
+    Score one session with MeetEval's cpWER algorithm and return the raw error and reference word
+    counts alongside the cpWER, so that callers can aggregate over sessions before dividing.
+
+    This is the single implementation of the algorithm described in `calculate_session_cpWER`.
+
+    Args:
+        spk_hypothesis (list):
+            List containing the hypothesis transcript for each speaker.
+        spk_reference (list):
+            List containing the reference transcript for each speaker.
+
+    Returns:
+        cpWER (float):
+            cpWER value for the given session.
+        total_errors (int):
+            Number of word-level edits under the optimal speaker assignment.
+        total_ref_length (int):
+            Number of reference words in the session.
+        min_perm_hyp_trans (str):
+            Hypothesis transcript containing the permutation that minimizes WER. Words are separated by spaces.
+        ref_trans (str):
+            Reference transcript in an arbitrary permutation. Words are separated by spaces.
+    """
+    num_hyp = len(spk_hypothesis)
+    num_ref = len(spk_reference)
+
+    if num_hyp == 0 and num_ref == 0:
+        return 0.0, 0, 0, "", ""
+
+    num_speakers_padded = max(num_hyp, num_ref)
+
+    ref_word_lists = [
+        spk_reference[ref_idx].split() if ref_idx < num_ref else [] for ref_idx in range(num_speakers_padded)
+    ]
+    hyp_word_lists = [
+        spk_hypothesis[hyp_idx].split() if hyp_idx < num_hyp else [] for hyp_idx in range(num_speakers_padded)
+    ]
+
+    cost_matrix = np.zeros((num_speakers_padded, num_speakers_padded), dtype=np.float64)
+    for ref_idx in range(num_speakers_padded):
+        for hyp_idx in range(num_speakers_padded):
+            cost_matrix[ref_idx, hyp_idx] = edit_distance(ref_word_lists[ref_idx], hyp_word_lists[hyp_idx])['total']
+
+    row_ind, col_ind = scipy_linear_sum_assignment(cost_matrix)
+
+    total_errors = 0
+    total_ref_length = 0
+    hyp_texts = []
+    for ref_idx, hyp_idx in zip(row_ind, col_ind):
+        total_errors += int(cost_matrix[ref_idx, hyp_idx])
+        total_ref_length += len(ref_word_lists[ref_idx])
+        hyp_texts.append(spk_hypothesis[hyp_idx] if hyp_idx < num_hyp else "")
+
+    cpWER = total_errors / total_ref_length if total_ref_length > 0 else float('inf')
+
+    min_perm_hyp_trans = " ".join(hyp_texts)
+    ref_trans = " ".join(spk_reference)
+
+    return cpWER, total_errors, total_ref_length, min_perm_hyp_trans, ref_trans

--- a/nemo/collections/asr/parts/utils/diarization_utils.py
+++ b/nemo/collections/asr/parts/utils/diarization_utils.py
@@ -29,7 +29,7 @@ import torch
 from lhotse import SupervisionSegment
 from omegaconf import OmegaConf
 
-from nemo.collections.asr.metrics.cpwer import calculate_session_cpWER, concat_perm_word_error_rate
+from nemo.collections.asr.metrics.cpwer import calculate_corpus_cpWER, calculate_session_cpWER
 from nemo.collections.asr.metrics.der import score_labels, score_labels_from_rttm_labels
 from nemo.collections.asr.metrics.wer import word_error_rate
 from nemo.collections.asr.models import ClusteringDiarizer
@@ -1560,11 +1560,15 @@ class OfflineDiarWithASR:
                 # Calculate session by session WER value
                 WER_values.append(word_error_rate([mix_hypothesis], [mix_reference]))
 
-            cpWER_values, hyps_spk, refs_spk = concat_perm_word_error_rate(spk_hypotheses, spk_references)
+            # The corpus cpWER is aggregated from the per-session error counts, the same way MeetEval
+            # reports it. Concatenating the per-speaker transcripts into one string and scoring that
+            # with `word_error_rate` would instead let edits cross speaker boundaries, undoing the
+            # per-(ref_speaker, hyp_speaker) scoring that cpWER is defined by.
+            average_cpWER, cpWER_values = calculate_corpus_cpWER(spk_hypotheses, spk_references)
 
             # Take an average of cpWER and regular WER value on all sessions
             wer_results['total'] = {}
-            wer_results['total']['average_cpWER'] = word_error_rate(hypotheses=hyps_spk, references=refs_spk)
+            wer_results['total']['average_cpWER'] = average_cpWER
             wer_results['total']['average_WER'] = word_error_rate(hypotheses=mix_hypotheses, references=mix_references)
 
             for uniq_id, cpWER, WER in zip(uniq_id_list, cpWER_values, WER_values):

--- a/tests/collections/speaker_tasks/utils/test_cpwer.py
+++ b/tests/collections/speaker_tasks/utils/test_cpwer.py
@@ -22,6 +22,7 @@ import pytest
 import torch
 
 from nemo.collections.asr.metrics.cpwer import (
+    calculate_corpus_cpWER,
     calculate_session_cpWER,
     calculate_session_cpWER_bruteforce,
     concat_perm_word_error_rate,
@@ -242,3 +243,93 @@ class TestConcatPermWordErrorRate:
     def test_length_mismatch_raises(self):
         with pytest.raises(ValueError):
             concat_perm_word_error_rate([["a"]], [["a"], ["b"]])
+
+
+def write_ctm(ctm_path, uniq_id, spk_texts):
+    """Write a minimal CTM file: `<uniq_id> <speaker> <start> <duration> <word>` per line."""
+    with open(ctm_path, "w") as ctm_file:
+        start_time = 0.0
+        for spk_idx, text in enumerate(spk_texts):
+            for word in text.split():
+                ctm_file.write(f"{uniq_id} speaker_{spk_idx} {start_time:.2f} 0.10 {word}\n")
+                start_time += 0.10
+
+
+class TestCorpusCpWER:
+    """Corpus-level cpWER aggregation: total errors over total reference words, as MeetEval reports it."""
+
+    @pytest.mark.unit
+    def test_corpus_cpwer_cross_boundary(self):
+        """A corpus of identical cross-boundary sessions aggregates to the session value, not to 0.0."""
+        hyps = [["the cat sat", "on"]] * 3
+        refs = [["the cat", "sat on"]] * 3
+        corpus_cpwer, cpwer_values = calculate_corpus_cpWER(hyps, refs)
+        assert_cpwer_equals(corpus_cpwer, 0.5)
+        assert all(abs(value - 0.5) < 1e-6 for value in cpwer_values)
+
+    @pytest.mark.unit
+    def test_corpus_cpwer_is_length_weighted(self):
+        """Sessions are weighted by reference length, matching how `word_error_rate` aggregates WER.
+
+        Session 1: errors=2, length=4 (cpWER=0.5). Session 2: errors=2, length=11 (cpWER=2/11).
+        Corpus: 4/15. An unweighted mean would give ~0.3409, and concatenating the per-speaker
+        transcripts before scoring would give 2/15.
+        """
+        hyps = [["the cat sat", "on"], ["z", "b c d e f g h i j x"]]
+        refs = [["the cat", "sat on"], ["a", "b c d e f g h i j k"]]
+        corpus_cpwer, cpwer_values = calculate_corpus_cpWER(hyps, refs)
+        assert_cpwer_equals(corpus_cpwer, 4 / 15)
+        assert_cpwer_equals(cpwer_values[0], 0.5)
+        assert_cpwer_equals(cpwer_values[1], 2 / 11)
+
+    @pytest.mark.unit
+    def test_corpus_cpwer_single_session_matches_session_cpwer(self):
+        hyp = ["alpha x", "gamma delta y", "zeta"]
+        ref = ["alpha beta", "gamma delta epsilon", "zeta"]
+        session_cpwer, _, _ = calculate_session_cpWER(hyp, ref)
+        corpus_cpwer, cpwer_values = calculate_corpus_cpWER([hyp], [ref])
+        assert_cpwer_equals(corpus_cpwer, session_cpwer)
+        assert_cpwer_equals(cpwer_values[0], session_cpwer)
+
+    @pytest.mark.unit
+    def test_corpus_cpwer_length_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            calculate_corpus_cpWER([["a"]], [["a"], ["b"]])
+
+    @pytest.mark.unit
+    def test_evaluate_corpus_cpwer_agrees_with_sessions(self, tmp_path):
+        """`OfflineDiarWithASR.evaluate` must report a corpus cpWER consistent with its session values.
+
+        Each session is the cross-boundary case pinned by `test_cross_boundary` (cpWER=0.5), so the
+        corpus value must also be 0.5. Concatenating the per-speaker transcripts and running plain
+        `word_error_rate` on them lets edits cross speaker boundaries again and yields 0.0.
+        """
+        # Imported inside the test: `diarization_utils` pulls in the ASR stack, which is far heavier
+        # than the rest of this module needs.
+        from nemo.collections.asr.parts.utils.diarization_utils import OfflineDiarWithASR
+
+        hyp_dir = tmp_path / "hyp"
+        hyp_dir.mkdir()
+        audio_file_list, ref_ctm_file_list, hyp_ctm_file_list = [], [], []
+        for session_idx in range(3):
+            uniq_id = f"session{session_idx}"
+            audio_path = tmp_path / f"{uniq_id}.wav"
+            audio_path.touch()
+            ref_ctm_path = tmp_path / f"{uniq_id}.ctm"
+            hyp_ctm_path = hyp_dir / f"{uniq_id}.ctm"
+            write_ctm(ref_ctm_path, uniq_id, ["the cat", "sat on"])
+            write_ctm(hyp_ctm_path, uniq_id, ["the cat sat", "on"])
+            audio_file_list.append(str(audio_path))
+            ref_ctm_file_list.append(str(ref_ctm_path))
+            hyp_ctm_file_list.append(str(hyp_ctm_path))
+
+        wer_results = OfflineDiarWithASR.evaluate(
+            audio_file_list=audio_file_list,
+            hyp_trans_info_dict=None,
+            hyp_ctm_file_list=hyp_ctm_file_list,
+            ref_ctm_file_list=ref_ctm_file_list,
+        )
+
+        for session_idx in range(3):
+            assert_cpwer_equals(wer_results[f"session{session_idx}"]["cpWER"], 0.5)
+        assert_cpwer_equals(wer_results["total"]["average_cpWER"], 0.5)


### PR DESCRIPTION

# What does this PR do ?

Fixes the corpus-level `average_cpWER` reported by `OfflineDiarWithASR.evaluate()`, which still used
the pre-MeetEval concatenation algorithm that #15573 replaced and therefore contradicted the
per-session cpWER values printed beside it.

Fixes #16093

**Collection**: ASR (speaker tasks / diarization metrics)

# Changelog

- `nemo/collections/asr/parts/utils/diarization_utils.py`: `OfflineDiarWithASR.evaluate` no longer
  computes `wer_results['total']['average_cpWER']` by running `word_error_rate` over the
  space-joined per-speaker transcripts returned by `concat_perm_word_error_rate`. It now calls the
  new `calculate_corpus_cpWER`.
- `nemo/collections/asr/metrics/cpwer.py`: added `calculate_corpus_cpWER`, which aggregates the
  per-session `(errors, reference words)` counts and divides once, returning the corpus cpWER
  together with the per-session cpWER values it computes along the way.
- `nemo/collections/asr/metrics/cpwer.py`: factored the session scoring into a single private helper
  `_calculate_session_cpWER_detail`, which also returns the raw error/reference counts that
  `calculate_session_cpWER` previously computed and discarded. `calculate_session_cpWER` is now a
  thin wrapper over it — its signature and behavior are unchanged.
- `tests/collections/speaker_tasks/utils/test_cpwer.py`: added `TestCorpusCpWER` (5 tests), including
  a regression test that drives `OfflineDiarWithASR.evaluate()` end to end.

Public API of `calculate_session_cpWER`, `calculate_session_cpWER_bruteforce` and
`concat_perm_word_error_rate` is unchanged, so the diarization tutorial that unpacks
`concat_perm_word_error_rate`'s 3-tuple keeps working.

# The bug

#15573 ("[Fix] Make cpWER calculation identical to meeteval") made cpWER score each
`(ref_speaker, hyp_speaker)` pair independently, so an edit can no longer cross a speaker boundary.
It changed `nemo/collections/asr/metrics/der.py` and its tests, but not
`nemo/collections/asr/parts/utils/diarization_utils.py`, which was left computing the corpus figure
the old way:

```python
cpWER_values, hyps_spk, refs_spk = concat_perm_word_error_rate(spk_hypotheses, spk_references)
wer_results['total']['average_cpWER'] = word_error_rate(hypotheses=hyps_spk, references=refs_spk)
```

`hyps_spk` / `refs_spk` are the per-speaker transcripts joined into a single string
(`cpwer.py:153-154`), so scoring them with plain `word_error_rate` lets edits cross speaker
boundaries again — exactly the algorithm #15573 removed.

That number is user-facing: `print_errors` prints it under the label `cpWER` and
`write_session_level_result_in_csv` writes it to the results CSV. It is reachable from
`examples/speaker_tasks/diarization/clustering_diarizer/offline_diar_with_asr_infer.py`,
`scripts/speaker_tasks/eval_diar_with_asr.py`, and
`tutorials/speaker_tasks/ASR_with_SpeakerDiarization.ipynb`.

# Usage

Before this PR, three sessions each scoring cpWER 0.5 aggregated to a corpus cpWER of 0.0 — the
exact value #15573's description cites as the bug it fixed:

```python
import os, tempfile
from nemo.collections.asr.parts.utils.diarization_utils import OfflineDiarWithASR

# CTM columns: <uniq_id> <speaker> <start> <duration> <word>
def write_ctm(path, uniq_id, spk_texts):
    with open(path, "w") as f:
        t = 0.0
        for spk_idx, text in enumerate(spk_texts):
            for w in text.split():
                f.write(f"{uniq_id} speaker_{spk_idx} {t:.2f} 0.10 {w}\n")
                t += 0.10

tmp = tempfile.mkdtemp()
hypdir = os.path.join(tmp, "hyp"); os.makedirs(hypdir)
audio_file_list, ref_ctms, hyp_ctms = [], [], []
for i in range(3):
    uid = f"sess{i}"
    audio = os.path.join(tmp, f"{uid}.wav"); open(audio, "w").close()
    ref = os.path.join(tmp, f"{uid}.ctm"); hyp = os.path.join(hypdir, f"{uid}.ctm")
    write_ctm(ref, uid, ["the cat", "sat on"])
    write_ctm(hyp, uid, ["the cat sat", "on"])
    audio_file_list.append(audio); ref_ctms.append(ref); hyp_ctms.append(hyp)

wer_results = OfflineDiarWithASR.evaluate(
    audio_file_list=audio_file_list, hyp_trans_info_dict=None,
    hyp_ctm_file_list=hyp_ctms, ref_ctm_file_list=ref_ctms,
)
for k in sorted(wer_results):
    print(k, "->", wer_results[k])
```

Before:

```
sess0 -> {'cpWER': 0.5, 'WER': 0.0}
sess1 -> {'cpWER': 0.5, 'WER': 0.0}
sess2 -> {'cpWER': 0.5, 'WER': 0.0}
total -> {'average_cpWER': 0.0, 'average_WER': 0.0}
```

After:

```
sess0 -> {'cpWER': 0.5, 'WER': 0.0}
sess1 -> {'cpWER': 0.5, 'WER': 0.0}
sess2 -> {'cpWER': 0.5, 'WER': 0.0}
total -> {'average_cpWER': 0.5, 'average_WER': 0.0}
```

# On how sessions are weighted

The corpus value is the total error count over the total reference word count, not the unweighted
mean of the session cpWER values. Two things pin that choice:

- It is MeetEval's corpus aggregation, and the direct extension of the per-session definition
  (`sum(errors) / sum(ref_word_counts)`) to multiple sessions.
- It matches the metric printed beside it. `average_WER` is `word_error_rate(...)` over the session
  list, and `word_error_rate` accumulates `scores` and `words` across the whole list before dividing
  (`nemo/collections/asr/metrics/wer.py:35-71`) — it is already length-weighted. Aggregating cpWER
  differently would have the two numbers on adjacent lines use different rules.

`test_corpus_cpwer_is_length_weighted` pins this: sessions at cpWER 0.5 (4 reference words) and 2/11
(11 reference words) give a corpus cpWER of 4/15. That expected value distinguishes the correct
result from both the old concatenation behavior (2/15) and an unweighted mean (~0.3409).

Summing counts, rather than length-weighting the ratios, is also better behaved at the edges: a
session with an empty reference has cpWER `inf`, which would poison a weighted average, while
summing counts folds its insertions into the numerator the way MeetEval does.

# Tests

`tests/collections/speaker_tasks/utils/test_cpwer.py::TestCorpusCpWER`:

- `test_evaluate_corpus_cpwer_agrees_with_sessions` — drives `OfflineDiarWithASR.evaluate()` with
  CTM files for three cross-boundary sessions and asserts the corpus value matches the session
  values. This is the regression test: it fails on `main` with
  `cpWER mismatch: actual=0.00000000, expected=0.50000000` and passes with this change.
- `test_corpus_cpwer_cross_boundary` — a corpus of cross-boundary sessions aggregates to 0.5, not 0.0.
- `test_corpus_cpwer_is_length_weighted` — pins 4/15 as described above.
- `test_corpus_cpwer_single_session_matches_session_cpwer`
- `test_corpus_cpwer_length_mismatch_raises`

```
$ pytest tests/collections/speaker_tasks/utils/test_cpwer.py -q
32 passed

$ pytest tests/collections/speaker_tasks/utils/test_cpwer.py \
         tests/collections/speaker_tasks/utils/test_der.py \
         tests/collections/speaker_tasks/test_diar_metrics.py -q
169 passed
```

The 27 pre-existing cpWER tests pass unchanged, which is what pins the refactor of
`calculate_session_cpWER` into a wrapper as behavior-preserving.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? (docstrings for the new/changed functions)
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

# Additional Information

- Related to #16093
- Follow-up to #15573, which introduced the MeetEval cpWER semantics but did not update the
  corpus-level aggregation in `diarization_utils.py`.
