### PR TITLE
fix(asr): keep TDT token durations under advance_mask in batched greedy decoding

### DIFF
--- a/nemo/collections/asr/parts/submodules/transducer_decoding/tdt_label_looping.py
+++ b/nemo/collections/asr/parts/submodules/transducer_decoding/tdt_label_looping.py
@@ -533,7 +533,10 @@ class GreedyBatchedTDTLabelLoopingComputer(GreedyBatchedLabelLoopingComputerBase
                 # same as: scores[advance_mask] = more_scores[advance_mask], but non-blocking
                 torch.where(advance_mask, more_scores, scores, out=scores)
                 jump_durations_indices = logits[:, -num_durations:].argmax(dim=-1)
-                durations = model_durations[jump_durations_indices]
+                more_durations = model_durations[jump_durations_indices]
+                # same as: durations[advance_mask] = more_durations[advance_mask], but non-blocking;
+                # elements that already found a non-blank label must keep the duration predicted with it
+                torch.where(advance_mask, more_durations, durations, out=durations)
 
                 if self.record_all_steps:
                     batched_hyps.add_results_masked_(

--- a/tests/collections/asr/decoding/test_rnnt_decoding.py
+++ b/tests/collections/asr/decoding/test_rnnt_decoding.py
@@ -69,7 +69,14 @@ def get_rnnt_decoder(vocab_size, decoder_output_size=4):
 
 
 @lru_cache(maxsize=2)
-def get_rnnt_joint(vocab_size, vocabulary=None, encoder_output_size=4, decoder_output_size=4, joint_output_shape=4):
+def get_rnnt_joint(
+    vocab_size,
+    vocabulary=None,
+    encoder_output_size=4,
+    decoder_output_size=4,
+    joint_output_shape=4,
+    num_extra_outputs=0,
+):
     jointnet_cfg = {
         'encoder_hidden': encoder_output_size,
         'pred_hidden': decoder_output_size,
@@ -77,7 +84,7 @@ def get_rnnt_joint(vocab_size, vocabulary=None, encoder_output_size=4, decoder_o
         'activation': 'relu',
     }
     torch.manual_seed(0)
-    joint = RNNTJoint(jointnet_cfg, vocab_size, vocabulary=vocabulary)
+    joint = RNNTJoint(jointnet_cfg, vocab_size, vocabulary=vocabulary, num_extra_outputs=num_extra_outputs)
     joint.freeze()
     return joint
 
@@ -519,6 +526,49 @@ class TestRNNTDecoding:
             boosting_tree=boosting_tree,
             enable_per_stream_biasing=enable_per_stream_biasing,
         )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("max_symbols_per_step", [1, 10])
+    def test_tdt_greedy_batched_token_duration_is_batch_invariant(self, max_symbols_per_step: int):
+        """Decoding an utterance alone must give the same token durations as decoding it in a batch.
+
+        `token_duration` is turned into the TDT end timestamp by `RNNTDecoding._compute_offsets_tdt`
+        (`end_offset = start_offset + token_duration`), so a batch-dependent duration means
+        batch-dependent end timestamps.
+        """
+        vocab = char_vocabulary()[:3]
+        durations = [0, 1, 2, 4]
+        decoder = get_rnnt_decoder(vocab_size=len(vocab))
+        joint = get_rnnt_joint(vocab_size=len(vocab), num_extra_outputs=len(durations))
+
+        generator = torch.Generator().manual_seed(37)
+        encoder_output = torch.randn(4, 4, 12, generator=generator)
+        encoded_lengths = torch.tensor([12, 4, 9, 5], dtype=torch.int32)
+
+        def decode(encoder_output, encoded_lengths):
+            decoding_algo = greedy_decode.GreedyBatchedTDTInfer(
+                decoder,
+                joint,
+                blank_index=len(vocab),
+                durations=durations,
+                max_symbols_per_step=max_symbols_per_step,
+                include_duration=True,
+                use_cuda_graph_decoder=False,
+            )
+            with torch.no_grad():
+                return decoding_algo(encoder_output=encoder_output, encoded_lengths=encoded_lengths)[0]
+
+        batched_hyps = decode(encoder_output, encoded_lengths)
+
+        for i, batched_hyp in enumerate(batched_hyps):
+            length = encoded_lengths[i : i + 1]
+            alone_hyp = decode(encoder_output[i : i + 1, :, : int(length)], length)[0]
+
+            assert torch.equal(alone_hyp.y_sequence, batched_hyp.y_sequence), f"tokens differ for utterance {i}"
+            assert torch.equal(alone_hyp.timestamp, batched_hyp.timestamp), f"timestamps differ for utterance {i}"
+            assert torch.equal(
+                alone_hyp.token_duration, batched_hyp.token_duration
+            ), f"token durations differ for utterance {i}: {alone_hyp.token_duration} vs {batched_hyp.token_duration}"
 
     @pytest.mark.skipif(
         not NUMBA_RNNT_LOSS_AVAILABLE,


### PR DESCRIPTION

# What does this PR do ?

Fixes #16097 — batched TDT greedy decoding records a stale `token_duration`, which makes TDT end
timestamps depend on which other utterances share the batch.

**Collection**: ASR

# Changelog

- `GreedyBatchedTDTLabelLoopingComputer.torch_impl`: write the newly predicted durations back only
  under `advance_mask`, mirroring the CUDA graph implementation of the same algorithm.
- Add a CPU-only regression test asserting that decoding an utterance alone and decoding it inside a
  batch give the same `token_duration`.
- Widen the existing `get_rnnt_joint` test helper with `num_extra_outputs` so it can build a TDT joint.

# Problem

In the stage 1.2 inner loop of `torch_impl`, `labels` and `scores` are carefully written back only
for the elements that are still searching for a non-blank label:

```python
torch.where(advance_mask, more_labels, labels, out=labels)     # line 532
torch.where(advance_mask, more_scores, scores, out=scores)     # line 534
```

but `durations` is rebound for the **whole batch** on every iteration:

```python
jump_durations_indices = logits[:, -num_durations:].argmax(dim=-1)   # line 535
durations = model_durations[jump_durations_indices]                  # line 536
```

Stage 2 then stores `token_durations=durations` (line 575) for every utterance in `found_labels_mask`,
including those that found their label in an earlier iteration — whose duration has since been
overwritten by a joint evaluation taken at a later encoder frame. The inner loop only iterates while
some *other* utterance is still searching, so the corruption depends on batch composition.

`token_duration` is the TDT end timestamp:

- `rnnt_decoding.py:341` — `tdt_include_token_duration = tdt_include_token_duration or compute_timestamps`,
  so asking for timestamps enables the field automatically.
- `rnnt_decoding.py:1203-1207` — `_compute_offsets_tdt` builds `end_offset = start_offset + token_duration`.

Affects the `torch_impl` path only: CPU decoding, `use_cuda_graph_decoder=False`, missing CUDA
conditional-node support, and validation decoding while CUDA graphs are disabled
(`WithOptionalCudaGraphs.disable_cuda_graphs`); dispatch at `label_looping_base.py:320-335`.

# Solution

The CUDA graph implementation of this exact algorithm already guards the write-back, in
`_inner_loop_step_find_next_non_blank` (line 1352 of the same file):

```python
torch.where(self.state.advance_mask, more_durations, self.state.durations, out=self.state.durations)
```

This PR applies the same guard, with the same `more_*` naming already used for `more_labels` /
`more_scores` a few lines above, so `torch_impl` and the CUDA graph path agree:

```python
 jump_durations_indices = logits[:, -num_durations:].argmax(dim=-1)
-durations = model_durations[jump_durations_indices]
+more_durations = model_durations[jump_durations_indices]
+torch.where(advance_mask, more_durations, durations, out=durations)
```

`durations` is created by advanced indexing at line 460 and is already mutated in place by
`masked_fill_`, so writing into it with `out=` is safe.

The guard is placed immediately after the labels/scores write-backs rather than after the
`time_indices` update, so that everything downstream in the loop (`masked_fill_`, the `time_indices`
advance, and the `record_all_steps` call) keeps reading exactly the values it reads today for the
elements it applies to. The change is therefore confined to what is stored for utterances that are
*not* advancing.

# Verification

CPU-only, no downloads. Same utterance decoded alone vs inside a batch of 4, with the same model:

Before:

```
utt 0 : alone tokens=[1, 1] ts=[0, 7] token_duration=[1, 1] | in batch token_duration=[4, 1]
utt 1 : alone tokens=[1]    ts=[0]    token_duration=[1]    | in batch token_duration=[4]
utt 2 : alone tokens=[1, 1] ts=[0, 1] token_duration=[1, 1] | in batch token_duration=[1, 4]
-> _compute_offsets_tdt end_offsets: [1, 8] / [1] / [1, 2] alone, [4, 8] / [4] / [1, 5] in batch
3 of 4 utterances batch-composition dependent
```

After: `0 of 4`. Tokens and start timestamps were identical throughout, before and after.

The batch-of-1 answer is the correct one. Evaluating the joint directly at frame 0 with the SOS state
for utterance 1 gives duration logits `[-2.2482, -1.7770, -2.2816, -2.0268]` -> index 1 -> duration 1,
which is what the batch-of-1 decode reports and the batch-of-4 decode does not.

The new test fails on `main` and passes with this change:

```
# before the fix
FAILED tests/collections/asr/decoding/test_rnnt_decoding.py::TestRNNTDecoding::test_tdt_greedy_batched_token_duration_is_batch_invariant[1]
FAILED tests/collections/asr/decoding/test_rnnt_decoding.py::TestRNNTDecoding::test_tdt_greedy_batched_token_duration_is_batch_invariant[10]
AssertionError: token durations differ for utterance 0: tensor([2, 2]) vs tensor([2, 4])
2 failed, 52 deselected

# after the fix
2 passed, 52 deselected
```

`preserve_alignments=True` and `preserve_frame_confidence=True` were also checked and produce the
same corrected, batch-invariant durations.

# Related

PR #14912 ("Fix TDT beam search timestamp alignment") is related but distinct: it is about the
**beam search** path (`BatchedBeamHyps` never populating `token_duration`, plus START/END timestamp
semantics), and touches `rnnt_decoding.py` / `batched_beam_decoding_utils.py`. This PR is in the
greedy batched `torch_impl` in `tdt_label_looping.py`, which populates the field but populates it
with a stale value. The two do not overlap and should not conflict.

# GitHub Actions CI

Trusted PRs run automatically through copy-pr-bot. For an untrusted PR, a maintainer can trigger CI by commenting
`/ok to test <head-sha>`; repeat this after a new push if the PR remains untrusted.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

# Additional Information

- Related to #16097

