### PR TITLE
fix(lhotse): seed the RIR augmentation from shard_seed, matching its sibling transforms

### DIFF
--- a/nemo/collections/common/data/lhotse/dataloader.py
+++ b/nemo/collections/common/data/lhotse/dataloader.py
@@ -1013,7 +1013,13 @@ def get_lhotse_sampler_from_config(config, global_rank, world_size, tokenizer=No
             ReverbWithImpulseResponse(
                 rir_recordings=RecordingSet.from_file(config.rir_path) if config.rir_path is not None else None,
                 p=config.rir_prob,
-                randgen=random.Random(config.seed),
+                # ``ReverbWithImpulseResponse`` takes a pre-built ``random.Random`` rather than a
+                # ``seed`` argument, so resolve ``shard_seed`` here to give every rank/worker its
+                # own RIR randomness. This mirrors what the sibling augmentations above and below
+                # do internally with ``seed=config.shard_seed``. Using ``config.seed`` would make
+                # every rank draw the same impulse responses, because it is resolved to a fixed
+                # integer before the sampler is built.
+                randgen=random.Random(resolve_seed(config.shard_seed)),
             )
         )
 

--- a/nemo/collections/common/data/lhotse/dataloader.py
+++ b/nemo/collections/common/data/lhotse/dataloader.py
@@ -1014,7 +1014,7 @@ def get_lhotse_sampler_from_config(config, global_rank, world_size, tokenizer=No
                 rir_recordings=RecordingSet.from_file(config.rir_path) if config.rir_path is not None else None,
                 p=config.rir_prob,
                 # ``ReverbWithImpulseResponse`` takes a pre-built ``random.Random`` rather than a
-                # ``seed`` argument, so resolve ``shard_seed`` here to give every rank/worker its
+                # ``seed`` argument, so resolve ``shard_seed`` here to give every rank its
                 # own RIR randomness. This mirrors what the sibling augmentations above and below
                 # do internally with ``seed=config.shard_seed``. Using ``config.seed`` would make
                 # every rank draw the same impulse responses, because it is resolved to a fixed

--- a/tests/collections/common/test_lhotse_multirank_rng.py
+++ b/tests/collections/common/test_lhotse_multirank_rng.py
@@ -201,3 +201,68 @@ def test_dataloader_multiple_ranks_trng(nemo_tarred_manifest_path: tuple[str, st
     assert b0_batches != b1_batches
     assert b0_incrseed_batches != b1_batches
     assert b0_batches != b0_incrseed_batches
+
+
+def _find_transform(sampler, cls):
+    """Return the first sampler-level transform of type ``cls`` (they are attached via ``sampler.map``)."""
+    matches = [t for t in sampler._transforms if isinstance(t, cls)]
+    assert matches, f"{cls.__name__} was not attached to the sampler; transforms={sampler._transforms}"
+    return matches[0]
+
+
+def _rir_dataloader(cutset_path: Path, rank: int, shard_seed):
+    config = OmegaConf.create(
+        {
+            "cuts_path": str(cutset_path),
+            "sample_rate": 16000,
+            "use_lhotse": True,
+            "num_workers": 0,
+            "batch_size": 2,
+            "seed": 0,
+            "shard_seed": shard_seed,
+            # RIR is the transform under test; lowpass is a sibling used as a control.
+            "rir_enabled": True,
+            "rir_prob": 0.5,
+            "lowpass_enabled": True,
+            "lowpass_prob": 0.5,
+        }
+    )
+    return get_lhotse_dataloader_from_config(config=config, global_rank=rank, world_size=2, dataset=_Identity())
+
+
+def test_rir_augmentation_rng_differs_across_ranks(cutset_path: Path):
+    """RIR augmentation must draw its randomness from ``shard_seed``, like every other online
+    augmentation attached to the sampler.
+
+    ``seed`` is resolved to a concrete integer before the sampler is built, so it is bit-identical
+    on every data-parallel rank; ``shard_seed`` defaults to ``"trng"`` and is resolved per process.
+    Seeding the RIR transform from ``seed`` therefore made every rank apply the same reverberation
+    coin flips and pick the same impulse responses, silently collapsing RIR augmentation diversity.
+    """
+    from lhotse.dataset import LowpassUsingResampling, ReverbWithImpulseResponse
+
+    dl0 = _rir_dataloader(cutset_path, rank=0, shard_seed="trng")
+    dl1 = _rir_dataloader(cutset_path, rank=1, shard_seed="trng")
+
+    rir0 = _find_transform(dl0.sampler, ReverbWithImpulseResponse)
+    rir1 = _find_transform(dl1.sampler, ReverbWithImpulseResponse)
+    assert [rir0.random.random() for _ in range(32)] != [rir1.random.random() for _ in range(32)]
+
+    # Control: a sibling augmentation that already used ``shard_seed`` differentiates the same way,
+    # so the assertion above is testing the seed source and not the harness.
+    lowpass0 = _find_transform(dl0.sampler, LowpassUsingResampling)
+    lowpass1 = _find_transform(dl1.sampler, LowpassUsingResampling)
+    assert [lowpass0.rng.random() for _ in range(32)] != [lowpass1.rng.random() for _ in range(32)]
+
+
+def test_rir_augmentation_rng_reproducible_with_fixed_shard_seed(cutset_path: Path):
+    """Counterpart to the test above: an explicit integer ``shard_seed`` must still give every rank
+    the same RIR randomness, so that fully reproducible runs remain possible."""
+    from lhotse.dataset import ReverbWithImpulseResponse
+
+    dl0 = _rir_dataloader(cutset_path, rank=0, shard_seed=1234)
+    dl1 = _rir_dataloader(cutset_path, rank=1, shard_seed=1234)
+
+    rir0 = _find_transform(dl0.sampler, ReverbWithImpulseResponse)
+    rir1 = _find_transform(dl1.sampler, ReverbWithImpulseResponse)
+    assert [rir0.random.random() for _ in range(32)] == [rir1.random.random() for _ in range(32)]


### PR DESCRIPTION
# What does this PR do ?

Seeds the Lhotse RIR augmentation from `shard_seed` instead of `seed`, so that
data-parallel ranks stop drawing bit-identical reverberation decisions and impulse
responses.

Fixes #16100.

**Collection**: common (ASR, Audio, speechlm2 — anything using the Lhotse dataloader
with `rir_enabled: true`)

## The problem

`get_lhotse_sampler_from_config` built the RIR transform with
`randgen=random.Random(config.seed)` (`nemo/collections/common/data/lhotse/dataloader.py:1016`).
`config.seed` is resolved to a concrete integer *before* the sampler is built
(`config.seed = resolve_seed(config.seed)`, `:584`, and `:678` for the multi-config
entry point), so it is bit-identical on every rank.

Every sibling augmentation attached to the same sampler already uses
`seed=config.shard_seed` — the noise mix (`:861`), `LowpassUsingResampling` (`:995`),
`ClippingTransform` (`:1007`) and `Compress` (`:1032`). `shard_seed` defaults to
`"trng"` and is resolved inside each process, which is what differentiates ranks.

Result: each rank applied the same reverb coin-flip sequence and picked the same
impulse response for the n-th cut it saw. DDP sharding itself was fine — each rank
still got a different subset of cuts — but the augmentation *decision sequence* was
duplicated across the whole job. Nothing errored; the only symptom was weaker
augmentation than the config implied.

# Changelog

- `nemo/collections/common/data/lhotse/dataloader.py`: pass
  `randgen=random.Random(resolve_seed(config.shard_seed))` to
  `ReverbWithImpulseResponse`, with a comment explaining why the resolution happens
  at the call site.
- `tests/collections/common/test_lhotse_multirank_rng.py`: two regression tests.

## Why `resolve_seed(...)` rather than `seed=config.shard_seed`

`lhotse.dataset.ReverbWithImpulseResponse` (the CutSet-level transform imported
here — distinct from the same-named `lhotse.augmentation` AudioTransform) takes only
`randgen: random.Random` and has no `seed` parameter, so passing `seed=` would raise
`TypeError`. The sibling transforms accept `seed` and then do
`self.rng = random.Random(resolve_seed(self.seed))` in `__post_init__`; this change
performs that same step at the call site. `resolve_seed` was already imported in this
module.

# Usage

```yaml
# Any Lhotse dataloader config with RIR augmentation enabled; no config change is required.
rir_enabled: true
rir_path: /path/to/rir_cuts.jsonl.gz
shard_seed: trng      # the default
```

With this change each data-parallel rank draws its own reverberation decisions and impulse
responses under the default `shard_seed`. An explicit integer `shard_seed` keeps every rank
identical, exactly as before.

## Backwards compatibility

With an explicit integer `shard_seed`, `resolve_seed(n) == n`, so every rank still
shares the RNG and fully reproducible runs are unaffected. The existing
`test_dataloader_with_synth_rir` (`tests/collections/common/test_lhotse_dataloading.py`,
`shard_seed: 0`) keeps its exact expectations about which cuts get reverberated and
passes unchanged.

**Scope.** This differentiates ranks under the default `shard_seed="trng"`. With
`shard_seed="randomized"` the RIR RNG stays identical across ranks, because
`resolve_seed("randomized")` only returns a per-rank/per-worker value inside a dataloader
worker, and these sampler-level `.map` transforms are constructed in the main process.
That limitation is pre-existing and shared with `LowpassUsingResampling`,
`ClippingTransform` and `Compress`; this change brings the RIR transform to parity with
them rather than fixing it, and the remaining gap is worth a separate issue.

## Tests

`tests/collections/common/test_lhotse_multirank_rng.py`:

- `test_rir_augmentation_rng_differs_across_ranks` — builds rank-0 and rank-1
  dataloaders under the default `shard_seed="trng"` and asserts the RIR RNG streams
  differ. **This test fails on `main`**, where both ranks produce the
  `random.Random(0)` stream (`0.8444218515250481, 0.7579544029403025, ...`). It also
  asserts the same for the sibling `LowpassUsingResampling` as a control, so the
  assertion is testing the seed source rather than the harness.
- `test_rir_augmentation_rng_reproducible_with_fixed_shard_seed` — asserts an
  explicit integer `shard_seed` still gives both ranks identical RIR randomness.
  This one passes both before and after; it is a guard against a future change that
  makes RIR unconditionally random and breaks reproducible runs.

## Checks run

```
pytest tests/collections/common/test_lhotse_multirank_rng.py      -> 4 passed
pytest tests/collections/common/test_lhotse_dataloading.py        -> 67 passed, 1 skipped
pytest tests/collections/common/ -k lhotse                        -> 279 passed, 1 skipped
git diff --check                                                  -> clean
```

Environment: Python 3.10.18, PyTorch 2.12.0, lhotse 2.0.0a3, CPU only.

## Documentation

No documentation change. `docs/source/dataloaders.rst` already documents
`shard_seed` as the knob controlling per-rank/per-worker randomness; this change
makes the RIR transform conform to that documented contract rather than altering it.

One thing I deliberately left alone: that section describes `shard_seed` only in
terms of *shard* randomization and does not mention that it also seeds the online
augmentation RNGs. That gap predates this change — the on-the-fly noise mix has been
seeded from `shard_seed` since well before the clipping/lowpass/codec augmentations were
added in #14809 — so I kept it out of scope; happy to add a clarifying sentence here if
you'd prefer it in this PR.

## Related

Open PR #14322 ("Flexible augmentation config for Lhotse dataloaders") relocates this
block into a new `augment.py` and carries the `config.seed` line across unchanged.
Its new `ReverbRIR` dataclass, however, already does
`rng = random.Random(resolve_seed(self.seed))` with `seed: int | str = "trng"` — the
same behaviour this PR gives the current default path. If #14322 lands first, this
change should be applied to the moved line; I'm happy to rebase either way.

# GitHub Actions CI

Trusted PRs run automatically through copy-pr-bot. For an untrusted PR, a maintainer can trigger CI by commenting
`/ok to test <head-sha>`; repeat this after a new push if the PR remains untrusted.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? (N/A — see Documentation above)
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.

# Additional Information

- Fixes #16100
- Related open PR #14322 ("Flexible augmentation config for Lhotse dataloaders") relocates the changed block; see "Related" above.

