### PR TITLE
fix(core): make save_adapters/load_adapters round-trip

### DIFF
--- a/nemo/core/classes/mixins/adapter_mixins.py
+++ b/nemo/core/classes/mixins/adapter_mixins.py
@@ -918,9 +918,14 @@ class AdapterModelPTMixin(AdapterModuleMixin):
                             # inside of the state dict.
                             # It will be normalized in the corresponding `load_adapters()` call.
                             adapter_state_dict = module.adapter_layer.state_dict()
+                            # `adapter_layer` is a ModuleDict holding every adapter of this module,
+                            # so its keys are `<some adapter name>.<...>`. Match on the exact
+                            # `<adapter_name>.` prefix - a substring test would also pick up any
+                            # adapter whose name merely contains `adapter_name`.
+                            adapter_key_prefix = f'{adapter_name}.'
                             state_dict = {}
                             for k, v in adapter_state_dict.items():
-                                if adapter_name in k:
+                                if k.startswith(adapter_key_prefix):
                                     state_dict[k] = v
 
                             output_dict[key].append(state_dict)
@@ -1038,12 +1043,15 @@ class AdapterModelPTMixin(AdapterModuleMixin):
             for state, module in zip(adapter_state, modules_to_load):
                 # Note that state is a list of multiple state dicts for 1:1 Module mapping.
                 # However, the state_dict keys are of the form `adapter_name.<module hierarchy with dots>`.
-                # We therefore strip the `adapter_name.` part of the state dict
+                # We therefore strip the leading `adapter_name.` prefix of the state dict
                 # And then directly load each module with its 1:1 state dict.
+                # Only the exact prefix is matched/stripped, so keys belonging to another adapter
+                # whose name contains `adapter_name` are neither picked up nor mangled.
+                adapter_key_prefix = f'{adapter_name}.'
                 sub_dict = {}
                 for k, v in state.items():
-                    if adapter_name in k:
-                        k_ = k.replace(f"{adapter_name}.", "")
+                    if k.startswith(adapter_key_prefix):
+                        k_ = k[len(adapter_key_prefix) :]
                         sub_dict[k_] = v
 
                 module.load_state_dict(sub_dict, strict=strict)

--- a/nemo/core/classes/mixins/adapter_mixins.py
+++ b/nemo/core/classes/mixins/adapter_mixins.py
@@ -970,7 +970,10 @@ class AdapterModelPTMixin(AdapterModuleMixin):
             name = [name]
 
         if name is None:
-            name = list(config.keys())
+            # Restore exactly the adapters that this file contains. `config` is the *source model's*
+            # entire adapter config, which is a superset of the file whenever `save_adapters` was
+            # called with an explicit `name`, so it cannot be used to derive the list to restore.
+            name = list(state_dict.keys())
 
         # For all module:adapter names (note, for global modules, we ignore the module: part)
         for module_adapter_name in name:

--- a/tests/core/mixins/adapters/test_adapter_model_mixin.py
+++ b/tests/core/mixins/adapters/test_adapter_model_mixin.py
@@ -1141,6 +1141,40 @@ class TestAdapterModelMixin:
             assert (original_state_dict[ogkey] - restored_state_dict[newkey]).abs().mean() < 1e-6
 
     @pytest.mark.unit
+    def test_save_adapter_subset_then_load_with_default_name(self, monkeypatch):
+        # `load_adapters(filepath)` with the default `name=None` must restore exactly the
+        # adapters the file contains, even when the source model had more adapters than were
+        # saved. Otherwise the documented "share just the adapter module" workflow is unusable.
+        monkeypatch.setenv('TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD', '1')  # see load_adapters() docstring
+
+        cfg = get_model_config(in_features=50)
+        model = DefaultAdapterModel(cfg)
+
+        model.add_adapter(name='encoder:adapter_0', cfg=get_adapter_cfg(dim=5))
+        model.add_adapter(name='encoder:adapter_1', cfg=get_adapter_cfg(dim=5))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adapter_path = os.path.join(tmpdir, 'temp.pt')
+
+            # Save only one of the two adapters
+            model.save_adapters(adapter_path, name='encoder:adapter_0')
+
+            # Restore with the default `name=None`
+            new_model = DefaultAdapterModel(cfg)
+            new_model.load_adapters(adapter_path)
+
+        # Only the saved adapter must have been restored
+        assert new_model.get_enabled_adapters() == ['adapter_0']
+        assert new_model.decoder.is_adapter_available() is False
+
+        original_state_dict = model.encoder.get_adapter_module('adapter_0').state_dict()
+        restored_state_dict = new_model.encoder.get_adapter_module('adapter_0').state_dict()
+
+        assert set(original_state_dict.keys()) == set(restored_state_dict.keys())
+        for key in original_state_dict:
+            assert (original_state_dict[key] - restored_state_dict[key]).abs().mean() < 1e-6
+
+    @pytest.mark.unit
     def test_single_decoder_save_load_adapter_only_partial_name(self):
         # create a model config, but do not add global_cfg to it
         # we want to test just module level adapter

--- a/tests/core/mixins/adapters/test_adapter_model_mixin.py
+++ b/tests/core/mixins/adapters/test_adapter_model_mixin.py
@@ -1175,6 +1175,42 @@ class TestAdapterModelMixin:
             assert (original_state_dict[key] - restored_state_dict[key]).abs().mean() < 1e-6
 
     @pytest.mark.unit
+    def test_save_load_adapter_with_name_that_is_prefix_of_another(self, monkeypatch):
+        # Adapter state dict keys are `<adapter_name>.<...>` inside a shared nn.ModuleDict, so
+        # selecting/stripping them by substring lets an adapter whose name merely contains
+        # another adapter's name leak into the saved file (and break the subsequent load).
+        monkeypatch.setenv('TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD', '1')  # see load_adapters() docstring
+
+        cfg = get_model_config(in_features=50)
+        model = DefaultAdapterModel(cfg)
+
+        model.add_adapter(name='encoder:adapter_0', cfg=get_adapter_cfg(dim=5))
+        model.add_adapter(name='encoder:adapter_0_v2', cfg=get_adapter_cfg(dim=5))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adapter_path = os.path.join(tmpdir, 'temp.pt')
+
+            model.save_adapters(adapter_path, name='encoder:adapter_0')
+
+            # The file must contain only `adapter_0`'s parameters
+            saved = torch.load(adapter_path, map_location='cpu', weights_only=False)
+            for module_state in saved['encoder:adapter_0']:
+                assert all(key.startswith('adapter_0.') for key in module_state), sorted(module_state.keys())
+                assert not any(key.startswith('adapter_0_v2.') for key in module_state), sorted(module_state.keys())
+
+            new_model = DefaultAdapterModel(cfg)
+            new_model.load_adapters(adapter_path, name='encoder:adapter_0')
+
+        assert new_model.get_enabled_adapters() == ['adapter_0']
+
+        original_state_dict = model.encoder.get_adapter_module('adapter_0').state_dict()
+        restored_state_dict = new_model.encoder.get_adapter_module('adapter_0').state_dict()
+
+        assert set(original_state_dict.keys()) == set(restored_state_dict.keys())
+        for key in original_state_dict:
+            assert (original_state_dict[key] - restored_state_dict[key]).abs().mean() < 1e-6
+
+    @pytest.mark.unit
     def test_single_decoder_save_load_adapter_only_partial_name(self):
         # create a model config, but do not add global_cfg to it
         # we want to test just module level adapter


### PR DESCRIPTION
# What does this PR do ?

Fixes two independent defects that stop `AdapterModelPTMixin.save_adapters()` /
`load_adapters()` from round-tripping. One commit each.

**Collection**: core

**1. `load_adapters` restored the wrong set of adapters.**
`save_adapters` writes state-dict entries only for the adapters it was asked to save, but stores
the source model's *entire* adapter config as `__cfg__`. `load_adapters(name=None)` derived its
list from that config instead of from the state dict, so the documented default
`load_adapters(path)` raised `KeyError` for every adapter that existed in the source model but
was never written to the file. It now derives the list from the state dict, which is by
construction exactly what the file holds.

**2. Adapter state-dict keys were matched and stripped by substring.**
`module.adapter_layer` is an `nn.ModuleDict` holding every adapter of that module, so its keys
are `<adapter name>.<...>` for all of them. `if adapter_name in k` and
`k.replace(f"{adapter_name}.", "")` therefore let overlapping names collide: saving `an4` when
`an4_v2` also exists silently wrote all of `an4_v2`'s tensors into the file, and loading it
failed with `RuntimeError: Unexpected key(s) in state_dict`. Both sites now compare and strip
the exact `<adapter_name>.` prefix.

**Collection:** [Core]

# Changelog

- `nemo/core/classes/mixins/adapter_mixins.py`
  - `load_adapters`: derive the adapter list from the state dict rather than from the stored
    `__cfg__`.
  - `save_adapters` / `load_adapters`: select and strip adapter state-dict keys by exact
    `<adapter_name>.` prefix instead of substring.
- `tests/core/mixins/adapters/test_adapter_model_mixin.py`
  - `test_save_adapter_subset_then_load_with_default_name`
  - `test_save_load_adapter_with_name_that_is_prefix_of_another`

# Usage

```python
model.add_adapter("encoder:en", cfg=adapter_cfg)
model.add_adapter("encoder:de", cfg=adapter_cfg)

# ship only the English adapter
model.save_adapters("en.pt", name="encoder:en")

# recipient, using the documented default -- raised KeyError before this PR
other_model.load_adapters("en.pt")
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.
Trusted PRs run automatically through copy-pr-bot. For an untrusted PR, a maintainer can trigger CI by commenting
`/ok to test <head-sha>`; repeat this after a new push if the PR remains untrusted.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.

# Additional Information

- Fixes #16102

- Both fixes are backward compatible. Files written with `save_adapters(name=None)` are
  unaffected by change 1 (the two key sources describe the same set). Files written by the old
  code that contain contaminated keys now load successfully under the new prefix strip, where
  before they raised; and files written by the new code load fine under old code, since a prefix
  match is a subset of a substring match.
- The two commits are independent - each one alone leaves the existing suite green and fixes only
  its own regression test - so they can be split if preferred.
- Verified locally with `TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1`: `tests/core/mixins` and
  `tests/collections/asr/mixins/adapters` -> 143 passed, 2 skipped. Both new tests fail on `main` and pass with the fix.
- Note for reviewers running these tests locally: seven pre-existing tests in this file fail on
  `main` under PyTorch >= 2.6 unless `TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1` is set, as the
  `load_adapters` docstring instructs. That is unrelated to this PR (the same seven fail before
  and after); the two new tests set it via `monkeypatch` so they pass either way.


