### PR TITLE
fix(asr): pad random_segment with an integer sample count

### DIFF
--- a/docs/source/asr/ssl/configs.rst
+++ b/docs/source/asr/ssl/configs.rst
@@ -28,6 +28,7 @@ dataset config:
     random_segment:
       prob: 1.0
       duration_sec: 16 # specify the duration you want
+      pad_to_duration: true # zero-pad utterances shorter than duration_sec (defaults to false)
 
 3) You can also use bucketing to ensure similar utterance lengths within batches.
 See :ref:`Bucketing documentation <Bucketing_Datasets>`.

--- a/nemo/collections/asr/parts/preprocessing/perturb.py
+++ b/nemo/collections/asr/parts/preprocessing/perturb.py
@@ -35,6 +35,7 @@
 import copy
 import inspect
 import io
+import math
 import os
 import random
 import subprocess
@@ -1095,7 +1096,10 @@ class RandomSegmentPerturbation(Perturbation):
                 # don't do anything if pad_to_duration is False
                 return
             start_time = 0.0
-            pad_size = self._duration_sec * data.sample_rate - data.num_samples
+            # `pad_size` must be an integer number of samples for np.pad, and `math.ceil`
+            # (rather than round/truncate) keeps the padded segment at least `duration_sec`
+            # long so that the subsegment() call below stays in bounds.
+            pad_size = math.ceil(self._duration_sec * data.sample_rate) - data.num_samples
             data.pad(pad_size=pad_size)
         else:
             start_time = random.uniform(0.0, data.duration - self._duration_sec)

--- a/tests/collections/asr/test_preprocessing_segment.py
+++ b/tests/collections/asr/test_preprocessing_segment.py
@@ -22,7 +22,12 @@ import numpy as np
 import pytest
 import soundfile as sf
 
-from nemo.collections.asr.parts.preprocessing.perturb import NoisePerturbation, ShiftPerturbation, SilencePerturbation
+from nemo.collections.asr.parts.preprocessing.perturb import (
+    NoisePerturbation,
+    RandomSegmentPerturbation,
+    ShiftPerturbation,
+    SilencePerturbation,
+)
 from nemo.collections.asr.parts.preprocessing.segment import AudioSegment, select_channels
 
 
@@ -530,3 +535,71 @@ class TestShiftPerturbation:
         original = segment.samples.copy()
         perturb.perturb(segment)
         np.testing.assert_array_equal(segment.samples, original, "Zero shift should not modify audio")
+
+
+class TestRandomSegmentPerturbation:
+    sample_rate = 16000
+
+    def _make_audio_segment(self, duration_sec, sample_rate=None):
+        """Create an AudioSegment holding a sine wave of the requested duration."""
+        sample_rate = self.sample_rate if sample_rate is None else sample_rate
+        num_samples = int(duration_sec * sample_rate)
+        t = np.linspace(0, duration_sec, num_samples, dtype=np.float32)
+        samples = np.sin(2 * np.pi * 440 * t)
+        return AudioSegment(samples=samples, sample_rate=sample_rate)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("duration_sec", [32.0, 32, 16.0, 16])
+    def test_random_segment_pads_short_audio(self, duration_sec):
+        """Short audio must be padded to duration_sec whether it is spelled as int or float."""
+        perturb = RandomSegmentPerturbation(duration_sec=duration_sec, pad_to_duration=True)
+        segment = self._make_audio_segment(duration_sec=5.0)
+        perturb.perturb(segment)
+        assert len(segment.samples) == int(duration_sec) * self.sample_rate
+
+    @pytest.mark.unit
+    def test_random_segment_pads_with_zeros_after_original_audio(self):
+        """The original audio is kept at the front and the tail is zero-filled."""
+        perturb = RandomSegmentPerturbation(duration_sec=2.0, pad_to_duration=True)
+        segment = self._make_audio_segment(duration_sec=0.5)
+        original = segment.samples.copy()
+        perturb.perturb(segment)
+        assert len(segment.samples) == 2 * self.sample_rate
+        np.testing.assert_array_equal(segment.samples[: len(original)], original)
+        np.testing.assert_array_equal(segment.samples[len(original) :], 0.0)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("duration_sec, expected_num_samples", [(0.05, 1102), (0.25, 5512), (0.35, 7717)])
+    def test_random_segment_pads_when_duration_is_not_a_whole_number_of_samples(
+        self, duration_sec, expected_num_samples
+    ):
+        """duration_sec * sample_rate need not be an integer.
+
+        At 22050 Hz these durations land on a half sample, so the padded segment must be rounded
+        *up* to stay at least duration_sec long -- rounding down leaves subsegment() out of bounds.
+        """
+        sample_rate = 22050
+        perturb = RandomSegmentPerturbation(duration_sec=duration_sec, pad_to_duration=True)
+        segment = self._make_audio_segment(duration_sec=duration_sec / 2, sample_rate=sample_rate)
+        perturb.perturb(segment)
+        assert len(segment.samples) == expected_num_samples
+
+    @pytest.mark.unit
+    def test_random_segment_without_padding_leaves_short_audio_untouched(self):
+        """With pad_to_duration disabled (the default), short audio is returned unchanged."""
+        perturb = RandomSegmentPerturbation(duration_sec=32.0)
+        segment = self._make_audio_segment(duration_sec=5.0)
+        original = segment.samples.copy()
+        perturb.perturb(segment)
+        np.testing.assert_array_equal(segment.samples, original)
+
+    @pytest.mark.unit
+    def test_random_segment_extracts_segment_from_long_audio(self):
+        """Audio longer than duration_sec is cut down to duration_sec.
+
+        The cut boundaries are rounded independently, so allow a one-sample tolerance.
+        """
+        perturb = RandomSegmentPerturbation(duration_sec=1.0, pad_to_duration=True)
+        segment = self._make_audio_segment(duration_sec=5.0)
+        perturb.perturb(segment)
+        assert abs(len(segment.samples) - self.sample_rate) <= 1


### PR DESCRIPTION
# What does this PR do ?

Fixes `RandomSegmentPerturbation` (`random_segment` augmentation) crashing with
`TypeError: `pad_width` must be of integral type.` whenever it has to pad a short utterance, and
corrects the SSL configuration doc that documents the padding behaviour but omits the flag that
enables it.

**Collection**: ASR

# Changelog

- `nemo/collections/asr/parts/preprocessing/perturb.py`: compute `pad_size` as an integer number
  of samples with `math.ceil`, so `AudioSegment.pad` -> `numpy.pad` receives an integral
  `pad_width`. Previously `duration_sec * sample_rate - num_samples` was a float whenever
  `duration_sec` was a float — including the constructor default `32.0` — and every short
  utterance raised `TypeError`. `math.ceil` rather than `round`/truncation is deliberate: the
  next statement is `subsegment(0.0, duration_sec)`, which raises `ValueError` if the segment
  ends up shorter than `duration_sec`, so the padded length must not round *down*. `subsegment`
  then trims to exactly `round(duration_sec * sample_rate)` samples, matching the non-padding
  branch.
- `docs/source/asr/ssl/configs.rst`: add `pad_to_duration: true` to the `random_segment` snippet.
  The surrounding text says "samples below the provided segment length will be padded", but the
  snippet omitted the flag and it defaults to `False`, so the documented recipe silently did not
  pad — which defeats its stated purpose of keeping durations uniform inside an SSL batch.
- `tests/collections/asr/test_preprocessing_segment.py`: add `TestRandomSegmentPerturbation`
  covering int and float `duration_sec`, the zero-fill placement, sample rates where
  `duration_sec * sample_rate` is not a whole number (22050 Hz), the `pad_to_duration=False`
  default, and the non-padding branch. There was previously no test for this perturbation.

# Usage

```python
import numpy as np
from nemo.collections.asr.parts.preprocessing.perturb import RandomSegmentPerturbation
from nemo.collections.asr.parts.preprocessing.segment import AudioSegment

seg = AudioSegment(np.zeros(16000 * 5, dtype=np.float32), 16000)      # 5 s
RandomSegmentPerturbation(duration_sec=32.0, pad_to_duration=True).perturb(seg)
len(seg.samples)   # before: TypeError    after: 512000
```

Equivalently, from a training config:

```yaml
model:
  train_ds:
    augmentor:
      random_segment:
        prob: 1.0
        duration_sec: 16.0
        pad_to_duration: true
```

# GitHub Actions CI

Checks run locally (macOS, CPU, Python 3.10.18, torch 2.12.0, numpy 2.2.6):

- `pre-commit run --from-ref main --to-ref HEAD` — all hooks pass (isort, black 24.10.0,
  check-case-conflict, detect-private-key, check-added-large-files).
- `pytest tests/collections/asr/test_preprocessing_segment.py -m "not pleasefixme"` — 73 passed.
- `pytest tests/collections/asr -m "not pleasefixme"` — 1402 passed, 402 skipped, 26 failed,
  12 errors. All 38 failures/errors are pre-existing on `main` and environmental on a CPU-only
  macOS box (`*_gpu` parametrisations, ONNX/TorchScript export, model-download errors); none is
  in preprocessing or perturbation code. Verified by re-running the 7 affected files with
  `perturb.py` reverted to `main`: the failure sets are byte-identical, so this change
  introduces no new failures.
- Regression check: with `perturb.py` reverted to `main` and the new tests in place, 6 of the 10
  new cases fail (`TypeError: `pad_width` must be of integral type.`); the 4 that pass are the
  int-`duration_sec`, `pad_to_duration=False` and long-audio controls. All 10 pass with the fix.
- `git diff --check` — clean.
- Not run: the Sphinx docs build. The doc change is one line inside an existing
  `.. code-block:: yaml` and adds no directive, role or reference; the snippet was parsed with
  `yaml.safe_load` to confirm it is still valid.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - No. `math` is stdlib; no new dependency and no optional import.

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [x] Documentation

# Additional Information

- Fixes #16104
- The documentation change is included here rather than split out because it is the same
  user-visible failure: on `main` the documented `random_segment` recipe does not pad, and the
  doc line would be actively misleading — it would walk readers into the `TypeError` — if landed
  without the code fix.


