### PR TITLE
fix(asr): collect whole labels in FeatureLabel.uniq_labels

### DIFF
--- a/nemo/collections/common/parts/preprocessing/collections.py
+++ b/nemo/collections/common/parts/preprocessing/collections.py
@@ -1685,7 +1685,6 @@ class FeatureLabel(_Collection):
         data = []
         duration_filtered = 0.0
         total_duration = 0.0
-        self.uniq_labels = set()
 
         if index_by_file_id:
             self.mapping = {}
@@ -1701,7 +1700,6 @@ class FeatureLabel(_Collection):
                 continue
 
             data.append(output_type(feature_file, label, duration))
-            self.uniq_labels |= set(label)
             total_duration += duration
 
             if index_by_file_id:
@@ -1717,6 +1715,8 @@ class FeatureLabel(_Collection):
                 logging.warning("Tried to sort dataset by duration, but cannot since index_by_file_id is set.")
             else:
                 data.sort(key=lambda entity: entity.duration)
+
+        self.uniq_labels = sorted(set(map(lambda x: x.label, data)))
 
         logging.info(f"Filtered duration for loading collection is {duration_filtered / 2600:.2f} hours.")
         logging.info(f"Dataset loaded with {len(data)} items, total duration of {total_duration / 3600: .2f} hours.")

--- a/nemo/collections/common/parts/preprocessing/collections.py
+++ b/nemo/collections/common/parts/preprocessing/collections.py
@@ -1718,7 +1718,7 @@ class FeatureLabel(_Collection):
 
         self.uniq_labels = sorted(set(map(lambda x: x.label, data)))
 
-        logging.info(f"Filtered duration for loading collection is {duration_filtered / 2600:.2f} hours.")
+        logging.info(f"Filtered duration for loading collection is {duration_filtered / 3600:.2f} hours.")
         logging.info(f"Dataset loaded with {len(data)} items, total duration of {total_duration / 3600: .2f} hours.")
         logging.info("# {} files loaded including # {} unique labels".format(len(data), len(self.uniq_labels)))
         super().__init__(data)

--- a/tests/collections/asr/test_label_datasets.py
+++ b/tests/collections/asr/test_label_datasets.py
@@ -21,9 +21,14 @@ import soundfile as sf
 import torch
 
 from nemo.collections.asr.data.audio_to_label import AudioToMultiLabelDataset, TarredAudioToClassificationLabelDataset
-from nemo.collections.asr.data.feature_to_label import FeatureToLabelDataset, FeatureToSeqSpeakerLabelDataset
+from nemo.collections.asr.data.feature_to_label import (
+    FeatureToLabelDataset,
+    FeatureToMultiLabelDataset,
+    FeatureToSeqSpeakerLabelDataset,
+)
 from nemo.collections.asr.parts.preprocessing.feature_loader import ExternalFeatureLoader
 from nemo.collections.asr.parts.preprocessing.features import WaveformFeaturizer
+from nemo.collections.common.parts.preprocessing.collections import ASRFeatureLabel, ASRSpeechLabel
 
 
 class TestASRDatasets:
@@ -134,6 +139,74 @@ class TestASRDatasets:
             for _ in dataset:
                 count += 1
             assert count == 2
+
+    @staticmethod
+    def _write_feature_manifest(tmpdir, labels, key='feature_file', name='manifest_input.json'):
+        manifest_path = os.path.join(tmpdir, name)
+        with open(manifest_path, 'w', encoding='utf-8') as fp:
+            for i, label in enumerate(labels):
+                feat_file = os.path.join(tmpdir, f"feat_{i}.pt")
+                torch.save(torch.randn(80, 5), feat_file)
+                fp.write(json.dumps({key: feat_file, 'duration': 1.0, 'label': label}) + '\n')
+        return manifest_path
+
+    @pytest.mark.unit
+    def test_feature_label_collection_collects_whole_labels(self):
+        """`uniq_labels` must hold the labels themselves, not the characters they are spelled with."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = self._write_feature_manifest(tmpdir, ['speech', 'background', 'speech'])
+
+            collection = ASRFeatureLabel(manifests_files=[manifest_path])
+
+            assert collection.uniq_labels == ['background', 'speech']
+
+    @pytest.mark.unit
+    def test_feature_label_collection_matches_audio_sibling(self):
+        """Control: `ASRSpeechLabel` is the audio-side equivalent and already gets this right."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feat_manifest = self._write_feature_manifest(tmpdir, ['speech', 'background'])
+            audio_manifest = self._write_feature_manifest(
+                tmpdir, ['speech', 'background'], key='audio_filepath', name='manifest_audio.json'
+            )
+
+            feature_collection = ASRFeatureLabel(manifests_files=[feat_manifest])
+            audio_collection = ASRSpeechLabel(manifests_files=[audio_manifest])
+
+            assert feature_collection.uniq_labels == audio_collection.uniq_labels
+
+    @pytest.mark.unit
+    def test_feat_label_dataset_infers_labels_when_none(self):
+        """`labels=None` is the documented fallback; it must build a usable label vocabulary."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = self._write_feature_manifest(tmpdir, ['speech', 'background'])
+
+            dataset = FeatureToLabelDataset(manifest_filepath=manifest_path, labels=None)
+
+            assert dataset.labels == ['background', 'speech']
+            assert dataset.num_classes == 2
+            assert dataset.label2id == {'background': 0, 'speech': 1}
+            assert torch.equal(dataset[0][2], torch.tensor(1))
+
+    @pytest.mark.unit
+    def test_feat_label_dataset_matches_multilabel_sibling_when_labels_none(self):
+        """Control: `FeatureToMultiLabelDataset` derives the same vocabulary from the same manifest."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = self._write_feature_manifest(tmpdir, ['speech', 'background'])
+
+            dataset = FeatureToLabelDataset(manifest_filepath=manifest_path, labels=None)
+            multi_label_dataset = FeatureToMultiLabelDataset(manifest_filepath=manifest_path, labels=None)
+
+            assert dataset.labels == multi_label_dataset.labels
+
+    @pytest.mark.unit
+    def test_feature_label_collection_supports_regression_labels(self):
+        """Regression labels are floats; iterating over them is not possible."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = self._write_feature_manifest(tmpdir, ['0.5', '1.5'])
+
+            collection = ASRFeatureLabel(manifests_files=[manifest_path], is_regression_task=True)
+
+            assert collection.uniq_labels == [0.5, 1.5]
 
     @pytest.mark.unit
     def test_audio_multilabel_dataset(self):


### PR DESCRIPTION
# What does this PR do ?

Makes `FeatureLabel` collect whole labels instead of the characters of each label string.

**Collection**: ASR

Fixes #16106.

# Changelog

`FeatureLabel.__init__` accumulated `self.uniq_labels |= set(label)`. `label` is the manifest's label
string, so `set()` yielded its characters: a corpus labelled `speech` / `background` produced a
14-entry vocabulary of single letters instead of `['background', 'speech']`.

`uniq_labels` is the label-vocabulary fallback for `FeatureToLabelDataset`
(`self.labels = labels if labels else self.collection.uniq_labels`), so three failures follow from that
one line:

1. wrong vocabulary — 14 characters instead of 2 labels;
2. `TypeError: 'set' object is not subscriptable` at `feature_to_label.py:358` (`self.labels[:5]`),
   because `uniq_labels` is a bare `set` while every other producer of `self.labels` yields a list —
   so the documented `labels=None` fallback cannot work at all;
3. `TypeError: 'float' object is not iterable` on the regression path, where `ASRFeatureLabel` sets
   `label = float(item['label'])`. This raises inside `ASRFeatureLabel.__init__`, before `labels` is
   consulted, so passing an explicit label list does not avoid it.

The fix computes `uniq_labels` after the loop, exactly the way the audio-side sibling `SpeechLabel`
already does in the same module:

```python
self.uniq_labels = sorted(set(map(lambda x: x.label, data)))
```

That single line fixes all three, and makes `FeatureLabel` agree with both `SpeechLabel` and
`FeatureToMultiLabelDataset._get_label_set()`.

A second, separate commit fixes the adjacent log line in the same function, which divided the filtered
duration by `2600` instead of `3600` — the line immediately below it, and every other collection in
this module, use `3600`. It is log output only and is kept as its own commit so it can be dropped
independently if preferred.

## Testing

Extended the existing `tests/collections/asr/test_label_datasets.py::TestASRDatasets` (which already
has a `tempfile`-based `test_feat_label_dataset`) with 5 unit tests:

- `uniq_labels` holds whole labels, not characters;
- it matches `ASRSpeechLabel.uniq_labels` on an equivalent manifest (sibling control);
- `FeatureToLabelDataset(labels=None)` builds `labels` / `num_classes` / `label2id` and yields the
  right label tensor;
- its vocabulary matches `FeatureToMultiLabelDataset(labels=None)` on the same manifest (sibling
  control);
- `ASRFeatureLabel(..., is_regression_task=True)` constructs and returns `[0.5, 1.5]`.

Results on this branch:

| state | result |
|---|---|
| before the fix | 5 failed, 1 passed (`assert {'a','b','c',...} == ['background','speech']`; `TypeError: 'set' object is not subscriptable`; `TypeError: 'float' object is not iterable`) |
| with this fix | 6 passed |

The test that passes in both states is the pre-existing `test_feat_label_dataset`, which passes an
explicit `labels=` list — included to show the existing behaviour is preserved.

Whole file: `10 passed`. Wider run on this branch —
`tests/collections/asr/test_asr_classification_model.py` and
`tests/collections/asr/test_asr_regression_model.py`: 19 passed.

Style: `black` 24.10.0 and `isort` 5.13.2 (repo settings, line length 119) report no changes;
`flake8 --config .flake8.other` exits 0; `pylint --rcfile .pylintrc.other` rates `collections.py`
10.00/10; `pre-commit run --from-ref main --to-ref HEAD` passes.

No documentation change: this restores the behaviour the `FeatureToLabelDataset` docstring already
describes ("if None then automatically picks from the collection") rather than changing an API.

# GitHub Actions CI

Trusted PRs run automatically through copy-pr-bot. For an untrusted PR, a maintainer can trigger CI by commenting
`/ok to test <head-sha>`; repeat this after a new push if the PR remains untrusted.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

