### PR TITLE
fix(common): load the expanded abbreviation set instead of assigning to list.extend

### DIFF
--- a/nemo/collections/common/parts/preprocessing/cleaners.py
+++ b/nemo/collections/common/parts/preprocessing/cleaners.py
@@ -178,7 +178,9 @@ def clean_abbreviations(string, version=None):
     if version == "fastpitch":
         abbbreviations = ABBREVIATIONS_TTS_FASTPITCH
     elif version == "expanded":
-        abbbreviations.extend = ABBREVIATIONS_EXPANDED
+        # Concatenate into a new list: `abbbreviations` aliases the module-level ABBREVIATIONS_COMMON,
+        # so mutating it in place would leak the expanded entries into every later call.
+        abbbreviations = ABBREVIATIONS_COMMON + ABBREVIATIONS_EXPANDED
     for regex, replacement in abbbreviations:
         string = re.sub(regex, replacement, string)
     return string

--- a/tests/collections/common/test_preprocessing_cleaners.py
+++ b/tests/collections/common/test_preprocessing_cleaners.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import string
+
+import pytest
+
+from nemo.collections.common.parts.preprocessing import cleaners
+from nemo.collections.common.parts.preprocessing.parsers import ENCharParser
+
+LABELS = [' ', "'"] + list(string.ascii_lowercase)
+
+
+class TestCleanAbbreviations:
+    @pytest.mark.unit
+    def test_expanded_version_expands_common_abbreviations(self):
+        """`version="expanded"` must still apply the common abbreviations."""
+        assert cleaners.clean_abbreviations("mr. smith", version="expanded") == "mister smith"
+
+    @pytest.mark.unit
+    def test_expanded_version_expands_the_expanded_only_abbreviations(self):
+        """`ltd` exists only in ABBREVIATIONS_EXPANDED, so it pins the extra list to `expanded`."""
+        assert cleaners.clean_abbreviations("ltd. co.", version="expanded") == "limited company"
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("version,expected", [(None, "mister smith"), ("fastpitch", "mister smith")])
+    def test_other_versions_are_unchanged(self, version, expected):
+        """Control: the sibling branches of the same function."""
+        assert cleaners.clean_abbreviations("mr. smith", version=version) == expected
+
+    @pytest.mark.unit
+    def test_expanded_version_does_not_mutate_module_level_lists(self):
+        """`abbbreviations` aliases ABBREVIATIONS_COMMON; an in-place `.extend()` fix would leak."""
+        common_before = list(cleaners.ABBREVIATIONS_COMMON)
+        fastpitch_before = list(cleaners.ABBREVIATIONS_TTS_FASTPITCH)
+
+        cleaners.clean_abbreviations("mr. smith", version="expanded")
+
+        assert cleaners.ABBREVIATIONS_COMMON == common_before
+        assert cleaners.ABBREVIATIONS_TTS_FASTPITCH == fastpitch_before
+
+    @pytest.mark.unit
+    def test_expanded_version_does_not_leak_into_later_calls(self):
+        """After an `expanded` call, `version=None` must not gain the expanded-only abbreviations."""
+        cleaners.clean_abbreviations("ltd. co.", version="expanded")
+
+        assert cleaners.clean_abbreviations("ltd. co.", version=None) == "ltd. company"
+        assert cleaners.clean_abbreviations("ltd. co.", version="fastpitch") == "limited company"
+
+
+class TestENCharParserAbbreviationVersion:
+    @pytest.mark.unit
+    def test_expanded_parser_does_not_drop_utterances(self):
+        """`CharParser._normalize` swallows every exception, so a raise here silently filters samples."""
+        parser = ENCharParser(abbreviation_version="expanded", labels=LABELS)
+        reference = ENCharParser(abbreviation_version=None, labels=LABELS)
+
+        assert parser("hello") == reference("hello")
+        assert parser("mr. smith") == reference("mr. smith")
+        assert parser("ltd. co.") == reference("limited company")
+
+    @pytest.mark.unit
+    def test_parser_instances_do_not_share_abbreviation_state(self):
+        """Two parsers must stay independent regardless of construction order."""
+        expanded = ENCharParser(abbreviation_version="expanded", labels=LABELS)
+        plain = ENCharParser(abbreviation_version=None, labels=LABELS)
+
+        assert expanded("ltd. co.") == plain("limited company")
+        assert plain("ltd. co.") != plain("limited company")
+        # and the plain parser is still unaffected after the expanded one has run again
+        expanded("ltd. co.")
+        assert plain("ltd. co.") != plain("limited company")


### PR DESCRIPTION
# What does this PR do ?

Makes the `expanded` abbreviation set actually load, so `ENCharParser(abbreviation_version='expanded')` stops returning `None`.

**Collection**: Common

Fixes #16108.

# Changelog

`clean_abbreviations(version="expanded")` assigned to `list.extend` instead of calling it:

```python
elif version == "expanded":
    abbbreviations.extend = ABBREVIATIONS_EXPANDED
```

`list.extend` is read-only, so this raises `AttributeError: 'list' object attribute 'extend' is
read-only`. `clean_abbreviations` is on the unconditional path inside `clean_text`, and
`CharParser._normalize` wraps `clean_text` in `except Exception: return None`; `AudioText` then treats
the `None` token list as a filtered sample. The result is that
`ENCharParser(abbreviation_version="expanded")` silently drops **every** utterance — including
utterances with no abbreviation in them — and the dataset loads zero samples with no traceback.

The fix builds a new list rather than mutating in place. `abbbreviations` aliases the module-level
`ABBREVIATIONS_COMMON`, so the obvious repair `abbbreviations.extend(ABBREVIATIONS_EXPANDED)` would
permanently grow that global and leak the expanded abbreviations into every later `version=None` and
`version="fastpitch"` call in the same process.

```python
elif version == "expanded":
    abbbreviations = ABBREVIATIONS_COMMON + ABBREVIATIONS_EXPANDED
```

Scope: one line in `cleaners.py` plus a new unit-test module. `version=None` and `version="fastpitch"`
behaviour is unchanged.

## Testing

New `tests/collections/common/test_preprocessing_cleaners.py` (8 unit tests). No existing test module
imported `cleaners` or `ENCharParser`.

- Expansion: `"expanded"` now expands both the common abbreviations (`mr.` → `mister`) and the
  expanded-only ones (`ltd.` → `limited`).
- Controls: `version=None` and `version="fastpitch"` are asserted unchanged; both pass before and
  after the fix.
- No shared state: `ABBREVIATIONS_COMMON` / `ABBREVIATIONS_TTS_FASTPITCH` are unmodified after an
  `"expanded"` call, a later `version=None` call does not gain the expanded entries, and two
  `ENCharParser` instances stay independent regardless of construction order.

Results on this branch:

| state | result |
|---|---|
| before the fix | 6 failed, 2 passed (`AttributeError: 'list' object attribute 'extend' is read-only`; `assert None == [9, 6, 13, 13, 16]`) |
| with `abbbreviations.extend(ABBREVIATIONS_EXPANDED)` instead | 3 failed, 5 passed — exactly the three state-leakage tests fail |
| with this fix | 8 passed |

The middle row is deliberate: the tests are written so that a fix which expands correctly but mutates
the module-level list still fails.

Wider run on this branch — `tests/collections/common/test_preprocessing_cleaners.py`,
`tests/collections/asr/test_asr_ctcencdec_model.py`, `tests/collections/common/tokenizers`:
18 passed, 48 skipped.

Style: `black` 24.10.0 and `isort` 5.13.2 (repo settings, line length 119) report no changes;
`flake8 --config .flake8.other` exits 0; `pylint --rcfile .pylintrc.other` rates `cleaners.py` 10.00/10;
`pre-commit run --from-ref main --to-ref HEAD` passes.

No documentation change: `abbreviation_version` is not documented in `docs/`, and this restores the
documented-by-signature behaviour rather than changing an API.

# GitHub Actions CI

Trusted PRs run automatically through copy-pr-bot. For an untrusted PR, a maintainer can trigger CI by commenting
`/ok to test <head-sha>`; repeat this after a new push if the PR remains untrusted.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

