### PR TITLE
Fix mismatched paired text shard expansion

### DIFF
--- a/nemo/collections/common/data/lhotse/text_adapters.py
+++ b/nemo/collections/common/data/lhotse/text_adapters.py
@@ -321,6 +321,11 @@ class LhotseTextPairAdapter:
             ), f"Source ({len(self.source_paths)}) and target ({len(self.target_paths)}) path lists must have the same number of items."
         self.source_paths = expand_sharded_filepaths(self.source_paths)
         self.target_paths = expand_sharded_filepaths(self.target_paths)
+        if len(self.source_paths) != len(self.target_paths):
+            raise ValueError(
+                "Source and target path patterns must expand to the same number of shards, "
+                f"but got {len(self.source_paths)} and {len(self.target_paths)}."
+            )
 
     def __iter__(self) -> Iterator[SourceTargetTextExample]:
         seed = resolve_seed(self.shard_seed)

--- a/tests/collections/common/test_lhotse_dataloading.py
+++ b/tests/collections/common/test_lhotse_dataloading.py
@@ -31,7 +31,11 @@ from lhotse.testing.random import deterministic_rng
 from omegaconf import OmegaConf
 
 from nemo.collections.common.data.lhotse import get_lhotse_dataloader_from_config
-from nemo.collections.common.data.lhotse.text_adapters import SourceTargetTextExample, TextExample
+from nemo.collections.common.data.lhotse.text_adapters import (
+    LhotseTextPairAdapter,
+    SourceTargetTextExample,
+    TextExample,
+)
 from nemo.collections.common.tokenizers.sentencepiece_tokenizer import SentencePieceTokenizer, create_spt_model
 from nemo.utils.dependency import is_module_available
 
@@ -1431,6 +1435,18 @@ def test_text_file_pairs_input(txt_en_path, txt_es_path, questions_path):
     assert all(isinstance(c, SourceTargetTextExample) for c in b)
     assert all(c.source.language == "en" for c in b)
     assert all(c.target.language == "es" for c in b)
+
+
+def test_text_file_pair_rejects_mismatched_shard_counts(tmp_path):
+    for shard_idx in range(2):
+        (tmp_path / f"source_{shard_idx}.txt").write_text(f"source {shard_idx}\n")
+    target_path = tmp_path / "target_0.txt"
+    target_path.write_text("target 0\n")
+
+    source_paths = f"{tmp_path}/source__OP_0..1_CL_.txt"
+
+    with pytest.raises(ValueError, match="same number of shards"):
+        LhotseTextPairAdapter(source_paths, target_path)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## What does this PR do?

Validate paired text shard counts after expanding source and target path patterns.

`LhotseTextPairAdapter` already requires explicit source and target path lists to have the same length. However, string shard patterns were checked before expansion and then expanded independently. If the two patterns produced different numbers of shards, `zip` silently ignored every unmatched shard, dropping training data without reporting the malformed dataset.

This change restores the existing invariant after expansion and raises a clear `ValueError` before iteration can silently truncate the shard pairs.

**Collection**: common

## Changelog

- Reject source and target path patterns that expand to different shard counts.
- Add regression coverage for a two-source-shard/one-target-shard dataset.

## Usage

No API changes are required. Invalid paired shard patterns now fail during `LhotseTextPairAdapter` initialization instead of silently dropping unmatched shards.

## GitHub Actions CI

Local validation:

- `uv run pytest --cpu -m 'not pleasefixme' tests/collections/common/test_lhotse_dataloading.py -k 'text_file_pair_rejects_mismatched_shard_counts' -q` (1 passed)
- `uv run pytest --cpu -m 'not pleasefixme' tests/collections/common/test_lhotse_dataloading.py -q` (68 passed, 1 skipped)
- `pre-commit run isort --files nemo/collections/common/data/lhotse/text_adapters.py tests/collections/common/test_lhotse_dataloading.py`
- `pre-commit run black --files nemo/collections/common/data/lhotse/text_adapters.py tests/collections/common/test_lhotse_dataloading.py`
- `pre-commit run check-case-conflict --files nemo/collections/common/data/lhotse/text_adapters.py tests/collections/common/test_lhotse_dataloading.py`
- `pre-commit run check-added-large-files --files nemo/collections/common/data/lhotse/text_adapters.py tests/collections/common/test_lhotse_dataloading.py`

## Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed the Contributor guidelines
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? (No documentation update is needed for this validation-only bug fix.)
- [x] Does the PR affect components that are optional to install? No.

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Additional Information

No related issue; this is a focused validation fix with a regression test.