### PR TITLE
Fix Nemotron-H gated RMSNorm fallback

### DIFF
--- a/nemo/collections/tts/modules/nemotron_h_decoder.py
+++ b/nemo/collections/tts/modules/nemotron_h_decoder.py
@@ -407,15 +407,17 @@ class MambaRMSNormGated(nn.Module):
                 norm_before_gate=False,
             )
         else:
-            # Fallback: simple RMSNorm + gating (works on CPU and GPU)
+            # Keep this fallback aligned with Mamba's reference implementation:
+            # https://github.com/state-spaces/mamba/blob/e9594ce1c732d97440f0332fdc43170a2294dbfa/mamba_ssm/ops/triton/layernorm_gated.py#L18-L39
             input_dtype = hidden_states.dtype
             hidden_states = hidden_states.to(torch.float32)
-            variance = hidden_states.pow(2).mean(-1, keepdim=True)
-            hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
-            hidden_states = (self.weight.to(torch.float32) * hidden_states).to(input_dtype)
             if gate is not None:
-                hidden_states = hidden_states * F.silu(gate)
-            return hidden_states
+                hidden_states = hidden_states * F.silu(gate.to(torch.float32))
+            hidden_states = hidden_states.reshape(*hidden_states.shape[:-1], -1, self.group_size)
+            variance = hidden_states.pow(2).mean(dim=-1, keepdim=True)
+            hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+            hidden_states = hidden_states.flatten(-2)
+            return (self.weight.to(torch.float32) * hidden_states).to(input_dtype)
 
 
 def pad_tensor_by_size(input_tensor: torch.Tensor, pad_size: int):

--- a/tests/collections/tts/test_nemotron_h_decoder.py
+++ b/tests/collections/tts/test_nemotron_h_decoder.py
@@ -39,6 +39,7 @@ except ImportError:
 
 import torch
 
+import nemo.collections.tts.modules.nemotron_h_decoder as nemotron_h_decoder
 from nemo.collections.tts.modules.nemotron_h_decoder import (
     HybridMambaAttentionDynamicCache,
     MambaRMSNormGated,
@@ -66,7 +67,23 @@ def test_mamba_rmsnorm_gated_pytorch_fallback_matches_grouped_reference():
     grouped = grouped * torch.rsqrt(grouped.square().mean(dim=-1, keepdim=True) + norm.variance_epsilon)
     expected = (grouped.flatten(-2) * norm.weight.float()).to(hidden_states.dtype)
     torch.testing.assert_close(actual, expected)
-    assert actual.dtype == hidden_states.dtype
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not nemotron_h_decoder.RMSNORM_FN_AVAILABLE,
+    reason="Triton gated RMSNorm requires CUDA and mamba-ssm",
+)
+def test_mamba_rmsnorm_gated_triton_matches_pytorch_fallback(monkeypatch):
+    hidden_states = torch.linspace(-3.0, 3.0, steps=2 * 4 * 64).reshape(2, 4, 64).cuda().half()
+    gate = hidden_states.flip(-1).contiguous()
+    norm = MambaRMSNormGated(hidden_size=64, group_size=16, eps=1e-5).cuda().half()
+    norm.weight.data.copy_(torch.linspace(0.5, 1.5, steps=64, device="cuda", dtype=torch.float16))
+
+    triton_output = norm(hidden_states, gate)
+    monkeypatch.setattr(nemotron_h_decoder, "RMSNORM_FN_AVAILABLE", False)
+    pytorch_output = norm(hidden_states, gate)
+
+    torch.testing.assert_close(triton_output, pytorch_output, rtol=1e-3, atol=1e-3)
 
 
 class TestNemotronHConfig:

--- a/tests/collections/tts/test_nemotron_h_decoder.py
+++ b/tests/collections/tts/test_nemotron_h_decoder.py
@@ -39,7 +39,6 @@ except ImportError:
 
 import torch
 
-import nemo.collections.tts.modules.nemotron_h_decoder as nemotron_h_decoder
 from nemo.collections.tts.modules.nemotron_h_decoder import (
     HybridMambaAttentionDynamicCache,
     MambaRMSNormGated,
@@ -49,6 +48,7 @@ from nemo.collections.tts.modules.nemotron_h_decoder import (
     NemotronHModel,
     NemotronHMOE,
     NemotronHTopkRouter,
+    RMSNORM_FN_AVAILABLE,
 )
 
 
@@ -70,7 +70,7 @@ def test_mamba_rmsnorm_gated_pytorch_fallback_matches_grouped_reference():
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or not nemotron_h_decoder.RMSNORM_FN_AVAILABLE,
+    not torch.cuda.is_available() or not RMSNORM_FN_AVAILABLE,
     reason="Triton gated RMSNorm requires CUDA and mamba-ssm",
 )
 def test_mamba_rmsnorm_gated_triton_matches_pytorch_fallback(monkeypatch):
@@ -80,7 +80,7 @@ def test_mamba_rmsnorm_gated_triton_matches_pytorch_fallback(monkeypatch):
     norm.weight.data.copy_(torch.linspace(0.5, 1.5, steps=64, device="cuda", dtype=torch.float16))
 
     triton_output = norm(hidden_states, gate)
-    monkeypatch.setattr(nemotron_h_decoder, "RMSNORM_FN_AVAILABLE", False)
+    monkeypatch.setattr("nemo.collections.tts.modules.nemotron_h_decoder.RMSNORM_FN_AVAILABLE", False)
     pytorch_output = norm(hidden_states, gate)
 
     torch.testing.assert_close(triton_output, pytorch_output, rtol=1e-3, atol=1e-3)

--- a/tests/collections/tts/test_nemotron_h_decoder.py
+++ b/tests/collections/tts/test_nemotron_h_decoder.py
@@ -41,6 +41,7 @@ import torch
 
 from nemo.collections.tts.modules.nemotron_h_decoder import (
     HybridMambaAttentionDynamicCache,
+    MambaRMSNormGated,
     NemotronHConfig,
     NemotronHForCausalLM,
     NemotronHMLP,
@@ -48,6 +49,24 @@ from nemo.collections.tts.modules.nemotron_h_decoder import (
     NemotronHMOE,
     NemotronHTopkRouter,
 )
+
+
+def test_mamba_rmsnorm_gated_pytorch_fallback_matches_grouped_reference():
+    hidden_states = torch.tensor(
+        [[[0.5, -1.0, 2.0, -0.25, 1.5, -3.0], [1.0, 0.25, -0.5, 2.0, -1.5, 0.75]]], dtype=torch.float16
+    )
+    gate = torch.tensor([[[-2.0, -1.0, 0.0, 0.5, 1.0, 2.0], [2.5, -0.5, 1.5, -1.5, 0.25, -2.5]]], dtype=torch.float16)
+    norm = MambaRMSNormGated(hidden_size=6, group_size=3, eps=1e-5)
+    norm.weight.data.copy_(torch.tensor([0.5, 1.0, 1.5, 2.0, 0.75, 1.25]))
+
+    actual = norm(hidden_states, gate)
+
+    gated = hidden_states.float() * torch.nn.functional.silu(gate.float())
+    grouped = gated.reshape(*gated.shape[:-1], -1, norm.group_size)
+    grouped = grouped * torch.rsqrt(grouped.square().mean(dim=-1, keepdim=True) + norm.variance_epsilon)
+    expected = (grouped.flatten(-2) * norm.weight.float()).to(hidden_states.dtype)
+    torch.testing.assert_close(actual, expected)
+    assert actual.dtype == hidden_states.dtype
 
 
 class TestNemotronHConfig:

--- a/tests/collections/tts/test_nemotron_h_decoder.py
+++ b/tests/collections/tts/test_nemotron_h_decoder.py
@@ -40,6 +40,7 @@ except ImportError:
 import torch
 
 from nemo.collections.tts.modules.nemotron_h_decoder import (
+    RMSNORM_FN_AVAILABLE,
     HybridMambaAttentionDynamicCache,
     MambaRMSNormGated,
     NemotronHConfig,
@@ -48,7 +49,6 @@ from nemo.collections.tts.modules.nemotron_h_decoder import (
     NemotronHModel,
     NemotronHMOE,
     NemotronHTopkRouter,
-    RMSNORM_FN_AVAILABLE,
 )
 
 


### PR DESCRIPTION
## Summary

- match upstream Mamba gate-before-normalization semantics in the PyTorch fallback
- normalize independently in contiguous RMS groups and restore the input dtype after applying weights
- add a focused CPU regression test for grouped gated RMSNorm behavior

## Testing

- `/home/vklimkov/miniconda3/envs/nemotts/bin/pytest -q tests/collections/tts/test_nemotron_h_decoder.py` (22 passed)
- `conda run -n nemotts python setup.py style --scope nemo/collections/tts/modules/nemotron_h_decoder.py`
- `conda run -n nemotts python setup.py style --scope tests/collections/tts/test_nemotron_h_decoder.py`