### PR TITLE
Fix crash with Lhotse train data and float limit_train_batches

### DIFF
--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models_prompt.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models_prompt.py
@@ -951,7 +951,12 @@ class EncDecHybridRNNTCTCBPEModelWithPrompt(PromptStreamingMixin, EncDecHybridRN
         # dataloader is the total number of samples rather than the number of batches,
         # and this messes up the tqdm progress bar. So we set the number of steps manually
         # (to the correct number) to fix this.
-        if 'is_tarred' in train_data_config and train_data_config['is_tarred']:
+        if (
+            self._train_dl is not None
+            and hasattr(self._train_dl, 'dataset')
+            and isinstance(self._train_dl.dataset, torch.utils.data.IterableDataset)
+            and hasattr(self._train_dl.dataset, '__len__')  # unsized (e.g. Lhotse) would crash the len() below
+        ):
             # We also need to check if limit_train_batches is already set.
             # If it's an int, we assume that the user has set it to something sane,
             # i.e. <= # training batches, and don't change it. Otherwise, adjust

--- a/nemo/collections/asr/models/rnnt_bpe_models_prompt.py
+++ b/nemo/collections/asr/models/rnnt_bpe_models_prompt.py
@@ -266,7 +266,12 @@ class EncDecRNNTBPEModelWithPrompt(PromptStreamingMixin, EncDecRNNTBPEModel, ASR
         self._update_dataset_config(dataset_name='train', config=train_data_config)
         self._train_dl = self._setup_dataloader_from_config(config=train_data_config)
 
-        if 'is_tarred' in train_data_config and train_data_config['is_tarred']:
+        if (
+            self._train_dl is not None
+            and hasattr(self._train_dl, 'dataset')
+            and isinstance(self._train_dl.dataset, torch.utils.data.IterableDataset)
+            and hasattr(self._train_dl.dataset, '__len__')  # unsized (e.g. Lhotse) would crash the len() below
+        ):
             if self._trainer is not None and isinstance(self._trainer.limit_train_batches, float):
                 self._trainer.limit_train_batches = int(
                     self._trainer.limit_train_batches

--- a/tests/collections/asr/test_asr_rnnt_encoder_model_bpe_prompt.py
+++ b/tests/collections/asr/test_asr_rnnt_encoder_model_bpe_prompt.py
@@ -16,8 +16,12 @@ import os
 import shutil
 import tempfile
 
+import numpy as np
 import pytest
+import soundfile as sf
 import torch
+from lhotse import CutSet, MonoCut, Recording, SupervisionSegment
+from lightning.pytorch import Trainer
 from omegaconf import DictConfig
 
 from nemo.collections.asr.models.rnnt_bpe_models_prompt import EncDecRNNTBPEModelWithPrompt
@@ -407,3 +411,60 @@ class TestEncDecRNNTBPEModelWithPrompt:
         assert out_a.shape == out_b.shape
         # The prompt projection should make outputs differ for different language ids.
         assert torch.max(torch.abs(out_a - out_b)) > 0
+
+    @pytest.mark.unit
+    def test_setup_training_data_lhotse_no_len_crash(self, rnnt_asr_model_with_prompt, tmp_path):
+        """Lhotse datasets have no __len__; setup_training_data must not crash with limit_train_batches=1.0."""
+        model = rnnt_asr_model_with_prompt
+        trainer = Trainer(accelerator='cpu', devices=1, limit_train_batches=1.0)
+        model.set_trainer(trainer)
+
+        cuts = []
+        for i in range(4):
+            audio_path = str(tmp_path / f'cut_{i}.wav')
+            samples = np.zeros((1, 16000), dtype=np.float32)
+            sf.write(audio_path, samples.T, 16000)
+            cuts.append(
+                MonoCut(
+                    id=f'cut_{i}',
+                    start=0.0,
+                    duration=1.0,
+                    channel=0,
+                    recording=Recording.from_file(audio_path, recording_id=f'rec_{i}'),
+                    supervisions=[
+                        SupervisionSegment(
+                            id=f'cut_{i}_sup0',
+                            recording_id=f'rec_{i}',
+                            start=0.0,
+                            duration=1.0,
+                            text='it was the first time',
+                            language='en_US',
+                        )
+                    ],
+                )
+            )
+
+        cuts_path = str(tmp_path / 'cuts.jsonl')
+        CutSet.from_cuts(cuts).to_file(cuts_path)
+
+        train_config = DictConfig(
+            {
+                'cuts_path': cuts_path,
+                'batch_size': 2,
+                'use_lhotse': True,
+                'is_tarred': True,
+                'sample_rate': 16000,
+                'shuffle': False,
+                'num_workers': 0,
+                'pretokenize': False,
+                'initialize_prompt_feature': True,
+                'num_prompts': 128,
+                'prompt_dictionary': {'en_US': 0},
+            }
+        )
+
+        model.setup_training_data(train_config)
+
+        assert not isinstance(model._train_dl.dataset, torch.utils.data.IterableDataset)
+        assert not hasattr(model._train_dl.dataset, '__len__')
+        assert trainer.limit_train_batches == 1.0


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Fixes #16004: training crashes with `TypeError: object of type 'LhotseSpeechToTextBpeDatasetWithPromptIndex' has no len()` whenever `limit_train_batches` is a float (including the Lightning default of 1.0) while the train data comes from Lhotse.

**Collection**: ASR

# Changelog

- In `EncDecHybridRNNTCTCBPEModel` and the prompt-based RNNT model, the `limit_train_batches` conversion now enters only when the dataloader's dataset is an `IterableDataset` that also defines `__len__`, matching the guard pattern already used by the base class for the other ASR models.
- NeMo tarred datasets still qualify and keep the conversion; Lhotse map-style datasets and `IterableDatasetWrapper` skip it, so Lightning keeps treating a float value as a fraction of one epoch.
- Adds a regression test that reproduces the reported `TypeError` before the fix and passes after it.

Root cause: both models guarded the conversion on the `is_tarred` config key and then called `len()` on the built dataset. With `use_lhotse=true` the dataset is map-style without `__len__`, so any float `limit_train_batches` raised the crash from the linked issue.

# Usage

No configuration change is required. With `model.train_ds.use_lhotse=true`, any float `trainer.limit_train_batches` now trains normally instead of crashing:

```yaml
trainer:
  limit_train_batches: 0.5   # or the default 1.0
model:
  train_ds:
    use_lhotse: true
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

Trusted PRs run automatically through copy-pr-bot. For an untrusted PR, a maintainer can trigger CI by commenting
`/ok to test <head-sha>`; repeat this after a new push if the PR remains untrusted.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? Yes: regression test in `tests/collections/asr/test_asr_rnnt_encoder_model_bpe_prompt.py`, fails before the fix (`TypeError ... has no len()`) and passes after.
- [ ] Did you add or update any necessary documentation? No documentation change needed: pure bug fix, no public API, config key, CLI behavior, or user workflow changed.
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc) No, no optional dependency is touched, so no new import guards are needed.
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries? N/A.

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to #16004 (fixes it)

Exact checks run locally (Python 3.12.6, torch 2.11.0+cu128):

```
python -m pytest tests/collections/asr/test_asr_rnnt_encoder_model_bpe_prompt.py -x -q -m "not pleasefixme"
  -> 13 passed (57s), including the new regression test
python -m pytest tests/collections/asr/test_asr_hybrid_rnnt_ctc_model_bpe_prompt.py -q -m "not pleasefixme"
  -> 15 passed (105s)
python -m black --check --diff <changed files>      -> clean
python -m isort --check-only --diff <changed files> -> clean
python -m flake8 <changed files>                    -> clean
git diff --check                                    -> clean
```

Intentionally skipped: full ASR suite (blast radius of this change is two setup methods plus their base-class pattern), docs build (`uv` unavailable on this machine), `pre-commit` binary absent locally; black/isort/flake8 were run directly against the same pinned configs instead.
