### PR TITLE
Bump minimum torch version to 2.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "smart-open",
     "tensorboard",
     "text-unidecode",
-    "torch>=2.6.0",
+    "torch>=2.7.0",
     "tqdm>=4.41.0",
     "wrapt",
 ]
@@ -518,7 +518,7 @@ requires-dist = [
     "pybind11",
     "pyyaml",
     "tiktoken",
-    "torch>=2.6.0",
+    "torch>=2.7.0",
     "torchdata",
     "transformers==5.12.1",
     "wandb>=0.28.0",

--- a/uv.lock
+++ b/uv.lock
@@ -59,7 +59,7 @@ overrides = [
 [[manifest.dependency-metadata]]
 name = "nemo-automodel"
 version = "0.5.0+cb03cf61"
-requires-dist = ["datasets>=4.0.0", "megatron-fsdp==0.5.0", "mistral-common[audio,hf-hub,sentencepiece]", "pybind11", "pyyaml", "tiktoken", "torch>=2.6.0", "torchdata", "transformers==5.12.1", "wandb>=0.28.0", "torchao", "mlflow", "flashoptim>=0.1.3", "quack-kernels==0.6.1 ; sys_platform == 'linux'"]
+requires-dist = ["datasets>=4.0.0", "megatron-fsdp==0.5.0", "mistral-common[audio,hf-hub,sentencepiece]", "pybind11", "pyyaml", "tiktoken", "torch>=2.7.0", "torchdata", "transformers==5.12.1", "wandb>=0.28.0", "torchao", "mlflow", "flashoptim>=0.1.3", "quack-kernels==0.6.1 ; sys_platform == 'linux'"]
 requires-python = ">=3.10"
 
 [[package]]
@@ -4742,9 +4742,9 @@ requires-dist = [
     { name = "soundfile", marker = "extra == 'tts'" },
     { name = "tensorboard" },
     { name = "text-unidecode" },
-    { name = "torch", marker = "sys_platform != 'darwin' and sys_platform != 'linux'", specifier = ">=2.6.0", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "torch", marker = "sys_platform == 'darwin'", specifier = ">=2.6.0", index = "https://pypi.org/simple" },
-    { name = "torch", marker = "sys_platform == 'linux'", specifier = ">=2.6.0" },
+    { name = "torch", marker = "sys_platform != 'darwin' and sys_platform != 'linux'", specifier = ">=2.7.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torch", marker = "sys_platform == 'darwin'", specifier = ">=2.7.0", index = "https://pypi.org/simple" },
+    { name = "torch", marker = "sys_platform == 'linux'", specifier = ">=2.7.0" },
     { name = "torch", marker = "sys_platform == 'linux' and extra == 'cu12'", specifier = "==2.11.0+cu129", index = "https://download.pytorch.org/whl/cu129", conflict = { package = "nemo-toolkit", extra = "cu12" } },
     { name = "torch", marker = "sys_platform == 'linux' and extra == 'cu13'", specifier = "==2.12.0+cu132", index = "https://download.pytorch.org/whl/cu132", conflict = { package = "nemo-toolkit", extra = "cu13" } },
     { name = "torchmetrics", marker = "extra == 'all'", specifier = ">=0.11.0" },


### PR DESCRIPTION
As discussed in #16114 
This is the minimum version that can detect dynamo export, and it's needed in modules that use triton kernels

cc @nithinraok @chtruong814 