### PR TITLE
Register PackedEncoderActivations as a pytree node so FSDP2 updates perception weights

### DIFF
--- a/nemo/collections/asr/parts/packed_sequence.py
+++ b/nemo/collections/asr/parts/packed_sequence.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 
 import torch
 from torch import Tensor
+from torch.utils._pytree import GetAttrKey, register_pytree_node
 
 __all__ = [
     "PackedEncoderActivations",
@@ -270,3 +271,49 @@ def _new_packed_encoder_activations(data, lengths, cu_seqlens, max_seqlen, paddi
     object.__setattr__(packed, "padding_value", padding_value)
     object.__setattr__(packed, "padded_length", padded_length)
     return packed
+
+
+_PACKED_TENSOR_FIELDS = ("data", "lengths", "cu_seqlens", "padding_value")
+
+
+def _flatten_packed_encoder_activations(packed: PackedEncoderActivations):
+    tensor_padding = isinstance(packed.padding_value, Tensor)
+    children = [packed.data, packed.lengths, packed.cu_seqlens]
+    if tensor_padding:
+        children.append(packed.padding_value)
+    context = (packed.max_seqlen, packed.padded_length, None if tensor_padding else packed.padding_value)
+    return children, context
+
+
+def _flatten_packed_encoder_activations_with_keys(packed: PackedEncoderActivations):
+    children, context = _flatten_packed_encoder_activations(packed)
+    return [(GetAttrKey(name), child) for name, child in zip(_PACKED_TENSOR_FIELDS, children)], context
+
+
+def _unflatten_packed_encoder_activations(children, context) -> PackedEncoderActivations:
+    max_seqlen, padded_length, scalar_padding_value = context
+    data, lengths, cu_seqlens, *tensor_padding_value = children
+    return _new_packed_encoder_activations(
+        data,
+        lengths,
+        cu_seqlens,
+        max_seqlen,
+        padding_value=tensor_padding_value[0] if tensor_padding_value else scalar_padding_value,
+        padded_length=padded_length,
+    )
+
+
+# FSDP2 discovers the output tensors that need its pre-backward hook by calling
+# tree_flatten() on the module output. While unregistered, this container is a
+# single opaque leaf, so an FSDP root forward returning it never runs the
+# post-backward lifecycle that moves gradients onto the optimizer-owned DTensor
+# parameters, and the optimizer silently skips those weights. Only the tensor
+# fields are children so that generic tensor transforms never see the integer
+# metadata, and unflattening reuses the already validated offsets.
+register_pytree_node(
+    PackedEncoderActivations,
+    _flatten_packed_encoder_activations,
+    _unflatten_packed_encoder_activations,
+    flatten_with_keys_fn=_flatten_packed_encoder_activations_with_keys,
+    serialized_type_name="nemo.collections.asr.parts.packed_sequence.PackedEncoderActivations",
+)

--- a/tests/collections/asr/test_packed_sequence_round2.py
+++ b/tests/collections/asr/test_packed_sequence_round2.py
@@ -16,6 +16,7 @@ import copy
 
 import pytest
 import torch
+from torch.utils._pytree import tree_flatten, tree_flatten_with_path, tree_map, tree_unflatten
 
 from nemo.collections.asr.modules.moe_transformer_encoder import MoEFeedForward, MoETransformerEncoder
 from nemo.collections.asr.parts.packed_sequence import PackedEncoderActivations, pack_encoder_output
@@ -35,6 +36,45 @@ def test_packed_output_with_data_reuses_validated_metadata_and_preserves_gradien
     assert replacement.grad is not None
     with pytest.raises(ValueError, match="replacement data"):
         packed.with_data(torch.randn(5, 3))
+
+
+def test_packed_output_flattens_to_its_tensors_so_autograd_hooks_can_reach_them():
+    packed = pack_encoder_output(torch.randn(2, 4, 3, requires_grad=True), torch.tensor([4, 2]))
+
+    leaves, treespec = tree_flatten(packed)
+    restored = tree_unflatten(leaves, treespec)
+
+    assert len(leaves) == 3
+    assert leaves[0] is packed.data
+    assert leaves[1] is packed.lengths
+    assert leaves[2] is packed.cu_seqlens
+    assert restored.data is packed.data
+    assert restored.max_seqlen == packed.max_seqlen
+    assert restored.padded_length == packed.padded_length
+    assert restored.padding_value == packed.padding_value
+    assert [str(path[-1]) for path, _ in tree_flatten_with_path(packed)[0]] == [".data", ".lengths", ".cu_seqlens"]
+
+
+def test_packed_output_tensor_mapping_covers_tensor_padding_and_keeps_metadata():
+    dense = pack_encoder_output(torch.randn(2, 4, 3), torch.tensor([4, 2]))
+    packed = PackedEncoderActivations(
+        dense.data,
+        dense.lengths,
+        dense.cu_seqlens,
+        dense.max_seqlen,
+        padding_value=torch.zeros(2, 3),
+        padded_length=dense.padded_length,
+    )
+
+    mapped = tree_map(lambda leaf: leaf.to(torch.float64) if leaf.is_floating_point() else leaf, packed)
+
+    assert len(tree_flatten(packed)[0]) == 4
+    assert mapped.data.dtype == torch.float64
+    assert mapped.padding_value.dtype == torch.float64
+    assert mapped.lengths.dtype == torch.int64
+    assert mapped.cu_seqlens.dtype == torch.int32
+    assert mapped.max_seqlen == packed.max_seqlen
+    assert mapped.padded_length == packed.padded_length
 
 
 @pytest.mark.parametrize(("top_k", "router_type"), [(1, "switch"), (2, "omni")])

--- a/tests/collections/speechlm2/test_perception_packed_sequence_fsdp2_distributed.py
+++ b/tests/collections/speechlm2/test_perception_packed_sequence_fsdp2_distributed.py
@@ -17,6 +17,7 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import DTensor
 
 from nemo.collections.asr.modules.transformer_encoder import TransformerEncoder
 from nemo.collections.asr.parts.packed_sequence import pack_encoder_output
@@ -42,6 +43,15 @@ class _WorldCpMesh:
 
     def get_group(self):
         return dist.group.WORLD
+
+
+class _PackedLinearPerception(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = torch.nn.Sequential(torch.nn.Linear(5, 8), torch.nn.SiLU(), torch.nn.Linear(8, 8))
+
+    def forward_sequence_packed(self, *, input_signal, input_signal_length):
+        return pack_encoder_output(self.layers(input_signal), input_signal_length)
 
 
 class _ScalePerception(torch.nn.Module):
@@ -212,6 +222,47 @@ def _run_fsdp2_grouped_pee_test(rank: int, world_size: int, init_file: str):
         assert all(parameter.grad is not None for parameter in perception.parameters() if parameter.requires_grad)
     finally:
         dist.destroy_process_group()
+
+
+def _run_fsdp2_optimizer_owned_gradient_test(rank: int, world_size: int, init_file: str):
+    dist.init_process_group("gloo", init_method=f"file://{init_file}", rank=rank, world_size=world_size)
+    try:
+        torch.manual_seed(123)
+        mesh = init_device_mesh("cpu", (world_size,), mesh_dim_names=("dp",))
+        perception = _fully_shard_perception(_PackedLinearPerception(), mesh)
+        head = torch.nn.Linear(8, 4)
+        optimizer = torch.optim.AdamW(list(perception.parameters()) + list(head.parameters()), lr=1e-2)
+
+        # Sample the parameter the optimizer owns before any forward. FSDP2 swaps
+        # in unsharded temporaries during forward, so gradients seen by iterating
+        # perception.parameters() afterwards do not prove that the optimizer's own
+        # sharded parameters received them.
+        sample = next(iter(perception.parameters()))
+        initial = sample.to_local().detach().clone()
+
+        for step in range(1, 4):
+            optimizer.zero_grad(set_to_none=True)
+            packed = perception.forward_sequence_packed(
+                input_signal=torch.randn(2, 7, 5),
+                input_signal_length=torch.tensor([7, 4]),
+            )
+            head(packed.data).square().mean().backward()
+            assert isinstance(sample.grad, DTensor)
+            optimizer.step()
+            assert int(optimizer.state[sample]["step"]) == step
+
+        assert (sample.to_local() - initial).abs().max() > 0
+    finally:
+        dist.destroy_process_group()
+
+
+def test_packed_perception_fsdp2_updates_optimizer_owned_parameters(tmp_path):
+    mp.spawn(
+        _run_fsdp2_optimizer_owned_gradient_test,
+        args=(2, str(tmp_path / "optimizer_owned_gradient_init")),
+        nprocs=2,
+        join=True,
+    )
 
 
 @pytest.mark.skipif(not torch.cuda.is_available() or torch.cuda.device_count() < 2, reason="Test requires 2 GPUs")


### PR DESCRIPTION
## Problem

When perception is FSDP2-sharded, `_fully_shard_perception` registers `forward_sequence_packed` as the FSDP root forward, and that method returns `PackedEncoderActivations`. FSDP2 finds the output tensors that need its pre-backward hook by calling `tree_flatten` on the module output, and an unregistered frozen dataclass flattens to a single opaque leaf, so no output tensor ever receives the hook.

Backward still computes gradients through `PackedEncoderActivations.data`, so the temporary unsharded parameters exposed during forward look healthy. FSDP never runs the post-backward lifecycle that moves those gradients onto the optimizer-owned DTensor parameters, however, so the sharded ASR encoder, PEE fusion, and perception projection parameters keep `grad=None`, their Adam state stays at step 0, and their weights never change even though they are trainable and present in the optimizer.

This is silent in practice, and it silently affected real runs: Hero5c and Hero6a both enable `packed_encoder_sequences`, and their exported perception weights are byte-identical across widely separated steps (all 768 perception tensors unchanged between Hero5c steps 9000/10499/10999, all 850 unchanged across Hero6a steps 500/1000/16500), while sampled Adam state for those parameters sits near step 1 with a zero first moment and a sampled LLM parameter shows the expected step count. Those runs effectively fine-tuned the LLM while perception stayed at its initialization.

## Fix

Register `PackedEncoderActivations` as a pytree node so FSDP2's `tree_flatten` reaches its tensors and attaches the hook. Only the tensor fields are children; `max_seqlen`, `padded_length`, and a scalar `padding_value` live in the treespec context, so generic tensor transforms never see integer metadata, and unflattening goes through the existing already-validated constructor rather than re-running validation (and its host syncs) on every unflatten.

An equivalent alternative is to make the FSDP-registered method return a tensor/tuple and rebuild the dataclass outside the sharded module. Registration was chosen because it is local to the container and fixes every current and future FSDP boundary that returns it.

## Verification

A two-rank CPU FSDP2 A/B using the real `PackedEncoderActivations` and `pack_encoder_output`, with a registered custom packed root forward and AdamW over 5 steps, sampling the optimizer-owned parameter before the first forward:

| | optimizer-owned grad | Adam step | weight delta |
|---|---|---|---|
| before | `None` | none | `0.0` |
| after | `DTensor` | `5` | `0.047` |

## Tests

- `tests/collections/speechlm2/test_perception_packed_sequence_fsdp2_distributed.py::test_packed_perception_fsdp2_updates_optimizer_owned_parameters`: two-rank gloo/CPU regression test that shards a packed perception module through the production `_fully_shard_perception` helper, samples the optimizer-owned parameter *before* forward, and asserts a DTensor gradient, an advancing Adam step, and a nonzero weight delta. It fails on this branch without the fix and passes with it. Checking `module.parameters()` after forward, as the existing FSDP2 tests do, cannot catch this bug because it observes the unsharded temporaries.
- `tests/collections/asr/test_packed_sequence_round2.py`: unit coverage for the flatten contract — the tensor fields are the leaves (identity-preserving, so autograd hooks land on the real tensors), round-tripping preserves metadata, the keyed flatten reports field names, and a tensor `padding_value` participates in tensor mapping while the integer metadata is untouched.