### PR TITLE
[ASR] add cache-aware streaming transformer

### DIFF
--- a/docs/source/asr/api.rst
+++ b/docs/source/asr/api.rst
@@ -78,6 +78,20 @@ Modules
     :members:
 
 
+.. _transformer-encoder-api:
+
+.. autoclass:: nemo.collections.asr.modules.TransformerEncoder
+    :show-inheritance:
+    :members:
+
+
+.. _streaming-transformer-encoder-api:
+
+.. autoclass:: nemo.collections.asr.modules.StreamingTransformerEncoder
+    :show-inheritance:
+    :members:
+
+
 .. _rnn-encoder-api:
 
 .. autoclass:: nemo.collections.asr.modules.RNNEncoder

--- a/docs/source/asr/configs.rst
+++ b/docs/source/asr/configs.rst
@@ -432,6 +432,53 @@ Conformer-Transducer
 Please refer to the model page of :ref:`Conformer-Transducer <Conformer-Transducer_model>` for more information on this model.
 
 
+Streaming Transformer
+~~~~~~~~~~~~~~~~~~~~~
+
+:ref:`nemo.collections.asr.modules.StreamingTransformerEncoder <streaming-transformer-encoder-api>`
+is a convolution-free Transformer encoder for streaming ASR. It extends
+:ref:`TransformerEncoder <transformer-encoder-api>` with local attention and a rolling KV cache,
+and implements the same cache-aware streaming interface as ``ConformerEncoder``, so it can be
+driven by the shared streaming tooling unchanged.
+
+Attention is bounded by ``att_context_size: [left, right]``, in encoder frames, under one of two
+``att_context_style`` values:
+
+* ``chunked_limited`` — frames are grouped into chunks of ``right + 1``, and a query attends to
+  its whole chunk plus the ``left // (right + 1)`` preceding chunks. The look-ahead does **not**
+  compound across layers, so streaming stays exact at any depth. Use this for in-chunk look-ahead.
+* ``sliding_window`` (default) — a query attends to ``[t - left, t + right]``. Exact for
+  streaming only when ``right == 0``, since a sliding right context compounds across layers.
+
+Passing a list of pairs trains one model across several latencies; one entry is sampled per
+training batch, and evaluation and streaming use the first entry (or whatever
+``set_default_att_context_size`` pins). Select the operating point at inference with
+``transcribe_speech.py att_context_size=[70,13]``.
+
+.. code-block:: yaml
+
+  model:
+    encoder:
+      _target_: nemo.collections.asr.modules.transformer_encoder.StreamingTransformerEncoder
+      d_model: 1024
+      n_heads: 8
+      n_layers: 48
+      subsampling: feature_stacking
+      subsampling_factor: 8
+      self_attention_model: rope     # rel_pos | abs_pos | rope | no_pos
+      qk_norm: true
+      att_context_style: chunked_limited
+      att_context_size: [[70, 13], [70, 6], [70, 1], [70, 0]]
+      # Input-frame look-back prepended to each streaming chunk so the mel front-end's STFT
+      # window has its context. Must be a multiple of ``subsampling_factor``. ``FeatureStacking``
+      # is non-overlapping and needs none of this offline, but a streaming front-end that
+      # recomputes the spectrogram per chunk does.
+      pre_encode_cache_size: ${model.encoder.subsampling_factor}
+
+A ready-to-train RNN-T recipe ships at
+``examples/asr/conf/transformer/transformer_stacking_rnnt_bpe_streaming.yaml``.
+
+
 Transducer Configurations
 -------------------------
 

--- a/docs/source/asr/configs.rst
+++ b/docs/source/asr/configs.rst
@@ -450,6 +450,14 @@ Attention is bounded by ``att_context_size: [left, right]``, in encoder frames, 
 * ``sliding_window`` (default) — a query attends to ``[t - left, t + right]``. Exact for
   streaming only when ``right == 0``, since a sliding right context compounds across layers.
 
+The read-only ``cache_size`` property reports how many encoder frames the rolling KV cache retains.
+For ``sliding_window`` it equals ``left``. For ``chunked_limited`` it is rounded down to the visible
+whole chunks when ``right`` is finite: ``(left // (right + 1)) * (right + 1)``. An unlimited right
+context uses ``left`` directly. A negative cache size means unbounded left context;
+``setup_streaming_params`` maps it to ``max_context`` (10,000 frames by default) for the allocated
+streaming cache. This is separate from ``pre_encode_cache_size``, which retains input-feature frames
+needed before subsampling.
+
 Passing a list of pairs trains one model across several latencies; one entry is sampled per
 training batch, and evaluation and streaming use the first entry (or whatever
 ``set_default_att_context_size`` pins). Select the operating point at inference with

--- a/examples/asr/conf/transformer/transformer_stacking_rnnt_bpe_streaming.yaml
+++ b/examples/asr/conf/transformer/transformer_stacking_rnnt_bpe_streaming.yaml
@@ -78,9 +78,9 @@ model:
     _target_: nemo.collections.asr.modules.transformer_encoder.StreamingTransformerEncoder
     feat_in: ${model.preprocessor.features}
     feat_out: -1  # -1 -> output dim = d_model
-    d_model: 1024
-    n_heads: 8  # d_model / n_heads = 128
-    n_layers: 48
+    d_model: 1536
+    n_heads: 12  # d_model / n_heads = 128
+    n_layers: 21
     drop_rate: 0.1
     qkv_bias: false
     qk_norm: true

--- a/examples/asr/conf/transformer/transformer_stacking_rnnt_bpe_streaming.yaml
+++ b/examples/asr/conf/transformer/transformer_stacking_rnnt_bpe_streaming.yaml
@@ -1,4 +1,4 @@
-# It contains the default values for training a cache-aware streaming Streaming-Transformer-Stacked-RNNT ASR model, xlarge size (~600M) with sub-word encoding.
+# It contains the default values for training a cache-aware streaming Transformer-RNNT ASR model, xlarge size (~600M) with sub-word encoding.
 
 name: "Streaming-Transformer-RNNT-BPE-Streaming"
 
@@ -20,7 +20,7 @@ model:
     shuffle: true
     num_workers: 8
     pin_memory: true
-    max_duration: 20 # you may need to update it for your dataset
+    max_duration: 50 # you may need to update it for your dataset
     min_duration: 0.1
     # tarred datasets
     is_tarred: false
@@ -61,7 +61,7 @@ model:
     window_size: 0.025
     window_stride: 0.01
     window: "hann"
-    features: 80
+    features: 128
     n_fft: 512
     frame_splicing: 1
     dither: 0.00001

--- a/examples/asr/conf/transformer/transformer_stacking_rnnt_bpe_streaming.yaml
+++ b/examples/asr/conf/transformer/transformer_stacking_rnnt_bpe_streaming.yaml
@@ -20,7 +20,7 @@ model:
     shuffle: true
     num_workers: 8
     pin_memory: true
-    max_duration: 50 # you may need to update it for your dataset
+    max_duration: 40 # you may need to update it for your dataset
     min_duration: 0.1
     # tarred datasets
     is_tarred: false
@@ -143,15 +143,6 @@ model:
       score_norm: true
       tsd_max_sym_exp: 50  # for Time Synchronous Decoding
       alsd_max_target_len: 2.0  # for Alignment-Length Synchronous Decoding
-
-  # config for InterCTC loss: https://arxiv.org/abs/2102.03216
-  # specify loss weights and which layers to use for InterCTC
-  # e.g., to reproduce the paper results, set loss_weights: [0.3]
-  # and apply_at_layers: [8] (assuming 18 layers). Note that final
-  # layer loss coefficient is automatically adjusted (to 0.7 in above example)
-  interctc:
-    loss_weights: []
-    apply_at_layers: []
 
   loss:
     loss_name: "default"

--- a/examples/asr/conf/transformer/transformer_stacking_rnnt_bpe_streaming.yaml
+++ b/examples/asr/conf/transformer/transformer_stacking_rnnt_bpe_streaming.yaml
@@ -1,0 +1,222 @@
+# It contains the default values for training a cache-aware streaming Streaming-Transformer-Stacked-RNNT ASR model, xlarge size (~600M) with sub-word encoding.
+
+name: "Streaming-Transformer-RNNT-BPE-Streaming"
+
+model:
+  sample_rate: 16000
+  compute_eval_loss: false # eval samples can be very long and exhaust memory. Disable computation of transducer loss during validation/testing with this flag.
+  log_prediction: true # enables logging sample predictions in the output during training
+  skip_nan_grad: false
+
+  model_defaults:
+    enc_hidden: ${model.encoder.d_model}
+    pred_hidden: 640
+    joint_hidden: 640
+
+  train_ds:
+    manifest_filepath: ???
+    sample_rate: ${model.sample_rate}
+    batch_size: 16 # you may increase batch_size if your memory allows
+    shuffle: true
+    num_workers: 8
+    pin_memory: true
+    max_duration: 20 # you may need to update it for your dataset
+    min_duration: 0.1
+    # tarred datasets
+    is_tarred: false
+    tarred_audio_filepaths: null
+    shuffle_n: 2048
+    # bucketing params
+    bucketing_strategy: "synced_randomized"
+    bucketing_batch_size: null
+
+  validation_ds:
+    manifest_filepath: ???
+    sample_rate: ${model.sample_rate}
+    batch_size: 16
+    shuffle: false
+    use_start_end_token: false
+    num_workers: 8
+    pin_memory: true
+
+  test_ds:
+    manifest_filepath: null
+    sample_rate: ${model.sample_rate}
+    batch_size: 16
+    shuffle: false
+    use_start_end_token: false
+    num_workers: 8
+    pin_memory: true
+
+  # You may find more detail on how to train a tokenizer at: /scripts/tokenizers/process_asr_text_tokenizer.py
+  # We recommend to use vocab size of 1024 with SPE Unigram for most languages
+  tokenizer:
+    dir: ???  # path to directory which contains either tokenizer.model (bpe) or vocab.txt (for wpe)
+    type: bpe  # Can be either bpe (SentencePiece tokenizer) or wpe (WordPiece tokenizer)
+
+  preprocessor:
+    _target_: nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor
+    sample_rate: ${model.sample_rate}
+    normalize: "NA" # No normalization for mel-spectogram makes streaming easier
+    window_size: 0.025
+    window_stride: 0.01
+    window: "hann"
+    features: 80
+    n_fft: 512
+    frame_splicing: 1
+    dither: 0.00001
+    pad_to: 0
+
+  spec_augment:
+    _target_: nemo.collections.asr.modules.SpectrogramAugmentation
+    freq_masks: 2 # set to zero to disable it
+    time_masks: 10 # set to zero to disable it
+    freq_width: 27
+    time_width: 0.05
+
+  encoder:
+    _target_: nemo.collections.asr.modules.transformer_encoder.StreamingTransformerEncoder
+    feat_in: ${model.preprocessor.features}
+    feat_out: -1  # -1 -> output dim = d_model
+    d_model: 1024
+    n_heads: 8  # d_model / n_heads = 128
+    n_layers: 48
+    drop_rate: 0.1
+    qkv_bias: false
+    qk_norm: true
+    ff_expansion: 4
+    pre_block_norm: true
+    subsampling: feature_stacking
+    subsampling_factor: 8
+    self_attention_model: rope  # rel_pos
+    rope_base: 10000.0
+    rotary_fraction: 1.0
+    pos_emb_max_len: 5000
+    att_context_size: [[70, 13], [70, 6], [70, 1], [70, 0]]  # [left, right]; causal (right=0)
+    att_context_style: chunked_limited # sliding_window
+    pre_encode_cache_size: ${model.encoder.subsampling_factor}
+
+  decoder:
+    _target_: nemo.collections.asr.modules.RNNTDecoder
+    normalization_mode: null # Currently only null is supported for export.
+    random_state_sampling: false # Random state sampling: https://arxiv.org/pdf/1910.11455.pdf
+    blank_as_pad: true # This flag must be set in order to support exporting of RNNT models + efficient inference.
+
+    prednet:
+      pred_hidden: ${model.model_defaults.pred_hidden}
+      pred_rnn_layers: 1
+      t_max: null
+      dropout: 0.2
+
+  joint:
+    _target_: nemo.collections.asr.modules.RNNTJoint
+    log_softmax: null  # 'null' would set it automatically according to CPU/GPU device
+    preserve_memory: false  # dramatically slows down training, but might preserve some memory
+
+    # Fuses the computation of prediction net + joint net + loss + WER calculation
+    # to be run on sub-batches of size `fused_batch_size`.
+    # When this flag is set to true, consider the `batch_size` of *_ds to be just `encoder` batch size.
+    # `fused_batch_size` is the actual batch size of the prediction net, joint net and transducer loss.
+    # Using small values here will preserve a lot of memory during training, but will make training slower as well.
+    # An optimal ratio of fused_batch_size : *_ds.batch_size is 1:1.
+    # However, to preserve memory, this ratio can be 1:8 or even 1:16.
+    # Extreme case of 1:B (i.e. fused_batch_size=1) should be avoided as training speed would be very slow.
+    fuse_loss_wer: true
+    fused_batch_size: 4
+
+    jointnet:
+      joint_hidden: ${model.model_defaults.joint_hidden}
+      activation: "relu"
+      dropout: 0.2
+
+  decoding:
+    strategy: "greedy_batch" # can be greedy, greedy_batch, beam, tsd, alsd.
+
+    # greedy strategy config
+    greedy:
+      max_symbols: 10
+
+    # beam strategy config
+    beam:
+      beam_size: 2
+      return_best_hypothesis: False
+      score_norm: true
+      tsd_max_sym_exp: 50  # for Time Synchronous Decoding
+      alsd_max_target_len: 2.0  # for Alignment-Length Synchronous Decoding
+
+  # config for InterCTC loss: https://arxiv.org/abs/2102.03216
+  # specify loss weights and which layers to use for InterCTC
+  # e.g., to reproduce the paper results, set loss_weights: [0.3]
+  # and apply_at_layers: [8] (assuming 18 layers). Note that final
+  # layer loss coefficient is automatically adjusted (to 0.7 in above example)
+  interctc:
+    loss_weights: []
+    apply_at_layers: []
+
+  loss:
+    loss_name: "default"
+    warprnnt_numba_kwargs:
+      # FastEmit regularization: https://arxiv.org/abs/2010.11148
+      # You may enable FastEmit to increase the accuracy and reduce the latency of the model for streaming
+      # You may set it to lower values like 1e-3 for models with larger right context
+      fastemit_lambda: 5e-3  # Recommended values to be in range [1e-4, 1e-2], 0.001 is a good start.
+      clamp: -1.0  # if > 0, applies gradient clamping in range [-clamp, clamp] for the joint tensor only.
+
+  optim:
+    name: adamw
+    lr: 0.001
+    # optimizer arguments
+    betas: [0.9, 0.98]
+    weight_decay: 1e-3
+
+    # scheduler setup
+    sched:
+      name: CosineAnnealing
+      # scheduler config override
+      warmup_steps: 10000
+      warmup_ratio: null
+      min_lr: 1e-6
+
+trainer:
+  devices: -1 # number of GPUs, -1 would use all available GPUs
+  num_nodes: 1
+  max_epochs: -1
+  max_steps: 1000000
+  val_check_interval: 5000 # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
+  accelerator: auto
+  strategy:
+    _target_: lightning.pytorch.strategies.DDPStrategy
+    gradient_as_bucket_view: true
+  accumulate_grad_batches: 1
+  gradient_clip_val: 1.0
+  precision: 32 # 16, 32, or bf16
+  log_every_n_steps: 10  # Interval of logging.
+  enable_progress_bar: True
+  num_sanity_val_steps: 0 # number of steps to perform validation steps for sanity check the validation process before starting the training, setting to 0 disables it
+  check_val_every_n_epoch: 1 # number of evaluations on validation every n epochs
+  sync_batchnorm: true
+  enable_checkpointing: False  # Provided by exp_manager
+  logger: false  # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
+
+
+exp_manager:
+  exp_dir: null
+  name: ${name}
+  create_tensorboard_logger: true
+  create_checkpoint_callback: true
+  checkpoint_callback_params:
+    # in case of multiple validation sets, first one is used
+    monitor: "val_wer"
+    mode: "min"
+    save_top_k: 5
+    always_save_nemo: True # saves the checkpoints as nemo files instead of PTL checkpoints
+  resume_from_checkpoint: null # The path to a checkpoint file to continue the training, restores the whole state including the epoch, step, LR schedulers, apex, etc.
+  resume_if_exists: false
+  resume_ignore_no_checkpoint: false
+
+  create_wandb_logger: false
+  wandb_logger_kwargs:
+    name: null
+    project: null
+    resume: true

--- a/nemo/collections/asr/modules/__init__.py
+++ b/nemo/collections/asr/modules/__init__.py
@@ -53,7 +53,10 @@ from nemo.collections.asr.modules.ssl_modules import (  # noqa: F401
     RandomBlockMasking,
     RandomProjectionVectorQuantizer,
 )
-from nemo.collections.asr.modules.transformer_encoder import TransformerEncoder  # noqa: F401
+from nemo.collections.asr.modules.transformer_encoder import (  # noqa: F401
+    StreamingTransformerEncoder,
+    TransformerEncoder,
+)
 
 __all__ = [
     'AudioToMelSpectrogramPreprocessor',
@@ -86,5 +89,6 @@ __all__ = [
     'MultiSoftmaxDecoder',
     'RandomBlockMasking',
     'RandomProjectionVectorQuantizer',
+    'StreamingTransformerEncoder',
     'TransformerEncoder',
 ]

--- a/nemo/collections/asr/modules/transformer_encoder.py
+++ b/nemo/collections/asr/modules/transformer_encoder.py
@@ -183,16 +183,6 @@ class FeedForward(nn.Module):
     def __init__(self, cfg: TransformerEncoderConfig):
         super().__init__()
         ff_hidden = int(cfg.ff_expansion * cfg.d_model)
-        # No dropout after the output projection: ``TransformerBlock`` already applies
-        # dropout to this module's output on the residual branch, and stacking the two
-        # gives an effective rate of ``1 - (1 - drop_rate)^2`` (19% at the default 0.1)
-        # with ~2.1x the intended noise variance, in every layer. Matches
-        # ``ConformerFeedForward``, which also drops only after the activation.
-        #
-        # Keep the trailing position free rather than renumbering: the module indices are
-        # state_dict keys (``net.0.*``, ``net.3.*``), so removing this last entry stays
-        # load-compatible with existing checkpoints, while dropping the *inner* Dropout
-        # would shift the second Linear to ``net.2.*`` and break them.
         self.net = nn.Sequential(
             nn.Linear(cfg.d_model, ff_hidden),
             nn.GELU(),

--- a/nemo/collections/asr/modules/transformer_encoder.py
+++ b/nemo/collections/asr/modules/transformer_encoder.py
@@ -133,6 +133,13 @@ def _make_sliding_window_mod(left, right):
     context; ``right < 0`` -> unlimited right context / look-ahead). Callers are expected
     to pass at least one non-negative bound — when both are negative the window is
     unbounded (full attention) and this mod should be skipped entirely.
+
+    Args:
+        left (int): Maximum number of positions available to the left of each query.
+        right (int): Maximum number of positions available to the right of each query.
+
+    Returns:
+        mask_mod (Callable): FlexAttention mask function for the requested sliding window.
     """
 
     def sliding_window(b, h, q_idx, kv_idx):
@@ -159,6 +166,13 @@ def _make_chunked_limited_mod(left, right):
     layers: every layer stops at the same chunk boundary, so an N-layer stack still looks
     ahead at most to the end of the current chunk. That is what makes it streamable — see
     :class:`StreamingTransformerEncoder`.
+
+    Args:
+        left (int): Maximum left context in encoder frames; negative means unlimited.
+        right (int): In-chunk right context. The attention chunk size is ``right + 1``.
+
+    Returns:
+        mask_mod (Callable): FlexAttention mask function for chunk-aligned limited context.
     """
     chunk = right + 1
     # ``left_chunks`` is a Python int (or None) known at trace time, so the branch below is
@@ -338,6 +352,18 @@ class MultiHeadAttention(nn.Module):
         position *difference*, so streaming needs no explicit position offset) and returns
         ``score_mod=None``; ``rel_pos`` leaves ``q``/``k`` in place (folding ``pos_bias_u`` into
         ``q``) and returns a relative-position ``score_mod``.
+
+        Args:
+            q (torch.Tensor): Current-chunk queries of shape ``(B, H, num_cur, D)``.
+            k (torch.Tensor): Cached and current keys of shape ``(B, H, num_kv, D)``.
+            pos_emb (Optional[torch.Tensor]): Positional embeddings for relative attention.
+            num_cur (int): Number of query positions in the current chunk.
+            num_kv (int): Total number of cached and current key/value positions.
+
+        Returns:
+            q (torch.Tensor): Position-adjusted queries.
+            k_mod (Optional[torch.Tensor]): Position-adjusted keys, or ``None`` when unchanged.
+            score_mod (Optional[Callable]): FlexAttention score modifier, if required.
         """
         if self.self_attention_model == "rel_pos":
             return self._build_streaming_rel_pos_score_mod(q, pos_emb, num_cur, num_kv)
@@ -368,7 +394,16 @@ class MultiHeadAttention(nn.Module):
         ``i = num_cur - 1 - j + k``. The bias is gathered directly (no square ``rel_shift``),
         which keeps it correct for ``num_cur != num_kv`` and easy to generalize.
 
-        Returns ``(q_with_bias_u, k, score_mod)``.
+        Args:
+            q (torch.Tensor): Current-chunk queries of shape ``(B, H, num_cur, D)``.
+            pos_emb (torch.Tensor): Relative-position embeddings for the full KV span.
+            num_cur (int): Number of query positions in the current chunk.
+            num_kv (int): Total number of cached and current key/value positions.
+
+        Returns:
+            q_with_bias_u (torch.Tensor): Queries with the Transformer-XL content bias applied.
+            k_mod (None): ``None`` because relative attention does not transform the keys.
+            score_mod (Callable): FlexAttention score modifier containing the relative-position bias.
         """
         H, D = self.n_heads, self.head_dim
         device = q.device
@@ -788,6 +823,12 @@ class TransformerEncoder(nn.Module):
         (e.g. :class:`StreamingTransformerEncoder`) override this to inject other attention
         patterns such as a sliding window; the single overridable hook keeps
         ``forward_internal`` agnostic to the masking scheme.
+
+        Args:
+            length (torch.Tensor): Valid sequence length for each batch element.
+
+        Returns:
+            mask_mod (Callable): FlexAttention mask function combining attention and padding constraints.
         """
         pad_mod = _make_padding_mod(length)
         if self.attn_mode == "causal":
@@ -1076,14 +1117,15 @@ class StreamingTransformerEncoder(TransformerEncoder, StreamingEncoder):
                 attention context — ``right + 1`` — which is the true chunk size under
                 ``chunked_limited`` and, under a causal ``sliding_window`` (``right == 0``), the
                 minimum-latency single-frame step. A causal sliding window streams exactly at *any*
-                chunk size, so overriding this is free there; under ``chunked_limited`` it must not
-                exceed ``right + 1`` or streaming stops matching the offline forward.
+                chunk size, so overriding this is free there; under ``chunked_limited`` it must
+                equal ``right + 1`` or streaming stops matching the offline forward.
             shift_size: Encoder frames the buffer advances per step. Defaults to ``chunk_size``.
                 Only equal values are supported — overlapping chunks would recompute frames this
                 encoder already emits exactly.
-            left_chunks: Number of left chunks visible to each chunk. When given, it *retunes the
-                attention window* (``left = left_chunks * chunk_size``) rather than only the cache,
-                so the mask and the cache cannot disagree.
+            left_chunks: Number of left chunks visible to each chunk. When given, it retunes the
+                active evaluation/streaming attention window (``left = left_chunks * chunk_size``)
+                rather than only the cache, so the mask and the cache cannot disagree. Configured
+                training contexts in ``att_context_size_all`` are left unchanged.
             att_context_size: Optional ``[left, right]`` to apply before computing the config.
             max_context: Cache size to use when the left context is unbounded (``left < 0``).
         """
@@ -1098,10 +1140,10 @@ class StreamingTransformerEncoder(TransformerEncoder, StreamingEncoder):
         chunk = implied_chunk if chunk_size is None else int(chunk_size)
         if chunk < 1:
             raise ValueError(f"chunk_size must be >= 1 encoder frames, but got {chunk}.")
-        if self.att_context_style == "chunked_limited" and chunk > implied_chunk:
+        if self.att_context_style == "chunked_limited" and chunk != implied_chunk:
             raise ValueError(
-                f"chunk_size={chunk} exceeds the chunked_limited attention chunk "
-                f"(right + 1 = {implied_chunk}); streaming would stop matching the offline forward."
+                f"chunk_size={chunk} must equal the chunked_limited attention chunk "
+                f"(right + 1 = {implied_chunk}) so streaming matches the offline forward."
             )
         shift = chunk if shift_size is None else int(shift_size)
         if shift != chunk:
@@ -1112,8 +1154,10 @@ class StreamingTransformerEncoder(TransformerEncoder, StreamingEncoder):
             )
 
         if left_chunks is not None:
-            # Retune the window itself, not just the cache — otherwise the mask and the rolling
-            # cache would describe different amounts of history.
+            # Retune the active window itself, not just the cache — otherwise the mask and rolling
+            # cache would describe different amounts of history. Copy first because the initial
+            # active context aliases att_context_size_all[0], which remains the training contract.
+            self.att_context_size = list(self.att_context_size)
             self.att_context_size[0] = int(left_chunks) * chunk
 
         cache_size = self.cache_size

--- a/nemo/collections/asr/modules/transformer_encoder.py
+++ b/nemo/collections/asr/modules/transformer_encoder.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+import random
 from dataclasses import dataclass
 from typing import Optional
 
@@ -20,6 +21,8 @@ import torch
 import torch.nn as nn
 from torch.nn.attention.flex_attention import and_masks, create_block_mask, flex_attention
 
+from nemo.collections.asr.models.configs import CacheAwareStreamingConfig
+from nemo.collections.asr.parts.mixins.streaming import StreamingEncoder
 from nemo.collections.asr.parts.submodules.multi_head_attention import (
     PositionalEncoding,
     RelPositionalEncoding,
@@ -28,6 +31,7 @@ from nemo.collections.asr.parts.submodules.multi_head_attention import (
 )
 from nemo.collections.asr.parts.submodules.subsampling import FeatureStacking, StackingSubsampling
 from nemo.core.classes.module import freeze, unfreeze
+from nemo.utils import logging
 from nemo.utils.decorators import experimental
 
 flex_attention_compiled = torch.compile(flex_attention, dynamic=True)
@@ -121,20 +125,79 @@ def _make_causal_mod():
     return causal
 
 
+def _make_sliding_window_mod(left, right):
+    """Sliding-window (local) attention.
+
+    Query ``q_idx`` may attend only to keys within ``[q_idx - left, q_idx + right]``.
+    A negative bound removes the limit on that side (``left < 0`` -> unlimited left
+    context; ``right < 0`` -> unlimited right context / look-ahead). Callers are expected
+    to pass at least one non-negative bound — when both are negative the window is
+    unbounded (full attention) and this mod should be skipped entirely.
+    """
+
+    def sliding_window(b, h, q_idx, kv_idx):
+        # ``left`` / ``right`` are Python ints known at trace time, so these branches are
+        # resolved once when FlexAttention traces the mask, not per element.
+        if left >= 0 and right >= 0:
+            return (kv_idx >= q_idx - left) & (kv_idx <= q_idx + right)
+        if left >= 0:
+            return kv_idx >= q_idx - left
+        return kv_idx <= q_idx + right
+
+    return sliding_window
+
+
+def _make_chunked_limited_mod(left, right):
+    """Chunk-aligned (``chunked_limited``) attention, matching ``ConformerEncoder``.
+
+    Frames are grouped into non-overlapping chunks of ``chunk_size = right + 1``. A query
+    attends to every frame of its own chunk (including in-chunk look-ahead) plus the
+    ``left // chunk_size`` preceding chunks — whole chunks only, never a partial one.
+    ``left < 0`` removes the left bound.
+
+    Unlike :func:`_make_sliding_window_mod`, the look-ahead does **not** compound across
+    layers: every layer stops at the same chunk boundary, so an N-layer stack still looks
+    ahead at most to the end of the current chunk. That is what makes it streamable — see
+    :class:`StreamingTransformerEncoder`.
+    """
+    chunk = right + 1
+    # ``left_chunks`` is a Python int (or None) known at trace time, so the branch below is
+    # resolved once when FlexAttention traces the mask, not per element.
+    left_chunks = (left // chunk) if left >= 0 else None
+
+    def chunked_limited(b, h, q_idx, kv_idx):
+        diff = (q_idx // chunk) - (kv_idx // chunk)
+        if left_chunks is None:
+            return diff >= 0
+        return (diff >= 0) & (diff <= left_chunks)
+
+    return chunked_limited
+
+
 _SUPPORTED_ATTENTION_MODES = ("full", "causal")
 _SUPPORTED_SELF_ATTENTION_MODELS = ("abs_pos", "rel_pos", "no_pos", "rope")
+_SUPPORTED_ATT_CONTEXT_STYLES = ("sliding_window", "chunked_limited")
 
 
 class FeedForward(nn.Module):
     def __init__(self, cfg: TransformerEncoderConfig):
         super().__init__()
         ff_hidden = int(cfg.ff_expansion * cfg.d_model)
+        # No dropout after the output projection: ``TransformerBlock`` already applies
+        # dropout to this module's output on the residual branch, and stacking the two
+        # gives an effective rate of ``1 - (1 - drop_rate)^2`` (19% at the default 0.1)
+        # with ~2.1x the intended noise variance, in every layer. Matches
+        # ``ConformerFeedForward``, which also drops only after the activation.
+        #
+        # Keep the trailing position free rather than renumbering: the module indices are
+        # state_dict keys (``net.0.*``, ``net.3.*``), so removing this last entry stays
+        # load-compatible with existing checkpoints, while dropping the *inner* Dropout
+        # would shift the second Linear to ``net.2.*`` and break them.
         self.net = nn.Sequential(
             nn.Linear(cfg.d_model, ff_hidden),
             nn.GELU(),
             nn.Dropout(cfg.drop_rate),
             nn.Linear(ff_hidden, cfg.d_model),
-            nn.Dropout(cfg.drop_rate),
         )
 
     def forward(self, x):
@@ -272,6 +335,108 @@ class MultiHeadAttention(nn.Module):
         out = out.transpose(1, 2).contiguous().view(B, T, self.d_model)
         return self.out_proj(out)
 
+    def _apply_streaming_position(self, q, k, pos_emb, num_cur, num_kv):
+        """Positional handling for the cache-aware streaming path — the single extension point.
+
+        Given the current-frame queries ``q`` ``(B, H, num_cur, D)`` and the concatenated
+        ``[cache | current]`` keys ``k`` ``(B, H, num_kv, D)``, apply this attention's
+        positional scheme and return ``(q, k, score_mod)`` for ``flex_attention``.
+
+        The cache stores raw (position-agnostic) layer inputs, so each scheme applies its own
+        transform here over the concatenated span — keeping the cache format scheme-agnostic.
+        ``rope`` rotates ``q``/``k`` in place (its rotation depends only on the query/key
+        position *difference*, so streaming needs no explicit position offset) and returns
+        ``score_mod=None``; ``rel_pos`` leaves ``q``/``k`` in place (folding ``pos_bias_u`` into
+        ``q``) and returns a relative-position ``score_mod``.
+        """
+        if self.self_attention_model == "rel_pos":
+            return self._build_streaming_rel_pos_score_mod(q, pos_emb, num_cur, num_kv)
+        if self._uses_rope:
+            # RoPE.forward handles ``num_kv > num_cur`` directly: keys rotate from position 0,
+            # queries from ``num_kv - num_cur`` (= cache length), so the query/key position
+            # difference matches the full-sequence forward exactly — streaming is exact.
+            q, k = self.rope(q, k)
+            return q, k, None
+        if self.self_attention_model == "no_pos":
+            return q, k, None
+        # abs_pos bakes absolute positions into the embeddings before the blocks, which does
+        # not compose with a running KV cache without a position offset; deferred.
+        raise NotImplementedError(
+            f"Cache-aware streaming is not implemented for self_attention_model="
+            f"'{self.self_attention_model}'. Supported streaming schemes: 'rel_pos', 'rope', 'no_pos'."
+        )
+
+    def _build_streaming_rel_pos_score_mod(self, q, pos_emb, num_cur, num_kv):
+        """Transformer-XL relative-position ``score_mod`` for the streaming (cached) attention.
+
+        Same (b)+(d) bias and (c) query-rewrite as :meth:`_build_rel_pos_score_mod`, but for a
+        rectangular ``num_cur`` (queries) x ``num_kv`` (keys) block instead of a square one.
+        The concatenated ``[cache | current]`` sequence is positionally contiguous, so key
+        index ``k`` sits at position ``k`` and current-query ``j`` sits at position
+        ``(num_kv - num_cur) + j``; their relative distance maps into the length-``num_kv``
+        ``pos_emb`` (``2*num_kv - 1`` entries, index 0 = most-positive rel-pos) at
+        ``i = num_cur - 1 - j + k``. The bias is gathered directly (no square ``rel_shift``),
+        which keeps it correct for ``num_cur != num_kv`` and easy to generalize.
+
+        Returns ``(q_with_bias_u, k, score_mod)``.
+        """
+        H, D = self.n_heads, self.head_dim
+        device = q.device
+        # pos_emb: (1, 2*num_kv - 1, d_model) -> p: (1, H, 2*num_kv - 1, D)
+        p = self.linear_pos(pos_emb).view(pos_emb.size(0), -1, H, D).transpose(1, 2)
+        bias_u = self.pos_bias_u.view(1, H, 1, D).to(dtype=q.dtype)
+        bias_v = self.pos_bias_v.view(1, H, 1, D).to(dtype=q.dtype)
+        # (b)+(d): (Q + v) @ R^T over all relative-position entries, then gather per (j, k).
+        all_bd = torch.matmul(q + bias_v, p.transpose(-2, -1))  # (B, H, num_cur, 2*num_kv - 1)
+        j = torch.arange(num_cur, device=device).view(num_cur, 1)
+        k = torch.arange(num_kv, device=device).view(1, num_kv)
+        rel_idx = num_cur - 1 - j + k  # (num_cur, num_kv), values in [0, num_cur + num_kv - 2]
+        rows = torch.arange(num_cur, device=device).view(num_cur, 1).expand(num_cur, num_kv)
+        rel_pos_bias = all_bd[:, :, rows, rel_idx] * (D**-0.5)  # (B, H, num_cur, num_kv)
+
+        def score_mod(score, b, h, q_idx, kv_idx):
+            return score + rel_pos_bias[b, h, q_idx, kv_idx]
+
+        # Matrix c: fold u @ K^T into FlexAttention by rewriting Q as (Q + u).
+        return q + bias_u, None, score_mod
+
+    def forward_streaming(self, kv_normed, num_cur, block_mask, pos_emb):
+        """Cache-aware attention: keys/values from the whole ``[cache | current]`` span,
+        queries from the current frames only.
+
+        Args:
+            kv_normed: ``(B, num_kv, d_model)`` layer-normed ``[cache | current]`` inputs, with
+                the current frames as the last ``num_cur`` positions.
+            num_cur: number of current-chunk frames (the query count).
+            block_mask: FlexAttention ``BlockMask`` over ``(num_cur, num_kv)``.
+            pos_emb: relative-position embedding for length ``num_kv`` (``rel_pos`` only).
+
+        Returns:
+            ``(B, num_cur, d_model)`` attention output for the current frames.
+        """
+        B, num_kv, _ = kv_normed.shape
+        H, D = self.n_heads, self.head_dim
+
+        # One fused projection over the concatenated span; slice Q to the current frames.
+        # ``w_qkv`` is linear, so ``q_all[:, :, -num_cur:]`` equals projecting only the current
+        # frames, while K/V cover cache + current.
+        qkv = self.w_qkv(kv_normed).view(B, num_kv, 3, H, D).permute(2, 0, 3, 1, 4)
+        q_all, k, v = qkv.unbind(0)
+        q = q_all[:, :, num_kv - num_cur :, :]
+
+        if self.qk_norm:
+            q = self.q_norm(q).to(v.dtype)
+            k = self.k_norm(k).to(v.dtype)
+
+        q, k_mod, score_mod = self._apply_streaming_position(q, k, pos_emb, num_cur, num_kv)
+        if k_mod is not None:
+            k = k_mod
+
+        attn_fn = flex_attention_compiled if q.is_cuda else flex_attention
+        out = attn_fn(q, k, v, block_mask=block_mask, score_mod=score_mod)
+        out = out.transpose(1, 2).contiguous().view(B, num_cur, self.d_model)
+        return self.out_proj(out)
+
 
 class TransformerBlock(nn.Module):
     def __init__(self, cfg: TransformerEncoderConfig, pos_enc=None):
@@ -286,6 +451,39 @@ class TransformerBlock(nn.Module):
         x = x + self.drop(self.attn(self.norm1(x), block_mask=block_mask, pos_emb=pos_emb))
         x = x + self.drop(self.ffn(self.norm2(x)))
         return x
+
+    def forward_streaming(self, x_cur, cache_in, block_mask, pos_emb, cache_size):
+        """Cache-aware streaming forward for one chunk.
+
+        Args:
+            x_cur: ``(B, C, d_model)`` current-chunk layer input (pre-norm residual stream).
+            cache_in: ``(B, L, d_model)`` cached layer inputs from previous chunks (padded to
+                ``L``; validity is enforced by ``block_mask``).
+            block_mask: FlexAttention ``BlockMask`` over ``(C, L + C)``.
+            pos_emb: relative-position embedding for length ``L + C`` (``rel_pos`` only).
+            cache_size: rolling-cache size in frames (``>= 0``), or ``< 0`` to grow the cache
+                unbounded (full cache). Determines how many layer-input frames to retain.
+
+        Returns:
+            ``(x_out, new_cache)`` — the current-chunk output ``(B, C, d_model)`` and this
+            layer's updated input cache.
+        """
+        C = x_cur.shape[1]
+        # K/V source is the layer input over [cache | current]; Q is the current frames only.
+        # LayerNorm is position-wise, so norm1([cache | cur]) == [norm1(cache) | norm1(cur)].
+        kv_in = torch.cat([cache_in, x_cur], dim=1)
+        attn_out = self.attn.forward_streaming(self.norm1(kv_in), C, block_mask, pos_emb)
+        x = x_cur + self.drop(attn_out)
+        x = x + self.drop(self.ffn(self.norm2(x)))
+        # Update cache with this layer's *inputs* (kv_in), keeping the last ``cache_size`` frames
+        # (rolling) or all of them (full cache when cache_size < 0). ``0`` keeps nothing.
+        if cache_size < 0:
+            new_cache = kv_in
+        elif cache_size == 0:
+            new_cache = kv_in[:, :0]
+        else:
+            new_cache = kv_in[:, -cache_size:]
+        return x, new_cache
 
 
 @experimental
@@ -576,10 +774,7 @@ class TransformerEncoder(nn.Module):
         x = self.embed_norm(x)
 
         B, T, _ = x.shape
-        if self.attn_mode == "causal":
-            mask_mod = and_masks(_make_causal_mod(), _make_padding_mod(length))
-        else:
-            mask_mod = _make_padding_mod(length)
+        mask_mod = self._build_mask_mod(length)
         block_mask = create_block_mask(mask_mod, B=B, H=1, Q_LEN=T, KV_LEN=T, device=x.device)
         # For ``abs_pos`` the positional information is already baked into ``x``, so we don't
         # need to thread ``pos_emb`` through each layer; only ``rel_pos`` consumes it.
@@ -593,6 +788,21 @@ class TransformerEncoder(nn.Module):
         x = x.transpose(1, 2)  # (B, T, D) -> (B, D, T)
         length = length.to(dtype=torch.int64)
         return x, length
+
+    def _build_mask_mod(self, length):
+        """Build the FlexAttention ``mask_mod`` shared by every layer in this forward.
+
+        Returns a callable ``(b, h, q_idx, kv_idx) -> bool`` that selects which keys each
+        query may attend to. The base encoder supports padding-only masking (``attn_mode
+        == "full"``) and additionally causal masking (``attn_mode == "causal"``). Subclasses
+        (e.g. :class:`StreamingTransformerEncoder`) override this to inject other attention
+        patterns such as a sliding window; the single overridable hook keeps
+        ``forward_internal`` agnostic to the masking scheme.
+        """
+        pad_mod = _make_padding_mod(length)
+        if self.attn_mode == "causal":
+            return and_masks(_make_causal_mod(), pad_mod)
+        return pad_mod
 
     def update_max_seq_length(self, seq_length: int, device):
         """
@@ -624,3 +834,514 @@ class TransformerEncoder(nn.Module):
 
     def unfreeze(self, partial: bool = False) -> None:
         unfreeze(self, partial=partial)
+
+
+@experimental
+class StreamingTransformerEncoder(TransformerEncoder, StreamingEncoder):
+    """``TransformerEncoder`` with bounded-context attention and cache-aware streaming.
+
+    Adds two things on top of the base FlexAttention :class:`TransformerEncoder`:
+
+    1. **Bounded-context attention** in the full-sequence (training) forward, in one of two
+       styles selected by ``att_context_style``:
+
+       - ``"sliding_window"`` (default): a per-query ``[left, right]`` window — frame ``t``
+         attends to ``[t - left, t + right]``.
+       - ``"chunked_limited"``: chunk-aligned attention matching ``ConformerEncoder`` — frames
+         are grouped into chunks of ``chunk_size = right + 1`` and a query attends to its whole
+         chunk plus the ``left // chunk_size`` preceding chunks.
+
+    2. **Cache-aware streaming** — a rolling KV cache of the last :attr:`cache_size` layer-input
+       frames, so chunked inference reproduces the full forward without re-encoding history.
+       Implements the real :class:`StreamingEncoder` interface consumed by ``StreamingSTTModel`` /
+       ``AudioPerceptionModule`` (``cache_aware_stream_step`` / ``get_initial_cache_state`` /
+       ``setup_streaming_params``), reusing the Conformer ``cache_last_channel`` cache plumbing.
+
+    **Look-ahead and exactness.** For ``sliding_window``, streaming is exact only with ``right ==
+    0``: a sliding right context compounds across layers (an N-layer stack sees ``N * right``
+    frames ahead), which chunk-by-chunk streaming cannot reproduce. ``chunked_limited`` exists
+    precisely to lift that restriction — every layer stops at the same chunk boundary, so the
+    look-ahead stays bounded by the current chunk no matter how deep the stack, and streaming is
+    exact as long as the streaming chunk matches ``chunk_size = right + 1``. Use
+    ``att_context_style="chunked_limited"`` with ``att_context_size=[left, chunk_size - 1]`` to get
+    in-chunk look-ahead; use the default sliding window with ``[left, 0]`` for a strictly causal
+    encoder.
+
+    The cache stores raw (position-agnostic) per-layer inputs; the positional scheme is applied per
+    step in :meth:`MultiHeadAttention._apply_streaming_position`, keeping the cache format
+    scheme-agnostic. Streaming supports ``rel_pos``, ``rope``, and ``no_pos`` (``abs_pos`` is not
+    supported for streaming).
+
+    Args:
+        att_context_size: ``[left, right]`` context in encoder (post-subsampling) frames, or a list
+            of such pairs to train one model across several chunk sizes. A negative bound removes
+            the limit on that side; ``left < 0`` means an unbounded (full) cache that grows with the
+            stream (bounded memory only for finite ``left``). Under ``chunked_limited``,
+            ``right + 1`` is the chunk size and the left context is quantized down to a whole number
+            of chunks. Default ``(-1, -1)`` is full bidirectional attention (no streaming benefit —
+            set a finite context to stream).
+
+            Given a list (e.g. ``[[70, 1], [70, 6], [70, 13]]`` for chunk sizes 2/7/14), one context
+            is sampled per training batch, matching ``ConformerEncoder``. Evaluation and streaming
+            always use ``att_context_size_all[0]`` — or whatever
+            :meth:`set_default_att_context_size` pinned — so validation loss and cache-aware
+            inference stay deterministic. Pick the inference size with
+            ``transcribe_speech.py att_context_size=[70,13]``.
+        att_context_probs: Sampling weights over the entries of a multi-context ``att_context_size``.
+            Defaults to uniform. Must be the same length as ``att_context_size`` and sum to 1.
+        att_context_style: ``"sliding_window"`` (default) or ``"chunked_limited"``. Mirrors the
+            ``ConformerEncoder`` argument of the same name so configs read alike across encoders.
+        pre_encode_cache_size: Input-feature (mel) frames of look-back prepended to each streaming
+            chunk before the pre-encoder; the resulting extra encoder frames are removed via
+            ``streaming_cfg.drop_extra_pre_encoded``. Must be a multiple of ``subsampling_factor``
+            so chunks stay aligned to the stacking grid. ``FeatureStacking`` itself is
+            non-overlapping and needs **none** of this (default ``0``), but a streaming front-end
+            that recomputes the mel spectrogram per chunk does: with no look-back the first ~2 mel
+            frames of every chunk are built from reflect-padded audio instead of the true preceding
+            samples. Set to ``subsampling_factor`` to give the STFT window its context back.
+        *args, **kwargs: Forwarded to :class:`TransformerEncoder` (``attn_mode`` is managed
+            internally and ignored).
+    """
+
+    def __init__(
+        self,
+        *args,
+        att_context_size=(-1, -1),
+        att_context_probs=None,
+        att_context_style="sliding_window",
+        pre_encode_cache_size: int = 0,
+        **kwargs,
+    ):
+        # This encoder's attention pattern is governed by ``att_context_size`` /
+        # ``att_context_style``; drop any caller-provided ``attn_mode`` so it never reaches (and
+        # fails) the base's supported-mode validation, then run the base with a valid placeholder.
+        kwargs.pop("attn_mode", None)
+        super().__init__(*args, attn_mode="full", **kwargs)
+        if att_context_style not in _SUPPORTED_ATT_CONTEXT_STYLES:
+            raise ValueError(
+                f"att_context_style='{att_context_style}' is not supported. "
+                f"Supported styles: {_SUPPORTED_ATT_CONTEXT_STYLES}."
+            )
+        self.att_context_style = att_context_style
+        if pre_encode_cache_size < 0 or pre_encode_cache_size % self.subsampling_factor != 0:
+            raise ValueError(
+                f"pre_encode_cache_size must be a non-negative multiple of subsampling_factor="
+                f"{self.subsampling_factor} (so chunks stay aligned to the stacking grid), "
+                f"but got {pre_encode_cache_size}."
+            )
+        self.pre_encode_cache_size = pre_encode_cache_size
+        self.streaming_cfg = None
+        self.att_context_size_all, self.att_context_probs = self._calc_context_sizes(
+            att_context_size, att_context_probs
+        )
+        # Eval/inference default: the first entry, as in ConformerEncoder.
+        self.att_context_size = self.att_context_size_all[0]
+        self.setup_streaming_params()
+        # Purely a label for introspection/logging: ``_build_mask_mod`` below fully
+        # overrides the base's mask selection, so ``attn_mode`` is never consulted here.
+        self.attn_mode = att_context_style
+
+    def _calc_context_sizes(self, att_context_size, att_context_probs):
+        """Normalize ``att_context_size`` to a list of ``[left, right]`` pairs plus sampling probs.
+
+        Accepts a single pair or a list of pairs, mirroring ``ConformerEncoder._calc_context_sizes``
+        so the two encoders read the same config.
+        """
+        sizes = list(att_context_size)
+        if not sizes:
+            raise ValueError("att_context_size must not be empty.")
+        # A bare [left, right] pair -> single-context list.
+        if isinstance(sizes[0], (int, float)):
+            sizes = [sizes]
+        normalized = []
+        for i, pair in enumerate(sizes):
+            pair = [int(v) for v in pair]
+            if len(pair) != 2:
+                raise ValueError(f"att_context_size entries must be [left, right] pairs, but entry {i} is {pair}.")
+            left, right = pair
+            if self.att_context_style == "chunked_limited" and left > 0 and right >= 0 and left % (right + 1):
+                # ConformerEncoder rejects this outright. We quantize instead (``cache_size`` reports
+                # the true value), because a config like [70, 3] is perfectly usable at 68 frames of
+                # left context — but say so, since the number in the config is not what you get.
+                chunk = right + 1
+                logging.warning(
+                    "att_context_size[%d]=%s: left context %d is not a whole multiple of the "
+                    "chunked_limited chunk size %d, so only %d frames are visible (%d whole chunks).",
+                    i,
+                    pair,
+                    left,
+                    chunk,
+                    (left // chunk) * chunk,
+                    left // chunk,
+                )
+            normalized.append(pair)
+
+        if att_context_probs is None:
+            probs = [1.0 / len(normalized)] * len(normalized)
+        else:
+            probs = [float(p) for p in att_context_probs]
+            if len(probs) != len(normalized):
+                raise ValueError(
+                    f"att_context_probs has {len(probs)} entries but att_context_size has "
+                    f"{len(normalized)}; they must match."
+                )
+            if not math.isclose(sum(probs), 1.0, rel_tol=1e-6):
+                raise ValueError(f"att_context_probs must sum to 1, but sums to {sum(probs)}.")
+        return normalized, probs
+
+    def _sample_att_context_size(self):
+        """The ``[left, right]`` context for this forward.
+
+        With several contexts configured, training samples one per batch so a single model learns
+        every chunk size; everything else (validation, export, cache-aware streaming) uses the
+        pinned :attr:`att_context_size` so it stays deterministic. Mirrors the sampling in
+        ``ConformerEncoder.forward_internal``.
+        """
+        if self.training and len(self.att_context_size_all) > 1:
+            return random.choices(self.att_context_size_all, weights=self.att_context_probs)[0]
+        return self.att_context_size
+
+    @property
+    def cache_size(self) -> int:
+        """Rolling attention-cache size in encoder frames (``< 0`` -> unbounded/full cache).
+
+        For ``sliding_window`` this is ``left`` — the furthest back any query may look. For
+        ``chunked_limited`` the visible history is a whole number of chunks, so the cache only
+        needs ``(left // chunk_size) * chunk_size`` frames; sizing it exactly is what keeps the
+        streaming mask a plain "last N cache frames" test with no per-query term.
+        """
+        left, right = self.att_context_size
+        if left < 0:
+            return -1
+        if self.att_context_style == "chunked_limited":
+            if right < 0:
+                # Unlimited right degenerates to a left-only sliding window (Conformer parity).
+                return left
+            chunk = right + 1
+            return (left // chunk) * chunk
+        return left
+
+    def set_default_att_context_size(self, att_context_size) -> None:
+        """Pin the ``[left, right]`` attention context (in encoder frames) and refresh streaming cfg.
+
+        A negative bound means unlimited context on that side. Named to mirror
+        ``ConformerEncoder.set_default_att_context_size`` so streaming inference code that calls this
+        method works uniformly across encoder types. This is how you select one of a multi-context
+        model's chunk sizes at inference.
+
+        Note this pins the *eval and streaming* context only. Training keeps sampling over
+        ``att_context_size_all`` — as ``ConformerEncoder`` does — so pinning a context does not
+        narrow what a training run sees. To train at a single context, configure a single pair.
+        """
+        att_context_size = [int(v) for v in att_context_size]
+        if len(att_context_size) != 2:
+            raise ValueError(f"att_context_size must be a [left, right] pair, but got {att_context_size}.")
+        if att_context_size not in self.att_context_size_all:
+            logging.warning(
+                "att_context_size=%s is not among the configured contexts %s; using it anyway, but "
+                "the model was not trained at this setting.",
+                att_context_size,
+                self.att_context_size_all,
+            )
+        self.att_context_size = att_context_size
+        self.setup_streaming_params()
+
+    def _build_mask_mod(self, length):
+        # Called exactly once per full-sequence forward, so sampling here gives one context per
+        # batch. The cache-aware path never comes through here — it reads ``att_context_size``
+        # directly — so streaming is unaffected by multi-context training.
+        left, right = self._sample_att_context_size()
+        pad_mod = _make_padding_mod(length)
+        if self.att_context_style == "chunked_limited" and right >= 0:
+            return and_masks(_make_chunked_limited_mod(left, right), pad_mod)
+        # Sliding window, and the ``chunked_limited`` + unlimited-right degenerate case which
+        # ConformerEncoder also collapses to a left-only bound.
+        if left < 0 and right < 0:
+            # Unbounded on both sides -> full (padding-only) attention.
+            return pad_mod
+        return and_masks(_make_sliding_window_mod(left, right), pad_mod)
+
+    # ------------------------------------------------------------------ #
+    # Cache-aware streaming interface (StreamingEncoder)
+    # ------------------------------------------------------------------ #
+    def setup_streaming_params(
+        self,
+        chunk_size: int = None,
+        shift_size: int = None,
+        left_chunks: int = None,
+        att_context_size: list = None,
+        max_context: int = 10000,
+    ) -> None:
+        """(Re)build ``streaming_cfg`` from the current attention context.
+
+        Populates the full :class:`CacheAwareStreamingConfig` — the same dataclass
+        ``ConformerEncoder`` uses — so the shared cache-aware tooling
+        (``speech_to_text_cache_aware_streaming_infer.py``, ``CacheAwareStreamingAudioBuffer``,
+        ``ASRModuleMixin.conformer_stream_step``) can drive this encoder unchanged. Sizes follow the
+        Conformer's units: ``chunk_size`` / ``shift_size`` / ``pre_encode_cache_size`` are in input
+        (mel) frames, everything else in encoder frames.
+
+        Args:
+            chunk_size: Encoder frames per streaming step. Defaults to the chunk implied by the
+                attention context — ``right + 1`` — which is the true chunk size under
+                ``chunked_limited`` and, under a causal ``sliding_window`` (``right == 0``), the
+                minimum-latency single-frame step. A causal sliding window streams exactly at *any*
+                chunk size, so overriding this is free there; under ``chunked_limited`` it must not
+                exceed ``right + 1`` or streaming stops matching the offline forward.
+            shift_size: Encoder frames the buffer advances per step. Defaults to ``chunk_size``.
+                Only equal values are supported — overlapping chunks would recompute frames this
+                encoder already emits exactly.
+            left_chunks: Number of left chunks visible to each chunk. When given, it *retunes the
+                attention window* (``left = left_chunks * chunk_size``) rather than only the cache,
+                so the mask and the cache cannot disagree.
+            att_context_size: Optional ``[left, right]`` to apply before computing the config.
+            max_context: Cache size to use when the left context is unbounded (``left < 0``).
+        """
+        if att_context_size is not None:
+            if len(att_context_size) != 2:
+                raise ValueError(f"att_context_size must be a [left, right] pair, but got {att_context_size}.")
+            self.att_context_size = list(att_context_size)
+
+        # Encoder frames per step. ``right + 1`` is the chunk under chunked_limited and the
+        # minimum-latency step under a causal sliding window (right == 0 -> 1 frame).
+        implied_chunk = self.att_context_size[1] + 1 if self.att_context_size[1] >= 0 else 1
+        chunk = implied_chunk if chunk_size is None else int(chunk_size)
+        if chunk < 1:
+            raise ValueError(f"chunk_size must be >= 1 encoder frames, but got {chunk}.")
+        if self.att_context_style == "chunked_limited" and chunk > implied_chunk:
+            raise ValueError(
+                f"chunk_size={chunk} exceeds the chunked_limited attention chunk "
+                f"(right + 1 = {implied_chunk}); streaming would stop matching the offline forward."
+            )
+        shift = chunk if shift_size is None else int(shift_size)
+        if shift != chunk:
+            raise ValueError(
+                f"Overlapping/striding chunks are not supported: shift_size ({shift}) must equal "
+                f"chunk_size ({chunk}). Every output frame of this encoder already equals the "
+                f"offline forward, so there is nothing for an overlap to recompute."
+            )
+
+        if left_chunks is not None:
+            # Retune the window itself, not just the cache — otherwise the mask and the rolling
+            # cache would describe different amounts of history.
+            self.att_context_size[0] = int(left_chunks) * chunk
+
+        cache_size = self.cache_size
+        S = self.subsampling_factor
+        P = self.pre_encode_cache_size
+        # ``[first_step, later_steps]`` when there is look-back at all: the first chunk has no
+        # history to look back at, and ``CacheAwareStreamingAudioBuffer`` only special-cases step 0
+        # when this field is a list. Emitting a scalar would make it prepend P zero frames at step 0
+        # while ``calc_drop_extra_pre_encoded`` returns 0 for that step — P/S phantom output frames.
+        # Stay a plain scalar when P == 0 so the default path is unchanged.
+        self.streaming_cfg = CacheAwareStreamingConfig(
+            chunk_size=S * chunk,
+            shift_size=S * shift,
+            # No look-ahead survives past a chunk boundary in either style, so nothing needs to be
+            # dropped off the end of the cache to compensate for it.
+            cache_drop_size=0,
+            last_channel_cache_size=cache_size if cache_size >= 0 else max_context,
+            # Every emitted frame already equals the offline forward (that is the design guarantee
+            # validated by test_streaming_matches_full_forward), so all outputs of a step are valid.
+            valid_out_len=shift,
+            pre_encode_cache_size=[0, P] if P > 0 else 0,
+            drop_extra_pre_encoded=P // S,
+            last_channel_num=self.n_layers,
+            last_time_num=0,  # convolution-free encoder — no time cache
+        )
+
+    def get_initial_cache_state(self, batch_size=1, dtype=None, device=None, max_dim=0):
+        """Empty KV cache. ``cache_last_channel`` is ``(n_layers, B, cache_size, d_model)`` of
+        per-layer inputs (padded to :attr:`cache_size` for a rolling cache; length ``0`` — grows —
+        for a full cache or a zero-size one). ``cache_last_time`` is an unused zero-width
+        placeholder (no conv)."""
+        if dtype is None:
+            dtype = next(self.parameters()).dtype
+        if device is None:
+            device = next(self.parameters()).device
+        cache_size = max(self.cache_size, 0)
+        cache_last_channel = torch.zeros(
+            self.n_layers, batch_size, cache_size, self.d_model, dtype=dtype, device=device
+        )
+        # Zero *width*, but the same RANK as ``ConformerEncoder``'s conv cache
+        # ``(n_layers, B, d_model, conv_cache)`` -- the shared cache-aware tooling slices this
+        # tensor positionally (e.g. ``StreamingContextManager.get_context`` does
+        # ``cache_last_time[:, slot_ids, :, :]``), so a 3-D placeholder raises
+        # "IndexError: too many indices" even though the encoder never reads it.
+        cache_last_time = torch.zeros(self.n_layers, batch_size, self.d_model, 0, dtype=dtype, device=device)
+        cache_last_channel_len = torch.zeros(batch_size, dtype=torch.int64, device=device)
+        return cache_last_channel, cache_last_time, cache_last_channel_len
+
+    def cache_aware_stream_step(
+        self,
+        processed_signal,
+        processed_signal_length=None,
+        cache_last_channel=None,
+        cache_last_time=None,
+        cache_last_channel_len=None,
+        keep_all_outputs=True,
+        drop_extra_pre_encoded=None,
+        bypass_pre_encode=False,
+    ):
+        """Encode one chunk with the rolling KV cache. Returns the Conformer-compatible 5-tuple
+        ``(encoded, encoded_len, cache_last_channel, cache_last_time, cache_last_channel_len)``.
+
+        Args:
+            keep_all_outputs: Accepted for interface parity, but this encoder has nothing to drop.
+                The Conformer trims to ``streaming_cfg.valid_out_len`` because under a *sliding*
+                right context its trailing frames are computed without their full look-ahead and get
+                recomputed on the next step. Neither of this encoder's masks has that property —
+                every emitted frame already equals the offline forward — so all outputs are valid
+                and are always returned.
+            drop_extra_pre_encoded: Encoder frames to drop from the front of the pre-encoder output,
+                removing the contribution of the ``pre_encode_cache_size`` look-back frames
+                prepended to this chunk. ``None`` uses ``streaming_cfg.drop_extra_pre_encoded``;
+                pass ``0`` explicitly for the first step, whose buffer has no real look-back to
+                strip (this is what ``calc_drop_extra_pre_encoded`` in
+                ``speech_to_text_cache_aware_streaming_infer.py`` does).
+        """
+        encoded, encoded_len, new_cache_last_channel, new_cache_last_channel_len = self._streaming_step(
+            processed_signal,
+            processed_signal_length,
+            cache_last_channel,
+            cache_last_channel_len,
+            bypass_pre_encode,
+            drop_extra_pre_encoded,
+        )
+        # This (convolution-free) encoder has no time cache; pass ``cache_last_time`` through as-is.
+        return encoded, encoded_len, new_cache_last_channel, cache_last_time, new_cache_last_channel_len
+
+    def _streaming_step(
+        self,
+        audio_signal,
+        length,
+        cache_last_channel,
+        cache_last_channel_len,
+        bypass_pre_encode,
+        drop_extra_pre_encoded=None,
+    ):
+        # 1. Pre-encode (subsample) the current chunk. FeatureStacking is non-overlapping, so a
+        #    chunk aligned to ``subsampling_factor`` subsamples independently and matches the full
+        #    forward exactly. Any ``pre_encode_cache_size`` look-back frames the caller prepended
+        #    are stripped back off here, after subsampling.
+        if length is None:
+            length = audio_signal.new_full(
+                (audio_signal.size(0),),
+                audio_signal.size(1) if bypass_pre_encode else audio_signal.size(-1),
+                dtype=torch.int64,
+                device=audio_signal.device,
+            )
+        if not bypass_pre_encode:
+            if isinstance(self.pre_encode, FeatureStacking):
+                x, length = self.pre_encode(audio_signal, length)
+            else:
+                x = torch.transpose(audio_signal, 1, 2)
+            if isinstance(self.pre_encode, nn.Linear):
+                x = self.pre_encode(x)
+            elif not isinstance(self.pre_encode, FeatureStacking):
+                x, length = self.pre_encode(x=x, lengths=length)
+        else:
+            x = audio_signal
+        length = length.to(torch.int64)
+
+        if drop_extra_pre_encoded is None:
+            # Only default to the configured drop when we are actually mid-stream. A caller with no
+            # cache is passing a whole utterance, not a chunk with look-back prepended — e.g.
+            # ``conformer_stream_step(processed_signal=<whole audio>)``, which
+            # ``speech_to_text_cache_aware_streaming_infer.py`` uses for ``compare_vs_offline``.
+            # Dropping there would silently truncate the offline reference. Mirrors the
+            # ``cache_last_channel is not None`` guard in ``ConformerEncoder.forward_internal``.
+            drop_extra_pre_encoded = self.streaming_cfg.drop_extra_pre_encoded if cache_last_channel is not None else 0
+        if drop_extra_pre_encoded > 0:
+            x = x[:, drop_extra_pre_encoded:, :]
+            length = (length - drop_extra_pre_encoded).clamp(min=0)
+
+        B, C, _ = x.shape
+        if cache_last_channel is None:
+            cache_last_channel, _, cache_last_channel_len = self.get_initial_cache_state(
+                batch_size=B, dtype=x.dtype, device=x.device
+            )
+        right = self.att_context_size[1]
+        cache_size = self.cache_size
+        if self.att_context_style == "chunked_limited" and right >= 0 and C > right + 1:
+            raise ValueError(
+                f"chunked_limited streaming needs the streaming chunk to fit inside one attention "
+                f"chunk, but got {C} encoder frames per step with chunk_size=right+1={right + 1}. "
+                f"Feed {right + 1} frames per step (a shorter final chunk is fine)."
+            )
+        L = cache_last_channel.shape[2]  # padded cache size (== cache_size for rolling; grows for full)
+        num_kv = L + C
+
+        # 2. Positional prep (once). Extend positional buffers to cover the [cache | current]
+        #    span, then apply this scheme's pre-block step (mirroring ``forward_internal``):
+        #    rope rotates Q/K inside attention (only xscale + dropout here); rel_pos needs an
+        #    additive pos_emb of length ``num_kv``; abs_pos bakes positions into ``x`` (and is
+        #    rejected downstream for streaming); no_pos does nothing.
+        if self.pos_enc is not None:
+            self.update_max_seq_length(seq_length=num_kv, device=x.device)
+        if self.self_attention_model == "rope":
+            if self.xscale:
+                x = x * self.xscale
+            x = self.dropout_pre_encoder(x)
+            pos_emb = None
+        elif self.pos_enc is not None:
+            x, _ = self.pos_enc(x=x)
+            pos_emb = self._streaming_pos_emb(num_kv, x) if self.self_attention_model == "rel_pos" else None
+        else:  # no_pos
+            pos_emb = None
+        x = self.embed_norm(x)
+
+        # 3. Streaming layers with the shared block mask; collect each layer's updated cache.
+        block_mask = self._build_streaming_block_mask(cache_last_channel_len, length, L, C, x.device)
+        new_caches = []
+        for i, layer in enumerate(self.layers):
+            x, new_cache_l = layer.forward_streaming(x, cache_last_channel[i], block_mask, pos_emb, cache_size)
+            new_caches.append(new_cache_l)
+        new_cache_last_channel = torch.stack(new_caches, dim=0)
+
+        x = self.final_norm(x)
+        if self.out_proj is not None:
+            x = self.out_proj(x)
+        x = x.transpose(1, 2)  # (B, C, D) -> (B, D, C)
+
+        new_cache_len = cache_last_channel_len + length
+        if cache_size >= 0:
+            new_cache_len = torch.clamp(new_cache_len, max=cache_size)
+        return x, length, new_cache_last_channel, new_cache_len.to(torch.int64)
+
+    def _streaming_pos_emb(self, num_kv, ref):
+        """Relative-position embedding ``(1, 2*num_kv - 1, d_model)`` for the concatenated
+        ``[cache | current]`` span. ``RelPositionalEncoding.forward`` returns ``(scaled_x, pos_emb)``;
+        feed a zero dummy of length ``num_kv`` and keep only ``pos_emb`` (deterministic in eval)."""
+        dummy = ref.new_zeros(1, num_kv, self.d_model)
+        _, pos_emb = self.pos_enc(x=dummy)
+        return pos_emb
+
+    def _build_streaming_block_mask(self, cache_valid_len, cur_len, L, C, device):
+        """FlexAttention block mask over ``(C, L + C)`` for the cache-aware step.
+
+        The ``[cache | current]`` sequence is positionally contiguous: key index ``k`` sits at
+        position ``k`` and current-query ``j`` at position ``L + j``. Valid keys are the last
+        ``cache_valid_len`` cache frames (right-aligned in ``[0, L)``) plus the first ``cur_len``
+        current frames.
+
+        For ``sliding_window`` that set is further intersected with the ``[left, right]`` window
+        around each query. For ``chunked_limited`` no per-query term is needed: the whole streaming
+        chunk is one attention chunk, and the cache is sized to exactly the visible history
+        (:attr:`cache_size` == ``left_chunks * chunk_size``), so "everything valid" *is* the mask.
+        """
+        left, right = self.att_context_size
+        chunked = self.att_context_style == "chunked_limited" and right >= 0
+        num_kv = L + C
+
+        def mask_mod(b, h, q_idx, kv_idx):
+            ok = (kv_idx >= L - cache_valid_len[b]) & (kv_idx < L + cur_len[b])
+            if chunked:
+                return ok
+            if right >= 0:
+                ok = ok & (kv_idx <= q_idx + L + right)
+            if left >= 0:
+                ok = ok & (kv_idx >= q_idx + L - left)
+            return ok
+
+        return create_block_mask(mask_mod, B=cache_valid_len.shape[0], H=1, Q_LEN=C, KV_LEN=num_kv, device=device)

--- a/nemo/collections/asr/parts/submodules/subsampling.py
+++ b/nemo/collections/asr/parts/submodules/subsampling.py
@@ -43,6 +43,15 @@ class FeatureStacking(nn.Module):
     def compute_num_out_frames(self, in_frames):
         return (in_frames + self.subsampling_factor - 1) // self.subsampling_factor
 
+    def get_sampling_frames(self):
+        """Input frames consumed per output frame — probed by the cache-aware streaming utils."""
+        return self.subsampling_factor
+
+    def get_streaming_cache_size(self):
+        """Input-frame look-back needed to reproduce the offline output. Stacking is
+        non-overlapping, so a chunk aligned to ``subsampling_factor`` needs none."""
+        return 0
+
     def forward(self, x, lengths):
         """
         Args:

--- a/tests/collections/asr/test_transformer_encoder.py
+++ b/tests/collections/asr/test_transformer_encoder.py
@@ -12,16 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
+
 import numpy as np
 import pytest
 import torch
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper
 
+from nemo.collections.asr.models.configs import CacheAwareStreamingConfig
 from nemo.collections.asr.modules.transformer_encoder import (
     FeatureStacking,
+    StreamingTransformerEncoder,
     TransformerEncoder,
     TransformerEncoderConfig,
+    _make_chunked_limited_mod,
+    _make_sliding_window_mod,
 )
+from nemo.collections.asr.parts.mixins.streaming import StreamingEncoder
 from nemo.collections.asr.parts.submodules.multi_head_attention import RotaryPositionalEncoding
 
 
@@ -316,6 +323,72 @@ class TestBypassPreEncode:
         assert out_full.shape == out_bypass.shape == (B, feat_out, pre_x.shape[1])
         assert torch.equal(len_full, len_bypass)
         assert torch.allclose(out_full, out_bypass, atol=1e-5)
+
+
+class TestDropout:
+    """Dropout wiring.
+
+    Every other test in this file builds encoders with ``drop_rate=0.0``, so nothing here
+    exercised the dropout path -- which is how the FFN branch ended up being dropped twice
+    (once inside ``FeedForward.net``, once by ``TransformerBlock``'s residual dropout),
+    giving an effective ``1 - 0.9**2 = 0.19`` instead of the configured 0.1.
+    """
+
+    @pytest.mark.unit
+    def test_ffn_drops_branch_output_exactly_once(self):
+        """The FFN residual branch must be dropped at the configured rate, not twice."""
+        torch.manual_seed(0)
+        p = 0.2
+        cfg = TransformerEncoderConfig(d_model=64, n_heads=4, n_layers=1, drop_rate=p, ff_expansion=4)
+        from nemo.collections.asr.modules.transformer_encoder import FeedForward, TransformerBlock
+
+        # FeedForward's own output must be dropout-free; TransformerBlock owns the branch dropout.
+        ffn = FeedForward(cfg).train()
+        assert not isinstance(ffn.net[-1], torch.nn.Dropout), (
+            "FeedForward.net must not end in Dropout -- TransformerBlock already drops this "
+            "module's output on the residual branch, and stacking the two doubles the rate."
+        )
+
+        # Measure the branch's realized drop rate end to end through the block.
+        block = TransformerBlock(cfg).train()
+        x = torch.ones(1, 8192, 64)
+        with torch.no_grad():
+            branch = block.drop(block.ffn(block.norm2(x)))
+        zero_frac = (branch == 0).float().mean().item()
+        assert zero_frac == pytest.approx(p, abs=0.02), (
+            f"FFN branch zero fraction {zero_frac:.4f} should be ~{p} (dropped once); "
+            f"~{1 - (1 - p) ** 2:.2f} means it is being dropped twice."
+        )
+
+    @pytest.mark.unit
+    def test_ffn_state_dict_keys_are_checkpoint_compatible(self):
+        """FFN Linear indices are state_dict keys -- they must stay net.0 / net.3.
+
+        ``nn.Dropout`` has no parameters, so only its *position* matters. Removing the
+        trailing Dropout keeps the Linears at indices 0 and 3; removing the inner one
+        would renumber the second Linear to ``net.2.*`` and break every existing
+        checkpoint. This test pins that down.
+        """
+        cfg = TransformerEncoderConfig(d_model=64, n_heads=4, n_layers=1, drop_rate=0.1, ff_expansion=4)
+        from nemo.collections.asr.modules.transformer_encoder import FeedForward
+
+        keys = sorted(k for k, _ in FeedForward(cfg).named_parameters())
+        assert keys == ['net.0.bias', 'net.0.weight', 'net.3.bias', 'net.3.weight'], (
+            f"FFN parameter keys changed to {keys}; this breaks loading existing "
+            "StreamingTransformerEncoder checkpoints."
+        )
+
+    @pytest.mark.unit
+    def test_eval_mode_disables_dropout(self):
+        """Inference must be deterministic and dropout-free at any drop_rate."""
+        torch.manual_seed(0)
+        model = TransformerEncoder(feat_in=128, d_model=64, n_heads=4, n_layers=2, drop_rate=0.5).eval()
+        x = torch.randn(2, 128, 32)
+        lengths = torch.tensor([32, 32])
+        with torch.no_grad():
+            a, _ = model(x, lengths)
+            b, _ = model(x, lengths)
+        torch.testing.assert_close(a, b)
 
 
 class TestTransformerEncoder:
@@ -773,3 +846,839 @@ class TestSelfAttentionModel:
 
         assert out.shape == (2, 64, 8)
         assert out_lengths.tolist() == [8, 6]
+
+    def test_base_build_mask_mod_unchanged(self):
+        """The refactored ``_build_mask_mod`` hook must preserve the base full/causal masks."""
+        full = TransformerEncoder(feat_in=80, d_model=64, n_heads=4, n_layers=1, attn_mode="full")
+        causal = TransformerEncoder(feat_in=80, d_model=64, n_heads=4, n_layers=1, attn_mode="causal")
+        length = torch.tensor([4, 4], dtype=torch.int64)
+
+        def allowed(mod, q, kv):
+            return bool(mod(torch.tensor(0), torch.tensor(0), torch.tensor(q), torch.tensor(kv)))
+
+        full_mod = full._build_mask_mod(length)
+        causal_mod = causal._build_mask_mod(length)
+        # Full: any valid (non-pad) key is attendable, including future keys.
+        assert allowed(full_mod, 1, 3)
+        assert allowed(full_mod, 3, 1)
+        # Padding (kv >= length) is masked in both.
+        assert not allowed(full_mod, 1, 4)
+        # Causal: future keys are masked, past/present allowed.
+        assert allowed(causal_mod, 3, 1)
+        assert not allowed(causal_mod, 1, 3)
+
+
+class TestSlidingWindowMod:
+    """Unit tests for the ``_make_sliding_window_mod`` FlexAttention mask factory."""
+
+    @staticmethod
+    def _allowed(mod, q, kv):
+        return bool(mod(torch.tensor(0), torch.tensor(0), torch.tensor(q), torch.tensor(kv)))
+
+    @pytest.mark.unit
+    def test_bounded_window(self):
+        """left=2, right=1 -> query q attends to kv in [q - 2, q + 1]."""
+        mod = _make_sliding_window_mod(2, 1)
+        assert self._allowed(mod, 5, 3)  # lower edge
+        assert self._allowed(mod, 5, 5)  # self
+        assert self._allowed(mod, 5, 6)  # upper edge (look-ahead)
+        assert not self._allowed(mod, 5, 2)  # beyond left context
+        assert not self._allowed(mod, 5, 7)  # beyond right context
+
+    @pytest.mark.unit
+    def test_unlimited_left_is_causal(self):
+        """left<0, right=0 -> unlimited past, no look-ahead (causal)."""
+        mod = _make_sliding_window_mod(-1, 0)
+        assert self._allowed(mod, 5, 0)  # far past allowed
+        assert self._allowed(mod, 5, 5)  # self allowed
+        assert not self._allowed(mod, 5, 6)  # future masked
+
+    @pytest.mark.unit
+    def test_unlimited_right_only_left_bound(self):
+        """right<0, left=1 -> unlimited future, only one frame of past."""
+        mod = _make_sliding_window_mod(1, -1)
+        assert self._allowed(mod, 5, 4)  # one frame back allowed
+        assert self._allowed(mod, 5, 99)  # far future allowed
+        assert not self._allowed(mod, 5, 3)
+
+
+class TestChunkedLimitedMod:
+    """Unit tests for the ``_make_chunked_limited_mod`` FlexAttention mask factory."""
+
+    @staticmethod
+    def _allowed(mod, q, kv):
+        return bool(mod(torch.tensor(0), torch.tensor(0), torch.tensor(q), torch.tensor(kv)))
+
+    @pytest.mark.unit
+    def test_own_chunk_plus_left_chunks(self):
+        """left=4, right=1 -> chunk_size 2, left_chunks 2: query in chunk 3 sees chunks 1..3."""
+        mod = _make_chunked_limited_mod(4, 1)
+        assert self._allowed(mod, 6, 7)  # own chunk, in-chunk look-ahead
+        assert self._allowed(mod, 7, 6)  # own chunk, backwards
+        assert self._allowed(mod, 6, 2)  # two chunks back (left_chunks = 4 // 2 = 2)
+        assert not self._allowed(mod, 6, 1)  # three chunks back -> masked
+        assert not self._allowed(mod, 6, 8)  # next chunk -> masked
+
+    @pytest.mark.unit
+    def test_left_context_quantized_to_whole_chunks(self):
+        """left is floored to whole chunks: left=5, chunk_size=4 -> 1 left chunk (4 frames)."""
+        mod = _make_chunked_limited_mod(5, 3)
+        assert self._allowed(mod, 8, 4)  # start of the single visible left chunk
+        assert not self._allowed(mod, 8, 3)  # 5 frames back, but a chunk earlier -> masked
+
+    @pytest.mark.unit
+    def test_unlimited_left(self):
+        """left<0 -> every earlier chunk is visible, still no cross-chunk look-ahead."""
+        mod = _make_chunked_limited_mod(-1, 3)
+        assert self._allowed(mod, 100, 0)
+        assert self._allowed(mod, 100, 103)  # own chunk (100..103)
+        assert not self._allowed(mod, 100, 104)
+
+    @pytest.mark.unit
+    def test_matches_conformer_reference_mask(self):
+        """Bit-for-bit agreement with ``ConformerEncoder._create_masks``'s chunked_limited branch."""
+        T, left, right = 24, 5, 2
+        chunk_size = right + 1
+        left_chunks_num = left // chunk_size
+        chunk_idx = torch.div(torch.arange(T), chunk_size, rounding_mode="trunc")
+        diff_chunks = chunk_idx.unsqueeze(1) - chunk_idx.unsqueeze(0)
+        reference = torch.logical_and(diff_chunks <= left_chunks_num, diff_chunks >= 0)
+
+        mod = _make_chunked_limited_mod(left, right)
+        ours = torch.tensor([[self._allowed(mod, q, kv) for kv in range(T)] for q in range(T)])
+        assert torch.equal(ours, reference)
+
+
+class TestStreamingTransformerEncoder:
+    """Tests for the sliding-window streaming encoder and its cache-aware interface."""
+
+    @pytest.mark.unit
+    def test_satisfies_streaming_encoder_interface(self):
+        enc = StreamingTransformerEncoder(feat_in=80, d_model=64, n_heads=4, n_layers=2)
+        # Must pass the isinstance(encoder, StreamingEncoder) gate in AudioPerceptionModule.
+        assert isinstance(enc, StreamingEncoder)
+        assert isinstance(enc, TransformerEncoder)
+        for method in ("cache_aware_stream_step", "get_initial_cache_state", "setup_streaming_params"):
+            assert callable(getattr(enc, method))
+
+    @pytest.mark.unit
+    def test_streaming_cfg_tracks_att_context(self):
+        """``streaming_cfg`` is (re)built from ``att_context_size`` — the left context sizes the
+        rolling cache; FeatureStacking needs no pre-encode overlap."""
+        enc = StreamingTransformerEncoder(feat_in=80, d_model=64, n_heads=4, n_layers=2, att_context_size=[7, 0])
+        assert enc.streaming_cfg.pre_encode_cache_size == 0
+        assert enc.streaming_cfg.last_channel_cache_size == 7
+        # Retuning the window rebuilds the cfg.
+        enc.set_default_att_context_size([12, 0])
+        assert enc.streaming_cfg.last_channel_cache_size == 12
+
+    @pytest.mark.unit
+    def test_initial_cache_state_shapes(self):
+        """A rolling cache pre-allocates ``left`` frames per layer (padded); ``cache_last_time`` is
+        a zero-width placeholder (no conv) and valid length starts at 0.
+
+        ``cache_last_time`` must keep ``ConformerEncoder``'s 4-D rank
+        ``(n_layers, B, d_model, conv_cache)`` even though its width is 0: the shared
+        cache-aware inference tooling slices it as ``cache_last_time[:, slot_ids, :, :]``,
+        so a 3-D placeholder breaks ``asr_streaming_infer.py`` at runtime.
+        """
+        d_model, n_layers, left, B = 64, 3, 7, 2
+        enc = StreamingTransformerEncoder(
+            feat_in=80, d_model=d_model, n_heads=4, n_layers=n_layers, att_context_size=[left, 0]
+        )
+        clc, clt, clcl = enc.get_initial_cache_state(batch_size=B)
+        assert clc.shape == (n_layers, B, left, d_model)
+        assert clt.shape == (n_layers, B, d_model, 0)
+        assert clt.dim() == 4, "cache_last_time must be 4-D for parity with ConformerEncoder"
+        assert clcl.shape == (B,)
+        assert clcl.sum().item() == 0
+        # A full cache (left < 0) starts empty and grows.
+        enc.set_default_att_context_size([-1, 0])
+        clc_full, _, _ = enc.get_initial_cache_state(batch_size=B)
+        assert clc_full.shape == (n_layers, B, 0, d_model)
+
+    @pytest.mark.unit
+    def test_default_att_context_size_is_full(self):
+        enc = StreamingTransformerEncoder(feat_in=80, d_model=64, n_heads=4, n_layers=2)
+        assert enc.att_context_size == [-1, -1]
+
+    @pytest.mark.unit
+    def test_set_default_att_context_size(self):
+        enc = StreamingTransformerEncoder(feat_in=80, d_model=64, n_heads=4, n_layers=2, att_context_size=[70, 1])
+        assert enc.att_context_size == [70, 1]
+        # StreamingSTTModel retunes the look-ahead per chunk by reassigning this attribute.
+        enc.set_default_att_context_size([70, 5])
+        assert enc.att_context_size == [70, 5]
+
+    @pytest.mark.unit
+    def test_invalid_att_context_size_raises(self):
+        with pytest.raises(ValueError, match=r"\[left, right\] pair"):
+            StreamingTransformerEncoder(feat_in=80, d_model=64, n_heads=4, n_layers=2, att_context_size=[1, 2, 3])
+
+    @pytest.mark.unit
+    def test_attn_mode_kwarg_is_ignored(self):
+        """Unlike the base (which rejects it), the streaming encoder swallows ``attn_mode``."""
+        enc = StreamingTransformerEncoder(
+            feat_in=80, d_model=64, n_heads=4, n_layers=2, attn_mode="sliding_window", att_context_size=[3, 0]
+        )
+        assert enc.attn_mode == "sliding_window"
+        assert enc.att_context_size == [3, 0]
+
+    @pytest.mark.unit
+    def test_forward_cpu_shape(self):
+        enc = StreamingTransformerEncoder(
+            feat_in=128, d_model=64, n_heads=4, n_layers=2, drop_rate=0.0, att_context_size=[10, 1]
+        )
+        enc.eval()
+
+        B, C, T = 2, 128, 200
+        x = torch.randn(B, C, T)
+        lengths = torch.tensor([T, 160])
+
+        with torch.no_grad():
+            out, out_lengths = enc(audio_signal=x, length=lengths)
+
+        assert out.shape == (B, 64, T // 4)
+        assert out_lengths.tolist() == [T // 4, 160 // 4]
+        assert not torch.isnan(out).any()
+
+    @pytest.mark.unit
+    def test_sliding_window_limits_receptive_field(self):
+        """With a single layer and window [1, 1], output at frame i must be invariant to
+        input changes outside [i - 1, i + 1]. Uses ``bypass_pre_encode`` + ``no_pos`` so
+        frame indices map 1:1 and no positional mixing obscures the receptive field."""
+        B, T, d_model = 1, 8, 64
+        enc = StreamingTransformerEncoder(
+            feat_in=d_model,
+            d_model=d_model,
+            n_heads=4,
+            n_layers=1,
+            drop_rate=0.0,
+            dropout_pre_encoder=0.0,
+            dropout_emb=0.0,
+            self_attention_model="no_pos",
+            att_context_size=[1, 1],
+        )
+        enc.eval()
+
+        x = torch.randn(B, T, d_model)
+        length = torch.tensor([T], dtype=torch.int64)
+        x_perturbed = x.clone()
+        x_perturbed[:, 5, :] = torch.randn(d_model)  # change only frame 5
+
+        with torch.no_grad():
+            out, _ = enc(audio_signal=x, length=length, bypass_pre_encode=True)
+            out_perturbed, _ = enc(audio_signal=x_perturbed, length=length, bypass_pre_encode=True)
+
+        # out is (B, d_model, T). Frame 2's window {1, 2, 3} excludes frame 5 -> unchanged.
+        assert torch.allclose(out[:, :, 2], out_perturbed[:, :, 2], atol=1e-6)
+        # Frame 4's window {3, 4, 5} includes frame 5 -> must change.
+        assert not torch.allclose(out[:, :, 4], out_perturbed[:, :, 4], atol=1e-6)
+
+    @pytest.mark.unit
+    def test_full_window_attends_everywhere(self):
+        """Contrast to the windowed case: att_context_size [-1, -1] is full attention, so a
+        distant perturbation *does* reach every output frame."""
+        B, T, d_model = 1, 8, 64
+        enc = StreamingTransformerEncoder(
+            feat_in=d_model,
+            d_model=d_model,
+            n_heads=4,
+            n_layers=1,
+            drop_rate=0.0,
+            dropout_pre_encoder=0.0,
+            dropout_emb=0.0,
+            self_attention_model="no_pos",
+            att_context_size=[-1, -1],
+        )
+        enc.eval()
+
+        x = torch.randn(B, T, d_model)
+        length = torch.tensor([T], dtype=torch.int64)
+        x_perturbed = x.clone()
+        x_perturbed[:, 5, :] = torch.randn(d_model)
+
+        with torch.no_grad():
+            out, _ = enc(audio_signal=x, length=length, bypass_pre_encode=True)
+            out_perturbed, _ = enc(audio_signal=x_perturbed, length=length, bypass_pre_encode=True)
+
+        assert not torch.allclose(out[:, :, 2], out_perturbed[:, :, 2], atol=1e-6)
+
+    @staticmethod
+    def _stream_sequence(enc, x, chunk_len, n_chunks, batch_size, bypass_pre_encode):
+        """Feed ``x`` through the cache-aware streaming path chunk by chunk and return the
+        concatenated encoder output ``(B, D, T')``. ``x`` is ``(B, T, d_model)`` when
+        ``bypass_pre_encode`` else ``(B, feat_in, T_in)``; ``chunk_len`` is in input frames."""
+        clc, clt, clcl = enc.get_initial_cache_state(batch_size=batch_size, dtype=x.dtype, device=x.device)
+        outs = []
+        for c in range(n_chunks):
+            if bypass_pre_encode:
+                chunk = x[:, c * chunk_len : (c + 1) * chunk_len, :]
+            else:
+                chunk = x[:, :, c * chunk_len : (c + 1) * chunk_len]
+            chunk_frames = chunk.shape[1] if bypass_pre_encode else chunk.shape[2]
+            clen = torch.tensor([chunk_frames] * batch_size, dtype=torch.int64)
+            enc_out, _, clc, clt, clcl = enc.cache_aware_stream_step(
+                processed_signal=chunk,
+                processed_signal_length=clen,
+                cache_last_channel=clc,
+                cache_last_time=clt,
+                cache_last_channel_len=clcl,
+                bypass_pre_encode=bypass_pre_encode,
+            )
+            outs.append(enc_out)
+        return torch.cat(outs, dim=2), clcl
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "sam, left, chunk, n_chunks, batch, bypass",
+        [
+            ("rel_pos", 3, 2, 4, 1, True),  # warm-up: cache fills over several chunks (chunk < left)
+            ("rel_pos", 2, 4, 4, 1, True),  # rolling: chunk > left
+            ("rel_pos", 3, 2, 4, 2, True),  # batched
+            ("no_pos", 3, 2, 4, 1, True),  # no positional encoding
+            ("rope", 3, 2, 4, 1, True),  # rotary position embedding (warm-up)
+            ("rope", 2, 4, 4, 1, True),  # rotary position embedding (rolling)
+            ("rope", 3, 2, 4, 1, False),  # rope with FeatureStacking subsampling
+            ("rel_pos", -1, 2, 4, 1, True),  # full (unbounded) cache
+            ("rel_pos", 3, 2, 4, 1, False),  # with FeatureStacking subsampling (aligned chunks)
+        ],
+    )
+    def test_streaming_matches_full_forward(self, sam, left, chunk, n_chunks, batch, bypass):
+        """The defining guarantee: causal chunk-by-chunk streaming with the KV cache must equal the
+        full-sequence causal forward. Requires ``right == 0`` (a frame never needs a future frame)."""
+        torch.manual_seed(0)
+        d_model, sub, feat_in = 64, 4, 32
+        enc = StreamingTransformerEncoder(
+            feat_in=feat_in if not bypass else d_model,
+            d_model=d_model,
+            n_heads=4,
+            n_layers=2,
+            drop_rate=0.0,
+            dropout_pre_encoder=0.0,
+            dropout_emb=0.0,
+            self_attention_model=sam,
+            subsampling_factor=sub,
+            att_context_size=[left, 0],
+        )
+        enc.eval()
+
+        if bypass:
+            x = torch.randn(batch, chunk * n_chunks, d_model)
+            chunk_len = chunk
+            in_len = x.shape[1]
+        else:
+            # ``chunk`` encoder frames == ``chunk * sub`` input frames; keep chunks aligned to the
+            # subsampling factor so each chunk subsamples independently (matches the full forward).
+            x = torch.randn(batch, feat_in, chunk * sub * n_chunks)
+            chunk_len = chunk * sub
+            in_len = x.shape[2]
+        lengths = torch.tensor([in_len] * batch, dtype=torch.int64)
+
+        with torch.no_grad():
+            full_out, _ = enc(audio_signal=x, length=lengths, bypass_pre_encode=bypass)
+            stream_out, final_valid_len = self._stream_sequence(enc, x, chunk_len, n_chunks, batch, bypass)
+
+        assert stream_out.shape == full_out.shape
+        assert torch.allclose(full_out, stream_out, atol=1e-5)
+        # Valid cache length saturates at ``left`` for a rolling cache (whole utterance for full).
+        expected = chunk * n_chunks if left < 0 else min(chunk * n_chunks, left)
+        assert final_valid_len.tolist() == [expected] * batch
+
+    # ------------------------------------------------------------------ #
+    # chunked_limited (chunk-aligned look-ahead)
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.unit
+    def test_invalid_att_context_style_raises(self):
+        with pytest.raises(ValueError, match="att_context_style"):
+            StreamingTransformerEncoder(feat_in=80, d_model=64, n_heads=4, n_layers=2, att_context_style="bogus")
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "left, right, expected",
+        [
+            (70, 13, 70),  # chunk 14 divides 70 exactly -> full left context
+            (70, 27, 56),  # chunk 28 -> 2 whole chunks, left quantized down from 70
+            (70, 3, 68),  # chunk 4 -> 17 whole chunks
+            (2, 13, 0),  # left smaller than one chunk -> chunk attends to itself only
+            (-1, 13, -1),  # unbounded left -> full (growing) cache
+        ],
+    )
+    def test_chunked_limited_cache_size_quantizes_to_chunks(self, left, right, expected):
+        """The rolling cache holds whole chunks only, so it matches what the mask can actually see."""
+        enc = StreamingTransformerEncoder(
+            feat_in=80,
+            d_model=64,
+            n_heads=4,
+            n_layers=2,
+            att_context_style="chunked_limited",
+            att_context_size=[left, right],
+        )
+        assert enc.cache_size == expected
+        clc, _, _ = enc.get_initial_cache_state(batch_size=2)
+        assert clc.shape[2] == max(expected, 0)
+        # ``streaming_cfg`` reports a concrete size, substituting ``max_context`` for an unbounded
+        # left context (Conformer parity); ``cache_size < 0`` stays the encoder's "grow" marker.
+        if expected >= 0:
+            assert enc.streaming_cfg.last_channel_cache_size == expected
+        else:
+            assert enc.streaming_cfg.last_channel_cache_size == 10000
+
+    @pytest.mark.unit
+    def test_chunked_limited_lookahead_does_not_compound_across_layers(self):
+        """The property that makes chunk-aligned look-ahead streamable.
+
+        A sliding ``right`` window lets each layer peek one window further ahead, so an N-layer
+        stack sees ``N * right`` frames of future — unreproducible chunk-by-chunk. Chunk-aligned
+        attention stops every layer at the same boundary, so the look-ahead stays inside the
+        current chunk no matter how deep the stack.
+        """
+        n_layers, chunk, sub, feat_in = 4, 8, 4, 32
+        right = chunk - 1
+
+        def first_affected_frame(style):
+            torch.manual_seed(0)
+            enc = StreamingTransformerEncoder(
+                feat_in=feat_in,
+                d_model=64,
+                n_heads=4,
+                n_layers=n_layers,
+                drop_rate=0.0,
+                dropout_pre_encoder=0.0,
+                dropout_emb=0.0,
+                self_attention_model="rope",
+                subsampling_factor=sub,
+                att_context_style=style,
+                att_context_size=[24, right],
+            ).eval()
+            T = 16 * chunk * sub
+            x = torch.randn(1, feat_in, T)
+            lengths = torch.tensor([T], dtype=torch.int64)
+            perturb_from = 8 * chunk  # encoder frame index — the start of chunk 8
+            x2 = x.clone()
+            x2[:, :, perturb_from * sub :] = torch.randn_like(x2[:, :, perturb_from * sub :])
+            with torch.no_grad():
+                a, _ = enc(audio_signal=x, length=lengths)
+                b, _ = enc(audio_signal=x2, length=lengths)
+            diff = (a - b).abs().mean(dim=1)[0]
+            return perturb_from - int((diff > 1e-6).nonzero()[0])
+
+        # Chunk-aligned: only the frames of the perturbed frame's own chunk can see it, and the
+        # perturbation starts on a chunk boundary — so nothing before it moves at all.
+        assert first_affected_frame("chunked_limited") == 0
+        # Sliding window with the same ``right``: the reach compounds well past one chunk.
+        assert first_affected_frame("sliding_window") > chunk
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("sam", ["rope", "rel_pos", "no_pos"])
+    @pytest.mark.parametrize("left, chunk, n_chunks", [(24, 8, 5), (6, 4, 6), (3, 8, 4)])
+    def test_chunked_limited_streaming_matches_full_forward(self, sam, left, chunk, n_chunks):
+        """The payoff: with chunk-aligned look-ahead, chunk-by-chunk streaming is still exact.
+
+        Contrast with :meth:`test_streaming_matches_full_forward`, which requires ``right == 0``.
+        Here ``right = chunk - 1`` gives a full chunk of look-ahead and streaming still reproduces
+        the full forward, because the current chunk is entirely present in the KV span.
+        """
+        torch.manual_seed(0)
+        d_model, sub, feat_in = 64, 4, 32
+        enc = StreamingTransformerEncoder(
+            feat_in=feat_in,
+            d_model=d_model,
+            n_heads=4,
+            n_layers=3,
+            drop_rate=0.0,
+            dropout_pre_encoder=0.0,
+            dropout_emb=0.0,
+            self_attention_model=sam,
+            subsampling_factor=sub,
+            att_context_style="chunked_limited",
+            att_context_size=[left, chunk - 1],
+        )
+        enc.eval()
+
+        x = torch.randn(1, feat_in, chunk * sub * n_chunks)
+        lengths = torch.tensor([x.shape[2]], dtype=torch.int64)
+
+        with torch.no_grad():
+            full_out, _ = enc(audio_signal=x, length=lengths)
+            stream_out, final_valid_len = self._stream_sequence(enc, x, chunk * sub, n_chunks, 1, False)
+
+        assert stream_out.shape == full_out.shape
+        assert torch.allclose(full_out, stream_out, atol=1e-5)
+        assert final_valid_len.tolist() == [min(chunk * n_chunks, enc.cache_size)]
+
+    @pytest.mark.unit
+    def test_chunked_limited_streaming_ragged_batch_matches_full_forward(self):
+        """Batched streaming stays exact over every stream's valid frames when lengths differ."""
+        torch.manual_seed(0)
+        sub, feat_in, chunk, n_chunks = 4, 32, 8, 5
+        enc = StreamingTransformerEncoder(
+            feat_in=feat_in,
+            d_model=64,
+            n_heads=4,
+            n_layers=3,
+            drop_rate=0.0,
+            dropout_pre_encoder=0.0,
+            dropout_emb=0.0,
+            self_attention_model="rope",
+            subsampling_factor=sub,
+            att_context_style="chunked_limited",
+            att_context_size=[16, chunk - 1],
+        )
+        enc.eval()
+
+        valid_enc = [chunk * n_chunks, 3 * chunk + 5]  # stream 1 ends mid-chunk
+        x = torch.randn(2, feat_in, chunk * sub * n_chunks)
+        x[1, :, valid_enc[1] * sub :] = 0.0  # zero-pad the tail, as streaming inference does
+        lengths = torch.tensor([v * sub for v in valid_enc], dtype=torch.int64)
+
+        with torch.no_grad():
+            full_out, _ = enc(audio_signal=x, length=lengths)
+            clc, clt, clcl = enc.get_initial_cache_state(batch_size=2)
+            outs = []
+            for c in range(n_chunks):
+                step = chunk * sub
+                chunk_lens = torch.tensor([max(0, min(step, int(l) - c * step)) for l in lengths], dtype=torch.int64)
+                out, _, clc, clt, clcl = enc.cache_aware_stream_step(
+                    processed_signal=x[:, :, c * step : (c + 1) * step],
+                    processed_signal_length=chunk_lens,
+                    cache_last_channel=clc,
+                    cache_last_time=clt,
+                    cache_last_channel_len=clcl,
+                )
+                outs.append(out)
+            stream_out = torch.cat(outs, dim=2)
+
+        # Frames past a stream's end are discarded by the caller, so only valid frames must match.
+        for b, v in enumerate(valid_enc):
+            assert torch.allclose(full_out[b, :, :v], stream_out[b, :, :v], atol=1e-5)
+
+    @pytest.mark.unit
+    def test_chunked_limited_rejects_oversized_streaming_chunk(self):
+        """A streaming step wider than one attention chunk would silently break exactness."""
+        enc = StreamingTransformerEncoder(
+            feat_in=64,
+            d_model=64,
+            n_heads=4,
+            n_layers=1,
+            att_context_style="chunked_limited",
+            att_context_size=[8, 3],  # chunk_size = 4
+        )
+        enc.eval()
+        clc, clt, clcl = enc.get_initial_cache_state(batch_size=1)
+        with torch.no_grad(), pytest.raises(ValueError, match="chunked_limited streaming"):
+            enc.cache_aware_stream_step(
+                processed_signal=torch.randn(1, 5, 64),  # 5 > chunk_size 4
+                processed_signal_length=torch.tensor([5]),
+                cache_last_channel=clc,
+                cache_last_time=clt,
+                cache_last_channel_len=clcl,
+                bypass_pre_encode=True,
+            )
+
+    # ------------------------------------------------------------------ #
+    # multi chunk-size training (att_context_size as a list of pairs)
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _multi_ctx_encoder(att_context_size, att_context_probs=None, n_layers=2, **kw):
+        return StreamingTransformerEncoder(
+            feat_in=128,
+            feat_out=-1,
+            d_model=256,
+            n_heads=8,
+            n_layers=n_layers,
+            drop_rate=0.0,
+            dropout_pre_encoder=0.0,
+            dropout_emb=0.0,
+            qk_norm=True,
+            subsampling="feature_stacking",
+            subsampling_factor=8,
+            self_attention_model="rope",
+            att_context_style="chunked_limited",
+            att_context_size=att_context_size,
+            att_context_probs=att_context_probs,
+            **kw,
+        )
+
+    @pytest.mark.unit
+    def test_multi_att_context_size_parsed(self):
+        """A list of [left, right] pairs configures multi chunk-size training."""
+        enc = self._multi_ctx_encoder([[70, 1], [70, 6], [70, 13]])
+        assert enc.att_context_size_all == [[70, 1], [70, 6], [70, 13]]
+        assert enc.att_context_probs == pytest.approx([1 / 3, 1 / 3, 1 / 3])
+        # Eval/streaming default is the first entry, as in ConformerEncoder.
+        assert enc.att_context_size == [70, 1]
+
+    @pytest.mark.unit
+    def test_single_pair_still_accepted(self):
+        """Backward compatible: a bare pair becomes a one-entry list and disables sampling."""
+        enc = self._multi_ctx_encoder([70, 13])
+        assert enc.att_context_size_all == [[70, 13]]
+        assert enc.att_context_size == [70, 13]
+        enc.train()
+        assert {tuple(enc._sample_att_context_size()) for _ in range(20)} == {(70, 13)}
+
+    @pytest.mark.unit
+    def test_sampling_only_in_training(self):
+        """Training samples per batch; eval is deterministic so val loss and streaming are stable."""
+        enc = self._multi_ctx_encoder([[70, 1], [70, 6], [70, 13]])
+        enc.train()
+        seen = {tuple(enc._sample_att_context_size()) for _ in range(200)}
+        assert seen == {(70, 1), (70, 6), (70, 13)}, f"not all contexts sampled: {seen}"
+        enc.eval()
+        assert {tuple(enc._sample_att_context_size()) for _ in range(50)} == {(70, 1)}
+
+    @pytest.mark.unit
+    def test_att_context_probs_respected(self):
+        """A degenerate distribution must pin the corresponding context."""
+        enc = self._multi_ctx_encoder([[70, 1], [70, 13]], att_context_probs=[0.0, 1.0])
+        enc.train()
+        assert {tuple(enc._sample_att_context_size()) for _ in range(100)} == {(70, 13)}
+
+    @pytest.mark.unit
+    def test_invalid_att_context_probs_raise(self):
+        with pytest.raises(ValueError, match="att_context_probs has"):
+            self._multi_ctx_encoder([[70, 1], [70, 13]], att_context_probs=[1.0])
+        with pytest.raises(ValueError, match="must sum to 1"):
+            self._multi_ctx_encoder([[70, 1], [70, 13]], att_context_probs=[0.3, 0.3])
+
+    @pytest.mark.unit
+    def test_malformed_att_context_size_raises(self):
+        with pytest.raises(ValueError, match=r"\[left, right\] pairs"):
+            self._multi_ctx_encoder([[70, 1, 2], [70, 13]])
+        with pytest.raises(ValueError, match="must not be empty"):
+            self._multi_ctx_encoder([])
+
+    @pytest.mark.unit
+    def test_set_default_att_context_size_pins_eval_context_only(self):
+        """How inference selects a chunk size — and what pinning does NOT do.
+
+        Pinning fixes the eval/streaming context. Training keeps sampling over the configured set
+        (matching ConformerEncoder), so pinning never silently narrows a training run.
+        """
+        enc = self._multi_ctx_encoder([[70, 1], [70, 6], [70, 13]])
+        enc.set_default_att_context_size([70, 13])
+        assert enc.att_context_size == [70, 13]
+        assert enc.streaming_cfg.chunk_size == 8 * 14  # input frames for a 14-frame chunk
+        enc.eval()
+        assert {tuple(enc._sample_att_context_size()) for _ in range(20)} == {(70, 13)}
+        enc.train()
+        assert enc.att_context_size_all == [[70, 1], [70, 6], [70, 13]]
+        assert len({tuple(enc._sample_att_context_size()) for _ in range(200)}) == 3
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("context", [[70, 1], [70, 6], [70, 13]])
+    def test_every_configured_context_streams_exactly(self, context):
+        """The guarantee that makes multi chunk-size training usable: each context a batch may be
+        trained at must also stream exactly, so one checkpoint serves every chunk size."""
+        torch.manual_seed(0)
+        sub, n_chunks = 8, 5
+        enc = self._multi_ctx_encoder([[70, 1], [70, 6], [70, 13]], n_layers=3)
+        enc.eval()
+        enc.set_default_att_context_size(context)
+        chunk = context[1] + 1
+        x = torch.randn(1, 128, chunk * sub * n_chunks)
+        lengths = torch.tensor([x.shape[2]], dtype=torch.int64)
+        with torch.no_grad():
+            full_out, _ = enc(audio_signal=x, length=lengths)
+            stream_out, _ = self._stream_sequence(enc, x, chunk * sub, n_chunks, 1, False)
+        assert stream_out.shape == full_out.shape
+        assert torch.allclose(full_out, stream_out, atol=1e-5)
+
+    # ------------------------------------------------------------------ #
+    # streaming_cfg / pre-encode cache (shared cache-aware tooling contract)
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.unit
+    def test_streaming_cfg_exposes_full_cache_aware_config(self):
+        """``speech_to_text_cache_aware_streaming_infer.py`` and ``CacheAwareStreamingAudioBuffer``
+        read fields off ``streaming_cfg`` directly; a missing one is an AttributeError mid-stream."""
+        enc = StreamingTransformerEncoder(
+            feat_in=80, d_model=64, n_heads=4, n_layers=2, subsampling_factor=8, att_context_size=[70, 0]
+        )
+        for field in dataclasses.fields(CacheAwareStreamingConfig):
+            assert hasattr(enc.streaming_cfg, field.name), f"streaming_cfg is missing {field.name}"
+        # Units follow the Conformer: chunk/shift in input frames, valid_out_len in encoder frames.
+        assert enc.streaming_cfg.chunk_size == 8 * enc.streaming_cfg.valid_out_len
+        assert enc.streaming_cfg.shift_size == enc.streaming_cfg.chunk_size
+        assert enc.streaming_cfg.cache_drop_size == 0
+        assert enc.streaming_cfg.last_channel_num == 2
+        assert enc.streaming_cfg.last_time_num == 0
+
+    @pytest.mark.unit
+    def test_setup_streaming_params_honors_chunk_and_left_chunks(self):
+        """The overrides the infer script passes for offline/full-context models must take effect."""
+        enc = StreamingTransformerEncoder(
+            feat_in=80, d_model=64, n_heads=4, n_layers=2, subsampling_factor=8, att_context_size=[70, 0]
+        )
+        # Causal sliding window implies a 1-frame step; the script can widen it for throughput.
+        assert enc.streaming_cfg.chunk_size == 8
+        enc.setup_streaming_params(chunk_size=14, shift_size=14)
+        assert enc.streaming_cfg.chunk_size == 8 * 14
+        assert enc.streaming_cfg.valid_out_len == 14
+        # left_chunks retunes the window itself, so mask and cache cannot disagree.
+        enc.setup_streaming_params(chunk_size=14, shift_size=14, left_chunks=3)
+        assert enc.att_context_size[0] == 42
+        assert enc.streaming_cfg.last_channel_cache_size == 42 == enc.cache_size
+
+    @pytest.mark.unit
+    def test_setup_streaming_params_rejects_unsupported_overrides(self):
+        enc = StreamingTransformerEncoder(
+            feat_in=80, d_model=64, n_heads=4, n_layers=2, subsampling_factor=8, att_context_size=[70, 0]
+        )
+        with pytest.raises(ValueError, match="shift_size"):
+            enc.setup_streaming_params(chunk_size=14, shift_size=7)  # overlapping chunks
+        enc2 = StreamingTransformerEncoder(
+            feat_in=80,
+            d_model=64,
+            n_heads=4,
+            n_layers=2,
+            subsampling_factor=8,
+            att_context_style="chunked_limited",
+            att_context_size=[70, 13],
+        )
+        with pytest.raises(ValueError, match="exceeds the chunked_limited attention chunk"):
+            enc2.setup_streaming_params(chunk_size=20)  # wider than the 14-frame attention chunk
+
+    @pytest.mark.unit
+    def test_pre_encode_cache_size_must_align_to_subsampling(self):
+        with pytest.raises(ValueError, match="pre_encode_cache_size"):
+            StreamingTransformerEncoder(
+                feat_in=80, d_model=64, n_heads=4, n_layers=2, subsampling_factor=8, pre_encode_cache_size=5
+            )
+
+    @pytest.mark.unit
+    def test_pre_encode_cache_size_derives_drop_extra_and_step0_list(self):
+        """``pre_encode_cache_size`` is emitted as ``[0, P]`` so the streaming buffer prepends
+        nothing on the first step, matching ``calc_drop_extra_pre_encoded`` returning 0 there."""
+        enc = StreamingTransformerEncoder(
+            feat_in=80,
+            d_model=64,
+            n_heads=4,
+            n_layers=2,
+            subsampling_factor=8,
+            pre_encode_cache_size=16,
+            att_context_size=[70, 0],
+        )
+        assert enc.streaming_cfg.pre_encode_cache_size == [0, 16]
+        assert enc.streaming_cfg.drop_extra_pre_encoded == 2  # 16 input frames / 8 = 2 encoder frames
+        # Default (no look-back) stays a plain scalar 0, unchanged from before.
+        plain = StreamingTransformerEncoder(feat_in=80, d_model=64, n_heads=4, n_layers=2, subsampling_factor=8)
+        assert plain.streaming_cfg.pre_encode_cache_size == 0
+        assert plain.streaming_cfg.drop_extra_pre_encoded == 0
+
+    @pytest.mark.unit
+    def test_no_cache_means_no_implicit_drop(self):
+        """A caller with no cache is passing a whole utterance, not a chunk with look-back.
+
+        ``conformer_stream_step(processed_signal=<whole audio>)`` — which the cache-aware infer
+        script uses for ``compare_vs_offline`` — reaches the encoder with ``cache_last_channel=None``
+        and ``drop_extra_pre_encoded=None``. Defaulting to the configured drop there would silently
+        truncate the offline reference it is meant to compare against.
+        """
+        sub, feat_in, frames = 8, 32, 6
+        enc = StreamingTransformerEncoder(
+            feat_in=feat_in,
+            d_model=64,
+            n_heads=4,
+            n_layers=2,
+            self_attention_model="rope",
+            subsampling_factor=sub,
+            att_context_size=[16, 0],
+            pre_encode_cache_size=sub,  # -> drop_extra_pre_encoded == 1
+        )
+        enc.eval()
+        assert enc.streaming_cfg.drop_extra_pre_encoded == 1
+        x = torch.randn(1, feat_in, frames * sub)
+        with torch.no_grad():
+            out, out_len, *_ = enc.cache_aware_stream_step(
+                processed_signal=x,
+                processed_signal_length=torch.tensor([x.shape[2]], dtype=torch.int64),
+                cache_last_channel=None,  # no cache -> whole-utterance call
+            )
+        assert out.shape[2] == frames, "whole-utterance call must not lose leading frames"
+        assert out_len.tolist() == [frames]
+        # An explicit value is still honoured regardless of the cache state.
+        with torch.no_grad():
+            out2, _, *_ = enc.cache_aware_stream_step(
+                processed_signal=x,
+                processed_signal_length=torch.tensor([x.shape[2]], dtype=torch.int64),
+                cache_last_channel=None,
+                drop_extra_pre_encoded=1,
+            )
+        assert out2.shape[2] == frames - 1
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("pre_encode_cache_size", [8, 16])
+    def test_drop_extra_pre_encoded_makes_lookback_chunks_exact(self, pre_encode_cache_size):
+        """Feeding ``[look-back | chunk]`` and dropping the extra pre-encoded frames must return the
+        same frames — and the same count — as feeding the bare chunk.
+
+        This mirrors ``CacheAwareStreamingAudioBuffer``: step 0 gets no look-back and drops nothing;
+        later steps prepend the real preceding input frames and drop ``drop_extra_pre_encoded``.
+        """
+        torch.manual_seed(0)
+        sub, feat_in, chunk, n_chunks = 8, 32, 4, 5
+        enc = StreamingTransformerEncoder(
+            feat_in=feat_in,
+            d_model=64,
+            n_heads=4,
+            n_layers=3,
+            drop_rate=0.0,
+            dropout_pre_encoder=0.0,
+            dropout_emb=0.0,
+            self_attention_model="rope",
+            subsampling_factor=sub,
+            att_context_size=[16, 0],
+            pre_encode_cache_size=pre_encode_cache_size,
+        )
+        enc.eval()
+        step = chunk * sub
+        x = torch.randn(1, feat_in, step * n_chunks)
+        lengths = torch.tensor([x.shape[2]], dtype=torch.int64)
+        drop = enc.streaming_cfg.drop_extra_pre_encoded
+
+        with torch.no_grad():
+            full_out, _ = enc(audio_signal=x, length=lengths)
+            clc, clt, clcl = enc.get_initial_cache_state(batch_size=1)
+            outs = []
+            for c in range(n_chunks):
+                start = c * step
+                # Step 0 has no history: no look-back, nothing to drop (calc_drop_extra_pre_encoded).
+                back = 0 if c == 0 else pre_encode_cache_size
+                piece = x[:, :, start - back : start + step]
+                out, out_len, clc, clt, clcl = enc.cache_aware_stream_step(
+                    processed_signal=piece,
+                    processed_signal_length=torch.tensor([piece.shape[2]], dtype=torch.int64),
+                    cache_last_channel=clc,
+                    cache_last_time=clt,
+                    cache_last_channel_len=clcl,
+                    drop_extra_pre_encoded=0 if c == 0 else drop,
+                )
+                assert out.shape[2] == chunk, f"chunk {c}: got {out.shape[2]} frames, expected {chunk}"
+                assert out_len.tolist() == [chunk]
+                outs.append(out)
+            stream_out = torch.cat(outs, dim=2)
+
+        assert stream_out.shape == full_out.shape
+        assert torch.allclose(full_out, stream_out, atol=1e-5)
+
+    @pytest.mark.unit
+    def test_streaming_abs_pos_not_implemented(self):
+        """``abs_pos`` streaming is intentionally unsupported (no position offset in the cache)."""
+        enc = StreamingTransformerEncoder(
+            feat_in=64, d_model=64, n_heads=4, n_layers=1, self_attention_model="abs_pos", att_context_size=[3, 0]
+        )
+        enc.eval()
+        clc, clt, clcl = enc.get_initial_cache_state(batch_size=1)
+        with torch.no_grad(), pytest.raises(NotImplementedError, match="Cache-aware streaming"):
+            enc.cache_aware_stream_step(
+                processed_signal=torch.randn(1, 2, 64),
+                processed_signal_length=torch.tensor([2]),
+                cache_last_channel=clc,
+                cache_last_time=clt,
+                cache_last_channel_len=clcl,
+                bypass_pre_encode=True,
+            )

--- a/tests/collections/asr/test_transformer_encoder.py
+++ b/tests/collections/asr/test_transformer_encoder.py
@@ -1519,8 +1519,10 @@ class TestStreamingTransformerEncoder:
         assert enc.streaming_cfg.chunk_size == 8 * 14
         assert enc.streaming_cfg.valid_out_len == 14
         # left_chunks retunes the window itself, so mask and cache cannot disagree.
+        configured_contexts = [list(context) for context in enc.att_context_size_all]
         enc.setup_streaming_params(chunk_size=14, shift_size=14, left_chunks=3)
         assert enc.att_context_size[0] == 42
+        assert enc.att_context_size_all == configured_contexts
         assert enc.streaming_cfg.last_channel_cache_size == 42 == enc.cache_size
 
     @pytest.mark.unit
@@ -1537,10 +1539,11 @@ class TestStreamingTransformerEncoder:
             n_layers=2,
             subsampling_factor=8,
             att_context_style="chunked_limited",
-            att_context_size=[70, 13],
+            att_context_size=[8, 3],
         )
-        with pytest.raises(ValueError, match="exceeds the chunked_limited attention chunk"):
-            enc2.setup_streaming_params(chunk_size=20)  # wider than the 14-frame attention chunk
+        for chunk_size in (2, 5):
+            with pytest.raises(ValueError, match="must equal the chunked_limited attention chunk"):
+                enc2.setup_streaming_params(chunk_size=chunk_size)
 
     @pytest.mark.unit
     def test_pre_encode_cache_size_must_align_to_subsampling(self):


### PR DESCRIPTION
# Add StreamingTransformerEncoder: cache-aware streaming Transformer encoder for ASR

## What does this PR do?

Adds `StreamingTransformerEncoder`, a convolution-free Transformer encoder for streaming ASR. It
extends the existing `TransformerEncoder` with:

1. **Bounded local attention** via `att_context_size: [left, right]` (encoder frames) under two
   styles:
   - `chunked_limited` (default) — chunk-aligned attention matching `ConformerEncoder._create_masks`
     bit-for-bit. Look-ahead does **not** compound across layers, so streaming stays exact at any
     depth.
   - `sliding_window` — `[t - left, t + right]`; exact for streaming only when
     `right == 0`, since a sliding right context compounds across layers.
2. **Cache-aware streaming** with a rolling KV cache, implementing the real `StreamingEncoder`
   interface (`cache_aware_stream_step` / `get_initial_cache_state` / `setup_streaming_params`)
   and reusing the Conformer `cache_last_channel` plumbing, so the shared streaming tooling drives
   it unchanged.
3. **Multi-latency training** — a list of `[left, right]` pairs samples one context per training
   batch (mirroring `ConformerEncoder`); eval and streaming use a pinned context.

The cache stores raw, position-agnostic per-layer inputs, so the format is independent of the
positional scheme. Streaming supports `rel_pos`, `rope` and `no_pos` (`abs_pos` raises).

## Changes

| file | change |
|---|---|
| `nemo/collections/asr/modules/transformer_encoder.py` | `StreamingTransformerEncoder`, the chunked/sliding mask mods, and the streaming step |
| `nemo/collections/asr/modules/__init__.py` | export `StreamingTransformerEncoder` |
| `nemo/collections/asr/parts/submodules/subsampling.py` | `FeatureStacking.get_sampling_frames` / `get_streaming_cache_size`, probed by the cache-aware streaming utils |
| `examples/asr/conf/transformer/transformer_stacking_rnnt_bpe_streaming.yaml` | RNN-T training recipe |
| `docs/source/asr/api.rst` | autoclass entries for `TransformerEncoder` and `StreamingTransformerEncoder` |
| `docs/source/asr/configs.rst` | "Streaming Transformer" section covering `att_context_size` / `att_context_style` / `pre_encode_cache_size` |
| `tests/collections/asr/test_transformer_encoder.py` | 124 unit tests |

No existing behaviour changes: `TransformerEncoder` is untouched apart from an overridable
`_build_mask_mod` hook, and the `subsampling.py` additions are new methods only.

## Evaluation

Trained a 0.6 B RNN-T with this encoder (48 layers, `d_model` 1024, `feature_stacking` ×8, `rope`,
`chunked_limited`, contexts `[[70,13],[70,6],[70,1],[70,0]]`) and compared against the released
`nvidia/nemotron-speech-streaming-en-0.6b` FastConformer RNN-T. Preprocessor, SpecAugment, RNN-T
decoder, joint, loss, vocab, context ladder and parameter count are matched; the encoder is the
variable. Training data differs and is uncontrolled.

8 Open ASR Leaderboard test sets (82,185 utts / 167.6 h), byte-identical eval sets for both
models, scored with the HuggingFace Open ASR Leaderboard normalizer. Harness validated: the
reference reproduces its published model card (ls-other 5.18 vs 4.84, spgispeech 3.11 vs 2.97,
gigaspeech 8.93 vs 9.66).

**Offline inference with `examples/asr/transcribe_speech.py` (macro WER%, lower is better)**

| chunk | lookahead | this PR | FastConformer |
|---|---|---|---|
| 14 | 1.12 s | **6.78** | 6.85 |
| 7 | 0.56 s | **6.94** | 6.97 |
| 2 | 0.16 s | 7.70 | **7.43** |

At parity — this encoder wins 5 of 8 datasets at chunks 14 and 7.

**True cache-aware streaming using `examples/asr/asr_streaming_inference/asr_streaming_infer.py` (macro WER penalty vs offline)**

| chunk | this PR | FastConformer |
|---|---|---|
| 14 | **+0.01** | +0.40 |
| 7 | **+0.02** | +0.37 |
| 2 | **+0.12** | +0.51 |

Streaming is essentially free for this encoder. At chunk 2 this flips the ranking: offline the
Conformer leads 7.43 vs 7.70, but under real streaming this PR leads **7.82 vs 7.94**. Hypothesis
agreement with the offline forward is 86–93% here vs 71–80% for the Conformer.

## Testing

`pytest tests/collections/asr/test_transformer_encoder.py` — **124 passed**.

Coverage includes:
- `chunked_limited` mask parity with `ConformerEncoder._create_masks`, elementwise, for every
  configured context and several sequence lengths
- `test_streaming_matches_full_forward` — chunk-by-chunk streaming equals the full forward
  (~1e-6 fp32), including ragged batches, partial final chunks, cache warm-up and rolling caches
- multi-context sampling (train-only, deterministic in eval), cache shapes, `abs_pos` guard,
  `bypass_pre_encode`, activation-checkpointing unwrap, dropout wiring

Docs build: new `autoclass` targets and the `:ref:` labels they define resolve.