### PR TITLE
fix(asr): keep zero-length utterances inactive in batched MALSD beam search

### DIFF
--- a/nemo/collections/asr/parts/submodules/rnnt_malsd_batched_computer.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_malsd_batched_computer.py
@@ -84,6 +84,7 @@ class MALSDState:
     hyp_scores: torch.Tensor  # scores for hypotheses
 
     active_mask: torch.Tensor  # mask for active hypotheses (the decoding is finished for the utterance if it is False)
+    non_empty_mask: torch.Tensor  # mask for utterances with encoder_output_length > 0
     blank_mask: torch.Tensor  # if the element is blank
     active_mask_any: torch.Tensor  # 0-dim bool tensor, condition for outer loop ('any element is still active')
 
@@ -183,6 +184,7 @@ class MALSDState:
         self.last_timesteps = torch.zeros_like(self.batch_indices)
 
         self.active_mask = torch.zeros_like(self.batch_indices, dtype=torch.bool)
+        self.non_empty_mask = torch.zeros_like(self.active_mask, dtype=torch.bool)
         self.blank_mask = torch.zeros_like(self.active_mask, dtype=torch.bool)
         self.active_mask_any = torch.tensor(True, device=self.device, dtype=torch.bool)
 
@@ -510,9 +512,8 @@ class ModifiedALSDBatchedRNNTComputer(WithOptionalCudaGraphs, ConfidenceMethodMi
         safe_time_indices = torch.zeros_like(time_indices)  # time indices, guaranteed to be < out_len
         # In mixed batches some rows may have `encoder_output_length == 0`.
         last_timesteps = torch.clamp_min(encoder_output_length - 1, 0)[:, None].expand_as(batch_beam_indices)
-        active_mask = (encoder_output_length > 0)[:, None].expand_as(batch_beam_indices) & (
-            time_indices <= last_timesteps
-        )
+        non_empty_mask = (encoder_output_length > 0)[:, None].expand_as(batch_beam_indices)
+        active_mask = non_empty_mask & (time_indices <= last_timesteps)
 
         # setup fusion models and/or biasing multi-model
         if self.per_stream_biasing_enabled:
@@ -728,7 +729,7 @@ class ModifiedALSDBatchedRNNTComputer(WithOptionalCudaGraphs, ConfidenceMethodMi
             # step 6: update time indices + active mask
             time_indices = torch.gather(time_indices, dim=-1, index=hyps_indices) + (next_labels == self._blank_index)
             torch.minimum(time_indices, last_timesteps, out=safe_time_indices)
-            active_mask = time_indices <= last_timesteps
+            active_mask = non_empty_mask & (time_indices <= last_timesteps)
 
         # NB: last labels can not exist (nothing decoded on this step).
         # return the last labels from the previous state in this case
@@ -1192,6 +1193,7 @@ class ModifiedALSDBatchedRNNTComputer(WithOptionalCudaGraphs, ConfidenceMethodMi
         # masks for utterances in batch
         # same as: active_mask = self.encoder_output_length > 0
         torch.greater(self.state.encoder_output_length, 0, out=self.state.active_mask)
+        self.state.non_empty_mask.copy_(self.state.active_mask)
 
         # same as: self.active_mask_any = active_mask.any()
         torch.any(self.state.active_mask, out=self.state.active_mask_any)
@@ -1413,6 +1415,7 @@ class ModifiedALSDBatchedRNNTComputer(WithOptionalCudaGraphs, ConfidenceMethodMi
         self.state.time_indices.copy_(self.state.batched_hyps.next_timestamp)
         torch.minimum(self.state.time_indices, self.state.last_timesteps, out=self.state.safe_time_indices)
         torch.less_equal(self.state.time_indices, self.state.last_timesteps, out=self.state.active_mask)
+        torch.logical_and(self.state.active_mask, self.state.non_empty_mask, out=self.state.active_mask)
         torch.any(self.state.active_mask, out=self.state.active_mask_any)
 
     def _init_decoding_state(self, prev_batched_state: Optional[BatchedBeamState], current_batch_size: int):

--- a/tests/collections/asr/decoding/test_batched_beam_zero_length.py
+++ b/tests/collections/asr/decoding/test_batched_beam_zero_length.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Batched beam search must not decode utterances whose encoder output is empty.
+
+Streaming inference feeds mixed batches in which an utterance that has already been
+consumed is passed with ``encoded_lengths == 0`` while the rest of the batch keeps
+decoding (see ``examples/asr/asr_chunked_inference/rnnt/speech_to_text_streaming_infer_rnnt.py``).
+Such a row must stay inactive for the whole call.
+"""
+
+import pytest
+import torch
+
+from nemo.collections.asr.modules import RNNTDecoder, RNNTJoint
+from nemo.collections.asr.parts.submodules.rnnt_beam_decoding import BeamBatchedRNNTInfer
+
+VOCABULARY = ["a", "b", "c", "d", "e", "f"]
+ENCODER_DIM = 8
+PRED_HIDDEN = 8
+
+
+@pytest.fixture(scope="module")
+def rnnt_decoder_joint():
+    torch.manual_seed(1234)
+    decoder = RNNTDecoder({'pred_hidden': PRED_HIDDEN, 'pred_rnn_layers': 1}, len(VOCABULARY) + 1)
+    joint = RNNTJoint(
+        {
+            'encoder_hidden': ENCODER_DIM,
+            'pred_hidden': PRED_HIDDEN,
+            'joint_hidden': 8,
+            'activation': 'relu',
+        },
+        len(VOCABULARY) + 1,
+        vocabulary=VOCABULARY,
+    )
+    return decoder.eval(), joint.eval()
+
+
+def _beam_search(decoder, joint, beam_size):
+    return BeamBatchedRNNTInfer(
+        decoder,
+        joint,
+        blank_index=len(VOCABULARY),
+        beam_size=beam_size,
+        search_type="malsd_batch",
+        score_norm=True,
+        max_symbols_per_step=5,
+        allow_cuda_graphs=False,
+        return_best_hypothesis=True,
+    )
+
+
+def _decode(decoder, joint, encoder_output, encoded_lengths, beam_size):
+    beam_search = _beam_search(decoder, joint, beam_size)
+    with torch.no_grad():
+        result = beam_search(encoder_output=encoder_output, encoded_lengths=encoded_lengths)
+    return result[0] if isinstance(result, tuple) else result
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("beam_size", [2, 4])
+def test_malsd_batch_zero_length_utterance_decodes_nothing(rnnt_decoder_joint, beam_size):
+    """A row with ``encoded_lengths == 0`` must produce an empty hypothesis."""
+    decoder, joint = rnnt_decoder_joint
+    torch.manual_seed(0)
+    encoder_output = torch.randn(2, ENCODER_DIM, 9) * 3.0
+    encoded_lengths = torch.tensor([9, 0], dtype=torch.int32)
+
+    hypotheses = _decode(decoder, joint, encoder_output, encoded_lengths, beam_size)
+
+    assert len(hypotheses[1].y_sequence) == 0
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("beam_size", [2, 4])
+def test_malsd_batch_finished_stream_gains_no_labels(rnnt_decoder_joint, beam_size):
+    """A stream that ends mid-batch must not keep decoding while the batch continues."""
+    decoder, joint = rnnt_decoder_joint
+    torch.manual_seed(0)
+    encoder_output = torch.randn(2, 12, ENCODER_DIM) * 3.0
+    chunk_size, finished_after = 4, 1
+    computer = _beam_search(decoder, joint, beam_size).decoding_computer
+
+    state, decoded_lengths = None, None
+    with torch.no_grad():
+        for chunk_idx, start in enumerate(range(0, encoder_output.shape[1], chunk_size)):
+            length = min(chunk_size, encoder_output.shape[1] - start)
+            out_len = torch.tensor([length, 0 if chunk_idx > finished_after else length])
+            hyps, state = computer(
+                x=encoder_output[:, start : start + chunk_size], out_len=out_len, prev_batched_state=state
+            )
+            if chunk_idx == finished_after:
+                decoded_lengths = hyps.current_lengths_nb[1].clone()
+            elif chunk_idx > finished_after:
+                assert torch.equal(hyps.current_lengths_nb[1], decoded_lengths)
+            hyps.flatten_()


### PR DESCRIPTION
# What does this PR do ?

Keeps a batch row whose `encoder_output_length` is 0 inactive for the whole `malsd_batch` beam search,
instead of re-activating it and decoding up to `max_symbols_per_step` labels.

**Collection**: [ASR]

# Changelog

- `rnnt_malsd_batched_computer.py`: carry the `encoder_output_length > 0` term into both in-loop
  `active_mask` recomputations (`:731` eager, `:1415` CUDA-graph) through a new
  `MALSDState.non_empty_mask`. The two init sites already have it; because `last_timesteps` is
  `clamp_min(encoder_output_length - 1, 0)`, `time_indices <= last_timesteps` alone reads `0 <= 0` for
  an empty row and re-activates it. Regression from #15753, which added the `clamp_min` and updated
  only the init sites.
- New `tests/collections/asr/decoding/test_batched_beam_zero_length.py`: a one-shot mixed batch and a
  cross-chunk streaming case that must gain no labels after its audio ends.

# Usage

```python
bs = BeamBatchedRNNTInfer(dec, joint, blank_index=len(V), beam_size=2,
                          search_type="malsd_batch", max_symbols_per_step=5,
                          allow_cuda_graphs=False)
hyps = bs(encoder_output=torch.randn(2, 8, 9) * 3.0,
          encoded_lengths=torch.tensor([9, 0], dtype=torch.int32))[0]
print(repr(hyps[1].y_sequence))
```

On `6281c939aa`: `array([4, 4, 4, 4, 4])`. With this PR: `array([], dtype=int64)`, matching
`a409dfd1bc` (the commit before #15753) and today's `maes_batch`, TDT `malsd_batch` and `greedy_batch`.

Negative control: with the production file reverted to `main` the new tests report `4 failed`; with the
fix, `4 passed`. `tests/collections/asr/decoding/` on this branch: `131 passed, 62 skipped`, no
failures. `non_empty_mask` is all-`True` when every row has frames, so decoding is byte-identical for
any batch without an empty row.

Only the eager path is covered on CPU; the CUDA-graph edit is the same change and is exercised by the
existing GPU streaming tests.

# GitHub Actions CI

Requires a maintainer `/ok to test <head-sha>`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

# Additional Information

- Related to #16161

Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>
