### PR TITLE
fix(audio): correct estimate/target routing into CombinedLoss's ASR loss

### DIFF
--- a/nemo/collections/audio/losses/maxine/losses_combined.py
+++ b/nemo/collections/audio/losses/maxine/losses_combined.py
@@ -186,8 +186,8 @@ class CombinedLoss(Loss, Typing):
         if input_length is None:
             input_length = torch.full((estimate.shape[0],), estimate.shape[1]).to(device)
         source_lengths_l = torch.where(input_length > min_len, min_len, input_length)
-        primary_audio = estimate[..., :min_len]
-        predicted_audio = target[..., :min_len]
+        primary_audio = target[..., :min_len]
+        predicted_audio = estimate[..., :min_len]
 
         loss_total = torch.tensor([0.0]).to(device)
 

--- a/tests/collections/audio/test_audio_losses.py
+++ b/tests/collections/audio/test_audio_losses.py
@@ -1085,9 +1085,12 @@ class TestAudioLosses:
 
         GOLDEN_VALUES = [
             ((1, 0, 0, True, True), 80.0),
-            ((0, 1, 0, True, True), 1.9749),
+            # asr-only and combined golden values recomputed after fixing forward()'s
+            # estimate/target routing into asr_loss (see CombinedLoss.forward); sisnr and
+            # spectral losses are unaffected because both are symmetric under that swap.
+            ((0, 1, 0, True, True), 1.9083),
             ((0, 0, 1, True, True), 19.2192),
-            ((1, 1, 1, True, True), 101.1941),
+            ((1, 1, 1, True, True), 101.1275),
         ]
         batch_size = 16
 
@@ -1118,3 +1121,51 @@ class TestAudioLosses:
             loss = loss_instance.forward(estimate=estimate, target=input_data).cpu()
 
             assert np.allclose(loss, golden, atol=ATOL)
+
+    @pytest.mark.unit
+    def test_maxine_combined_loss_asr_routing(self):
+        """Regression test for CombinedLoss.forward argument routing.
+
+        `estimate` (the model's own output) must be the signal passed as the
+        `predicted_audio` argument of `asr_loss`, and `target` (the ground-truth
+        reference) must be passed as `primary_audio`. A lightweight stand-in
+        replaces the real ASR model so this test needs neither network access
+        nor a downloaded checkpoint.
+        """
+        loss_fn = CombinedLoss(
+            sample_rate=16000,
+            fft_length=64,
+            hop_length=16,
+            num_mels=8,
+            sisnr_loss_weight=0.0,
+            spectral_loss_weight=0.0,
+            asr_loss_weight=1.0,
+            use_asr_loss=False,  # avoid downloading the real ASR checkpoint in __init__
+            use_mel_spec=False,
+        )
+        # `asr_loss` indexes `next(self.parameters())`, so register a dummy parameter.
+        loss_fn.dummy_param = torch.nn.Parameter(torch.zeros(1))
+        loss_fn.use_asr_loss = True
+
+        recorded = {}
+
+        def fake_asr_loss(self, predicted_audio, primary_audio):
+            recorded['predicted_audio'] = predicted_audio.clone()
+            recorded['primary_audio'] = primary_audio.clone()
+            return torch.tensor(0.0)
+
+        loss_fn.asr_loss = fake_asr_loss.__get__(loss_fn, CombinedLoss)
+
+        torch.manual_seed(0)
+        batch_size, num_channels, num_samples = 2, 1, 320
+        estimate = torch.randn(batch_size, num_channels, num_samples)
+        target = torch.randn(batch_size, num_channels, num_samples) + 5.0
+
+        loss_fn.forward(estimate=estimate, target=target)
+
+        assert torch.equal(
+            recorded['predicted_audio'], estimate
+        ), "asr_loss's `predicted_audio` argument must receive the model estimate, not the target signal"
+        assert torch.equal(
+            recorded['primary_audio'], target
+        ), "asr_loss's `primary_audio` argument must receive the ground-truth target, not the estimate signal"


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Fixes `CombinedLoss.forward()` passing the model's estimate and the ground-truth target backwards into
`asr_loss`.

**Collection**: audio

# Changelog

- `losses_combined.py`: swap the `primary_audio`/`predicted_audio` bindings in `forward()` so
  `predicted_audio` receives `estimate` and `primary_audio` receives `target`, matching every other
  reference to these names in the file and the sole production call site
  (`BNR2Model._compute_train_loss` in `models/maxine/bnr.py`, which names the model's own output
  `predicted_audio` and passes it as `estimate=`).
- `test_audio_losses.py`: add `test_maxine_combined_loss_asr_routing`, a fast, network-free regression
  test that stubs `asr_loss` and asserts it receives `estimate` as `predicted_audio` and `target` as
  `primary_audio`.
- `test_audio_losses.py`: recompute the two golden values in `test_maxine_combined_loss` that the ASR
  branch affects (asr-only: `1.9749` -> `1.9083`; combined: `101.1941` -> `101.1275`), against the real
  cached `stt_en_conformer_ctc_small` checkpoint used by that test. The sisnr-only and spectral-only
  golden values are unchanged, because both of those losses are provably symmetric under this
  particular argument swap — verified directly and by the fact those two golden values did not move.

# Usage

No API change; `CombinedLoss.forward(estimate=..., target=...)` keyword arguments are unchanged.

Negative control: reverting only `losses_combined.py` to `main` while keeping the updated test file and
running both `test_maxine_combined_loss_asr_routing` and `test_maxine_combined_loss` fails without the
fix, and both pass with it:

```
$ pytest tests/collections/audio/test_audio_losses.py::TestAudioLosses::test_maxine_combined_loss_asr_routing tests/collections/audio/test_audio_losses.py::TestAudioLosses::test_maxine_combined_loss -v
# production reverted to main, test file unchanged:
FAILED ...test_maxine_combined_loss_asr_routing - AssertionError: asr_loss's `predicted_audio` argument must receive the model estimate, not the target signal
FAILED ...test_maxine_combined_loss - assert False (1.9749ish != 1.9083 golden)
2 failed, 41 warnings in 39.74s

# with the fix applied:
2 passed, 41 warnings in ...s
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

Trusted PRs run automatically through copy-pr-bot. For an untrusted PR, a maintainer can trigger CI by
commenting `/ok to test <head-sha>`; repeat this after a new push if the PR remains untrusted.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md) contains
specific people who can review PRs to various areas.

# Additional Information

- Fixes #16168

Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>
