### PR TITLE
fix(asr): keep the batch dimension in verify_speakers_batch for a single pair

### DIFF
--- a/nemo/collections/asr/models/label_models.py
+++ b/nemo/collections/asr/models/label_models.py
@@ -765,8 +765,14 @@ class EncDecSpeakerLabelModel(ModelPT, ExportableEncDecModel, VerificationMixin)
         X = embs1.unsqueeze(dim=1)
         Y = embs2.unsqueeze(dim=2)
         # Score
-        similarity_scores = torch.matmul(X, Y).squeeze() / (
-            (torch.matmul(X, X.permute(0, 2, 1)).squeeze() * torch.matmul(Y.permute(0, 2, 1), Y).squeeze()) ** 0.5
+        # NOTE: squeeze only the trailing two singleton dims (not a bare .squeeze()), so a batch of
+        # exactly one pair keeps its batch dimension instead of collapsing to a 0-d scalar.
+        similarity_scores = torch.matmul(X, Y).squeeze(-1).squeeze(-1) / (
+            (
+                torch.matmul(X, X.permute(0, 2, 1)).squeeze(-1).squeeze(-1)
+                * torch.matmul(Y.permute(0, 2, 1), Y).squeeze(-1).squeeze(-1)
+            )
+            ** 0.5
         )
         similarity_scores = (similarity_scores + 1) / 2
 

--- a/tests/collections/speaker_tasks/test_verify_speakers_batch.py
+++ b/tests/collections/speaker_tasks/test_verify_speakers_batch.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+from nemo.collections.asr.models.label_models import EncDecSpeakerLabelModel
+
+
+class _FakeSpeakerModel:
+    """Stands in for an EncDecSpeakerLabelModel: only implements what verify_speakers_batch calls."""
+
+    def __init__(self, embeddings1, embeddings2):
+        self._embeddings1 = embeddings1
+        self._embeddings2 = embeddings2
+        self._batch_inference_calls = 0
+
+    def path2audio_files_to_manifest(self, audio_files, manifest_filepath):
+        # verify_speakers_batch only needs this to not raise; batch_inference below is stubbed
+        # to ignore the manifest file entirely, so no manifest content is required.
+        with open(manifest_filepath, 'w'):
+            pass
+
+    def batch_inference(self, manifest_filepath, batch_size, sample_rate, device):
+        self._batch_inference_calls += 1
+        embs = self._embeddings1 if self._batch_inference_calls == 1 else self._embeddings2
+        return embs, None, None, None
+
+
+@pytest.mark.unit
+def test_verify_speakers_batch_single_pair_returns_indexable_array():
+    """A single-pair batch must return a length-1 array, matching verify_speakers_batch's own
+    documented per-pair 'True/False' contract -- not a 0-d scalar that cannot be indexed or iterated."""
+    same_speaker_embedding = np.array([[1.0, 0.0, 0.0, 0.0]], dtype=np.float32)
+    fake_model = _FakeSpeakerModel(same_speaker_embedding, same_speaker_embedding)
+
+    decision = EncDecSpeakerLabelModel.verify_speakers_batch(
+        fake_model,
+        [("audio_a.wav", "audio_b.wav")],
+        threshold=0.5,
+        batch_size=1,
+        sample_rate=16000,
+        device='cpu',
+    )
+
+    assert decision.shape == (1,), f"expected a length-1 array, got shape {decision.shape}"
+    # A 0-d array raises on both of these -- this is the user-visible symptom.
+    assert decision[0] == True  # noqa: E712
+    assert list(decision) == [True]
+
+
+@pytest.mark.unit
+def test_verify_speakers_batch_multi_pair_unaffected():
+    """The fix must not change results for batches of more than one pair."""
+    same = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32)
+    different = np.array([0.0, 1.0, 0.0, 0.0], dtype=np.float32)
+    embs1 = np.stack([same, same, same])
+    embs2 = np.stack([same, different, same])
+    fake_model = _FakeSpeakerModel(embs1, embs2)
+
+    decision = EncDecSpeakerLabelModel.verify_speakers_batch(
+        fake_model,
+        [("a0", "b0"), ("a1", "b1"), ("a2", "b2")],
+        threshold=0.7,
+        batch_size=3,
+        sample_rate=16000,
+        device='cpu',
+    )
+
+    assert decision.shape == (3,)
+    assert list(decision) == [True, False, True]


### PR DESCRIPTION
# What does this PR do ?

Keeps the batch dimension in `EncDecSpeakerLabelModel.verify_speakers_batch` when the batch has exactly
one pair, instead of collapsing the result to an unindexable 0-d array.

**Collection**: [ASR]

# Changelog

- `label_models.py`: `verify_speakers_batch` replaces three bare `.squeeze()` calls on `(B,1,1)`-shaped
  matmul outputs with `.squeeze(-1).squeeze(-1)`, removing only the two trailing singleton dims. A bare
  `.squeeze()` also removes the batch dim when `B == 1`, collapsing the result to a 0-d scalar for that
  one batch size only; `B > 1` was already correct.
- New `tests/collections/speaker_tasks/test_verify_speakers_batch.py`: one test drives a single-pair
  batch and asserts the result has shape `(1,)` and can be indexed/iterated; a second drives a
  three-pair batch to confirm the fix changes nothing for `B > 1`.

# Usage

```python
decision = model.verify_speakers_batch([("a.wav", "b.wav")], threshold=0.7)
decision[0]        # previously: IndexError: too many indices for array: array is 0-dimensional
list(decision)     # previously: TypeError: iteration over a 0-d array
```

Negative control — `label_models.py` reverted to `main`, same new tests:

```
FAILED test_verify_speakers_batch_single_pair_returns_indexable_array - AssertionError: expected a length-1 array, got shape ()
1 failed, 1 passed
```

The multi-pair test passing on unpatched `main` is the asymmetry proof: only the single-pair case is
broken. With the fix: `2 passed`. Full `tests/collections/speaker_tasks/` suite: 874 passed (872
pre-existing + these 2), no new failures.

# GitHub Actions CI

Requires a maintainer `/ok to test <head-sha>`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

# Additional Information

- Related to #16172

Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>
