### PR TITLE
[TTS] Add audio masking to EasyMagpie

### DIFF
--- a/nemo/collections/tts/models/easy_magpietts.py
+++ b/nemo/collections/tts/models/easy_magpietts.py
@@ -127,6 +127,11 @@ class EasyMagpieTTSModel(EasyMagpieTTSInferenceModel):
 
         self.cross_entropy_loss = nn.CrossEntropyLoss(reduction='none')
 
+        if 'feature_masking' in cfg:
+            self.feature_masking = safe_instantiate(cfg.feature_masking)
+        else:
+            self.feature_masking = None
+
         # Validation inference with metrics (optional)
         self.run_val_inference = cfg.get('run_val_inference', False)
         self.use_multilingual_asr = cfg.get('use_multilingual_asr', False)
@@ -624,6 +629,7 @@ class EasyMagpieTTSModel(EasyMagpieTTSInferenceModel):
         delay: torch.Tensor,
         speech_eos_mask: Optional[torch.Tensor] = None,
         agent_mask: Optional[torch.Tensor] = None,
+        dropout_audio_conditioning: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
         """Prepare the delayed autoregressive audio channel and its targets.
 
@@ -646,6 +652,8 @@ class EasyMagpieTTSModel(EasyMagpieTTSInferenceModel):
                 aligned to the autoregressive target timeline and may be used both
                 for loss masking and for replacing user regions with dedicated
                 user-speech tokens.
+            dropout_audio_conditioning: Whether dropout should be applied to input audio embeddings.
+                Should only be done during training when text is not masked for CFG.
 
         Returns:
             A tuple containing:
@@ -826,6 +834,11 @@ class EasyMagpieTTSModel(EasyMagpieTTSInferenceModel):
             embeddings=[zero_delay_tensor, audio_embedded],
             lengths=[delay, audio_codes_lens_target],
         )
+
+        if dropout_audio_conditioning:
+            audio_channel_embedding = self.feature_masking.apply_dropout(
+                inputs=audio_channel_embedding, input_len=audio_channel_lens
+            )
 
         return (
             audio_channel_embedding,
@@ -1025,6 +1038,9 @@ class EasyMagpieTTSModel(EasyMagpieTTSInferenceModel):
             )
 
         # 5. Prepare audio channel embeddings
+        dropout_audio_conditioning = (
+            (self.feature_masking is not None) and self.training and (not dropout_conditional_input)
+        )
         (
             audio_channel_embedding,
             audio_channel_lens,
@@ -1037,6 +1053,7 @@ class EasyMagpieTTSModel(EasyMagpieTTSInferenceModel):
             delay=audio_delay,
             speech_eos_mask=speech_eos_mask,
             agent_mask=agent_mask,
+            dropout_audio_conditioning=dropout_audio_conditioning,
         )
 
         # 6. Sum the channel embeddings element-wise
@@ -1212,8 +1229,14 @@ class EasyMagpieTTSModel(EasyMagpieTTSInferenceModel):
         local_transformer_logits = None
         if self.local_transformer_type != LocalTransformerType.NO_LT:
             assert self.local_transformer_type == LocalTransformerType.AR, "Unexpected local transformer type"
+
+            if dropout_audio_conditioning:
+                lt_masking = self.feature_masking
+            else:
+                lt_masking = None
+
             local_transformer_logits = self._lt_helper.compute_logits(
-                pred_embeddings, audio_codes_target, targets_offset_by_one=False
+                pred_embeddings, audio_codes_target, targets_offset_by_one=False, feature_masking=lt_masking
             )
             local_transformer_loss, _ = self.compute_loss(
                 local_transformer_logits,

--- a/nemo/collections/tts/models/easy_magpietts.py
+++ b/nemo/collections/tts/models/easy_magpietts.py
@@ -1038,9 +1038,7 @@ class EasyMagpieTTSModel(EasyMagpieTTSInferenceModel):
             )
 
         # 5. Prepare audio channel embeddings
-        dropout_audio_conditioning = (
-            (self.feature_masking is not None) and self.training and (not dropout_conditional_input)
-        )
+        dropout_audio_conditioning = (self.feature_masking is not None) and (not dropout_conditional_input)
         (
             audio_channel_embedding,
             audio_channel_lens,

--- a/nemo/collections/tts/modules/magpietts_modules.py
+++ b/nemo/collections/tts/modules/magpietts_modules.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Optional
 
 import numpy as np
 import torch
+from einops import rearrange
 from torch import Tensor
 from torch.utils.data import get_worker_info
 
@@ -480,7 +481,7 @@ class LocalTransformerHelper:
         codes_with_mask = torch.where(mask, self.mask_token_id, codes)
         return codes_with_mask, mask
 
-    def compute_logits(self, dec_out, audio_codes_target, targets_offset_by_one=False):
+    def compute_logits(self, dec_out, audio_codes_target, targets_offset_by_one=False, feature_masking=None):
         """Predicts the logits for all codebooks using the local transformer.
 
         Used in both autoregressive (AR) and MaskGit (MG) modes during
@@ -507,8 +508,7 @@ class LocalTransformerHelper:
                 if True, target for index 1 is codebook 0 (MaskGit).
         """
         C = self.num_audio_codebooks
-        dec_out_all = dec_out.reshape(-1, dec_out.size(-1))  # (B*T', E)
-        local_transformer_input = [dec_out_all]
+        local_transformer_input = []
         audio_codes_target = pad_audio_codes(audio_codes_target, self.frame_stacking_factor).long()
         for fs_index in range(self.frame_stacking_factor):
             for codebook_num in range(C):
@@ -519,6 +519,18 @@ class LocalTransformerHelper:
                 local_transformer_input.append(codebook_embedding)
 
         local_transformer_input = torch.stack(local_transformer_input, dim=1)
+
+        if feature_masking is not None:
+            lt_batch_size = local_transformer_input.shape[0]
+            lt_num_codebook = local_transformer_input.shape[1]
+            input_len = lt_num_codebook * torch.ones([lt_batch_size], device=local_transformer_input.device)
+            local_transformer_input = feature_masking.apply_dropout(
+                inputs=local_transformer_input, input_len=input_len
+            )
+
+        dec_out_all = dec_out.reshape(-1, 1, dec_out.size(-1))  # (B*T', 1, E)
+        local_transformer_input = torch.cat([dec_out_all, local_transformer_input], dim=1)
+
         local_transformer_input = self.local_transformer_in_projection(local_transformer_input)
         _mask = torch.ones(
             local_transformer_input.size(0), local_transformer_input.size(1), device=local_transformer_input.device
@@ -785,3 +797,77 @@ class LocalTransformerHelper:
         if use_cfg:
             codes = codes[:actual_batch_size]
         return codes
+
+
+class FeatureMasking(NeuralModule):
+    """Randomly dropout ground truth features by replacing feature embeddings with a mask embeddings
+
+    Features are dropped out based on a beta distribution. For example, the default parameters
+    (min=0.0, max=0.75, alpha=2.0, beta=1.0) means each item in a training batch will mask between 0% and 75% of
+    its input, with an average of 45%.
+
+    (min=0.1, max=0.5, alpha=1.0, beta=1.0) would be a uniform distribution masking between 10% and 50% of its input.
+
+    Args:
+        hidden_size: Dimension of model hidden state
+        mask_min: Minimum fraction of timesteps to mask for each batch item.
+        mask_max: Maximum fraction of timesteps to mask for each batch item.
+        alpha: alpha value of beta distribution
+        beta: beta value of beta distribution
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        mask_min: float = 0.0,
+        mask_max: float = 0.75,
+        alpha: float = 2.0,
+        beta: float = 1.0,
+    ):
+        super().__init__()
+        self.masked_emb = torch.nn.Parameter(torch.zeros([1, 1, hidden_size]))
+        self.mask_min = mask_min
+        self.mask_max = mask_max
+        self.dist = torch.distributions.beta.Beta(concentration1=alpha, concentration0=beta)
+
+    def _create_dropout_mask(self, input_len):
+        batch_size = input_len.shape[0]
+        len_mask = get_mask_from_lengths(input_len)
+        max_len = len_mask.shape[1]
+
+        # Select a fraction of tokens to mask in the range [min, max]
+        mask_percent = self.dist.sample(sample_shape=torch.Size([batch_size])).to(input_len.device)
+        mask_percent = self.mask_min + (self.mask_max - self.mask_min) * mask_percent
+        mask_len = mask_percent * input_len.float()
+        # Determine how many values will be masked based on the item length
+        mask_rank = torch.clamp_min(mask_len - 1, 0).long()
+        mask_rank = rearrange(mask_rank, 'B -> B 1')
+
+        # [batch_size, time]
+        mask_vals = torch.rand(size=len_mask.shape, device=input_len.device)
+        mask_vals = mask_vals * len_mask
+        # Select top 'mask_rank' values to be output as the final mask
+        mask_topk = torch.topk(mask_vals, k=max_len, dim=1, sorted=True).values
+        mask_min_val = torch.gather(mask_topk, index=mask_rank, dim=1)
+        mask = mask_vals >= mask_min_val
+
+        # Set values outside the batch item length back to false
+        mask = mask * len_mask
+
+        return mask
+
+    def forward(self, inputs, mask):
+        """
+        The input mask specifies which ground truth values to mask.
+
+        At training time the mask should be randomly generated. At inference, this method can be given a custom
+        mask, signaling the model to predict all timesteps where the mask embedding is provided.
+        """
+        mask = rearrange(mask, 'B T -> B T 1')
+        out = torch.where(mask, self.masked_emb, inputs)
+        return out
+
+    def apply_dropout(self, inputs, input_len):
+        mask = self._create_dropout_mask(input_len=input_len)
+        out = self.forward(inputs=inputs, mask=mask)
+        return out

--- a/nemo/collections/tts/modules/magpietts_modules.py
+++ b/nemo/collections/tts/modules/magpietts_modules.py
@@ -856,7 +856,15 @@ class FeatureMasking(NeuralModule):
 
         return mask
 
-    def forward(self, inputs, mask):
+    def forward(self, inputs, input_len):
+        if not self.training:
+            return inputs
+
+        mask = self._create_dropout_mask(input_len=input_len)
+        out = self.infer(inputs=inputs, mask=mask)
+        return out
+
+    def infer(self, inputs, mask):
         """
         The input mask specifies which ground truth values to mask.
 
@@ -865,9 +873,4 @@ class FeatureMasking(NeuralModule):
         """
         mask = rearrange(mask, 'B T -> B T 1')
         out = torch.where(mask, self.masked_emb, inputs)
-        return out
-
-    def apply_dropout(self, inputs, input_len):
-        mask = self._create_dropout_mask(input_len=input_len)
-        out = self.forward(inputs=inputs, mask=mask)
         return out

--- a/tests/collections/tts/modules/test_magpietts_modules.py
+++ b/tests/collections/tts/modules/test_magpietts_modules.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from nemo.collections.tts.modules.magpietts_modules import FeatureMasking
+
+
+def _set_seed():
+    torch.manual_seed(42)
+
+
+class TestFeatureMasking:
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize('batch_size', [2, 5])
+    @pytest.mark.parametrize('time', [5, 10])
+    @pytest.mark.parametrize('hidden_size', [128, 256])
+    def test_feature_masking_infer(self, batch_size, time, hidden_size):
+        _set_seed()
+        feature_masking = FeatureMasking(hidden_size=hidden_size)
+        masked_emb = feature_masking.masked_emb[0, 0]
+        inputs = torch.randn(size=(batch_size, time, hidden_size), dtype=torch.float32)
+        mask = torch.randint(low=0, high=2, size=(batch_size, time), dtype=torch.bool)
+        masked_tensor = feature_masking.infer(inputs=inputs, mask=mask)
+        for i in range(batch_size):
+            for j in range(time):
+                output_val = masked_tensor[i, j]
+                if mask[i, j]:
+                    torch.testing.assert_close(actual=output_val, expected=masked_emb)
+                else:
+                    torch.testing.assert_close(actual=output_val, expected=inputs[i, j])

--- a/tests/collections/tts/modules/test_magpietts_modules.py
+++ b/tests/collections/tts/modules/test_magpietts_modules.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
# What does this PR do ?

Add an optional config to randomly dropout autoregressive information supplied to EasyMagpie backbone and local transformer.

**Collection**: [TTS]

# Usage

Add this to the easy magpie model config

```
  feature_masking:
    _target_: nemo.collections.tts.modules.magpietts_modules.FeatureMasking
    hidden_size: 1536
```

**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
