### PR TITLE
fix(speechlm2): stop a silent batch row from disabling loudness norm for other rows

### DIFF
--- a/nemo/collections/speechlm2/parts/augmentation.py
+++ b/nemo/collections/speechlm2/parts/augmentation.py
@@ -171,15 +171,18 @@ class AudioAugmenter:
 
             audio_cpu = batch_audio[i, :audio_length].cpu().numpy()
 
-            if use_loudness_norm and PYLOUDNORM_AVAILABLE:
+            # Per-row flag: whether a silent/invalid row disabled loudness
+            # normalization must not leak into the next row's iteration.
+            row_use_loudness_norm = use_loudness_norm
+            if row_use_loudness_norm and PYLOUDNORM_AVAILABLE:
                 meter = pyln.Meter(self.sample_rate)
                 try:
                     speech_loudness = meter.integrated_loudness(audio_cpu)
                     # Check for invalid loudness values (-inf for silent audio)
                     if speech_loudness == float('-inf') or not np.isfinite(speech_loudness):
-                        use_loudness_norm = False
+                        row_use_loudness_norm = False
                 except Exception:
-                    use_loudness_norm = False
+                    row_use_loudness_norm = False
 
             convolved = fftconvolve(audio_cpu, ir, mode="full")[:audio_length]
 
@@ -187,7 +190,7 @@ class AudioAugmenter:
             input_rms = np.sqrt(np.mean(audio_cpu**2)) + 1e-8
             convolved_rms = np.sqrt(np.mean(convolved**2)) + 1e-8
 
-            if use_loudness_norm and PYLOUDNORM_AVAILABLE:
+            if row_use_loudness_norm and PYLOUDNORM_AVAILABLE:
                 try:
                     convolved_loudness = meter.integrated_loudness(convolved)
                     # Check for invalid loudness values
@@ -255,15 +258,18 @@ class AudioAugmenter:
 
             audio_cpu = batch_audio[i, :audio_length].cpu().numpy()
 
-            if use_loudness_norm and PYLOUDNORM_AVAILABLE:
+            # Per-row flag: whether a silent/invalid row disabled loudness
+            # normalization must not leak into the next row's iteration.
+            row_use_loudness_norm = use_loudness_norm
+            if row_use_loudness_norm and PYLOUDNORM_AVAILABLE:
                 meter = pyln.Meter(self.sample_rate)
                 try:
                     speech_loudness = meter.integrated_loudness(audio_cpu)
                     # Check for invalid loudness values (-inf for silent audio)
                     if speech_loudness == float('-inf') or not np.isfinite(speech_loudness):
-                        use_loudness_norm = False
+                        row_use_loudness_norm = False
                 except Exception:
-                    use_loudness_norm = False
+                    row_use_loudness_norm = False
 
             convolved = fftconvolve(audio_cpu, ir, mode="full")[:audio_length]
 
@@ -271,7 +277,7 @@ class AudioAugmenter:
             input_rms = np.sqrt(np.mean(audio_cpu**2)) + 1e-8
             convolved_rms = np.sqrt(np.mean(convolved**2)) + 1e-8
 
-            if use_loudness_norm and PYLOUDNORM_AVAILABLE:
+            if row_use_loudness_norm and PYLOUDNORM_AVAILABLE:
                 try:
                     convolved_loudness = meter.integrated_loudness(convolved)
                     # Check for invalid loudness values

--- a/tests/collections/speechlm2/test_augmentation.py
+++ b/tests/collections/speechlm2/test_augmentation.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import types
+
+import numpy as np
+import pytest
+import soundfile as sf
+import torch
+
+from nemo.collections.speechlm2.parts import augmentation as aug_module
+from nemo.collections.speechlm2.parts.augmentation import AudioAugmenter
+
+SR = 16000
+
+
+class _FakeMeter:
+    """Stand-in for ``pyloudnorm.Meter`` with fully deterministic loudness values.
+
+    Any all-(near-)zero signal is reported as ``-inf`` loudness (matching real
+    pyloudnorm's behaviour for silent audio); everything else gets a fixed,
+    finite value so the test does not depend on the real algorithm.
+    """
+
+    def __init__(self, sample_rate):
+        self.sample_rate = sample_rate
+
+    def integrated_loudness(self, data):
+        if float(np.sqrt(np.mean(np.asarray(data, dtype=np.float64) ** 2))) < 1e-9:
+            return float("-inf")
+        return -20.0
+
+
+def _fake_normalize_loudness(data, input_loudness, target_loudness):
+    # Distinctive, easy-to-detect transform: flip sign and scale by 3.
+    return data * -3.0
+
+
+@pytest.fixture
+def fake_pyloudnorm(monkeypatch):
+    """Force the loudness-normalization branch to be live and deterministic,
+    without requiring the real (optional) ``pyloudnorm`` package."""
+    fake_pyln = types.SimpleNamespace(
+        Meter=_FakeMeter,
+        normalize=types.SimpleNamespace(loudness=_fake_normalize_loudness),
+    )
+    monkeypatch.setattr(aug_module, "pyln", fake_pyln)
+    monkeypatch.setattr(aug_module, "PYLOUDNORM_AVAILABLE", True)
+    return fake_pyln
+
+
+@pytest.fixture
+def roomir_folder(tmp_path):
+    # A near-identity impulse response is enough to exercise the convolution path.
+    ir = np.zeros(64, dtype=np.float32)
+    ir[0] = 1.0
+    path = tmp_path / "roomir"
+    path.mkdir()
+    sf.write(os.path.join(path, "ir.wav"), ir, SR)
+    return str(path)
+
+
+def _make_batch(*, leading_silence: bool) -> torch.Tensor:
+    t = torch.arange(SR, dtype=torch.float32) / SR
+    row1 = 0.5 * torch.sin(2 * torch.pi * 440 * t)
+    row2 = 0.2 * torch.sin(2 * torch.pi * 220 * t)
+    if leading_silence:
+        row0 = torch.zeros(SR, dtype=torch.float32)
+    else:
+        row0 = 0.3 * torch.sin(2 * torch.pi * 330 * t)
+    return torch.stack([row0, row1, row2], dim=0)
+
+
+@pytest.mark.unit
+def test_room_ir_loudness_norm_does_not_leak_across_batch_rows(fake_pyloudnorm, roomir_folder):
+    """A silent row must not disable loudness normalization for the OTHER rows
+    in the same batch.
+
+    Regression test for a state leak in ``add_room_ir_to_batch``: the
+    ``use_loudness_norm`` function parameter was reassigned to ``False``
+    in-place whenever one row's loudness was ``-inf`` (silent audio), and
+    that reassignment then applied to every subsequent row in the loop
+    because the loop reused the parameter itself instead of a per-row local.
+    """
+    augmenter = AudioAugmenter(sample_rate=SR)
+    audio_lens = torch.tensor([SR, SR, SR])
+
+    calls = {"n": 0}
+    real_normalize = aug_module.pyln.normalize.loudness
+
+    def counting_normalize(data, input_loudness, target_loudness):
+        calls["n"] += 1
+        return real_normalize(data, input_loudness, target_loudness)
+
+    aug_module.pyln.normalize.loudness = counting_normalize
+
+    batch = _make_batch(leading_silence=True)
+    augmenter.add_room_ir_to_batch(batch.clone(), audio_lens, roomir_folder, use_loudness_norm=True)
+
+    # Row 0 is silent, so it correctly skips loudness normalization (1 skip).
+    # Rows 1 and 2 are normal, non-silent audio and MUST still be
+    # loudness-normalized: exactly 2 calls expected.
+    assert calls["n"] == 2, (
+        f"expected loudness normalization to run for the 2 non-silent rows, got {calls['n']} calls "
+        "-- a silent row elsewhere in the batch must not disable it for the others"
+    )
+
+
+@pytest.mark.unit
+def test_mic_ir_loudness_norm_does_not_leak_across_batch_rows(fake_pyloudnorm, roomir_folder):
+    """Same defect, same fix, in the ``add_mic_ir_to_batch`` sibling."""
+    augmenter = AudioAugmenter(sample_rate=SR)
+    audio_lens = torch.tensor([SR, SR, SR])
+
+    calls = {"n": 0}
+    real_normalize = aug_module.pyln.normalize.loudness
+
+    def counting_normalize(data, input_loudness, target_loudness):
+        calls["n"] += 1
+        return real_normalize(data, input_loudness, target_loudness)
+
+    aug_module.pyln.normalize.loudness = counting_normalize
+
+    batch = _make_batch(leading_silence=True)
+    augmenter.add_mic_ir_to_batch(batch.clone(), audio_lens, roomir_folder, use_loudness_norm=True)
+
+    assert calls["n"] == 2, (
+        f"expected loudness normalization to run for the 2 non-silent rows, got {calls['n']} calls "
+        "-- a silent row elsewhere in the batch must not disable it for the others"
+    )


### PR DESCRIPTION
# What does this PR do ?

Fixes a state leak in `AudioAugmenter.add_room_ir_to_batch`/`add_mic_ir_to_batch` where one silent row in a batch silently disables LUFS loudness normalization for every subsequent row in that same batch.

**Collection**: [speechlm2]

# Changelog

- `nemo/collections/speechlm2/parts/augmentation.py`: both `add_room_ir_to_batch` (:174-182) and `add_mic_ir_to_batch` (:258-266) reassigned the `use_loudness_norm` function parameter directly inside the per-row loop whenever a row's loudness reading was invalid, so the disablement leaked into every following row instead of applying only to the row that triggered it. Introduced a per-row local (`row_use_loudness_norm`), re-initialized from the parameter at the top of each iteration, and used it for the rest of that row's branching.
- `tests/collections/speechlm2/test_augmentation.py`: new `test_room_ir_loudness_norm_does_not_leak_across_batch_rows` and `test_mic_ir_loudness_norm_does_not_leak_across_batch_rows`, each building a 3-row batch with a leading silent row and asserting loudness normalization still runs for the 2 non-silent rows after it. Uses a monkeypatched deterministic stand-in for the optional `pyloudnorm` dependency so the test does not require it to be installed.

# Usage

```python
import torch
from nemo.collections.speechlm2.parts.augmentation import AudioAugmenter

sr = 16000
t = torch.arange(sr, dtype=torch.float32) / sr
batch = torch.stack([
    torch.zeros(sr),                          # row 0: silent
    0.5 * torch.sin(2 * torch.pi * 440 * t),  # row 1: normal
])
lens = torch.tensor([sr, sr])
AudioAugmenter(sample_rate=sr).add_room_ir_to_batch(batch, lens, "<roomir_dir>", use_loudness_norm=True)
```

On `main` (`fe43df3eb9`), row 0 correctly skips loudness normalization, but row 1 is silently downgraded to RMS-only gain compensation too — with a deterministic test meter, the count of `pyln.normalize.loudness(...)` calls across a 3-row batch (1 silent + 2 normal) is `0`, not the expected `2`. With this PR, the normal rows are still loudness-normalized regardless of an earlier row's silence.

Negative control: `augmentation.py` reverted to `main`, only the two new tests added — both fail (`0` calls observed, not `2`): **2 failed**. With the fix: **2 passed**.

`augmentation.py` has had exactly one commit touching this construct since it was introduced (#15092); no test exercised either function before this PR.

# GitHub Actions CI

Requires a maintainer `/ok to test <head-sha>`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.

# Additional Information

Fixes #16180

Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>
