### PR TITLE
fix(common): respect enable_stop in IPLEpochStopper

### DIFF
--- a/nemo/collections/common/callbacks/ipl_epoch_stopper.py
+++ b/nemo/collections/common/callbacks/ipl_epoch_stopper.py
@@ -47,7 +47,8 @@ class IPLEpochStopper(Callback):
         """
         Sets `should_stop` stop flag to terminate the training.
         """
-        super().__init__()
+        if not self.enable_stop:
+            return
 
         if self.stop_every_n_epochs != 0:
             self.stop_every_n_epochs -= 1

--- a/tests/collections/common/test_ipl_epoch_stopper.py
+++ b/tests/collections/common/test_ipl_epoch_stopper.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from types import SimpleNamespace
+
+import pytest
+
+from nemo.collections.common.callbacks.ipl_epoch_stopper import IPLEpochStopper
+
+
+class TestIPLEpochStopper:
+    @pytest.mark.unit
+    def test_enable_stop_false_is_inert(self):
+        # Docstring contract: "If False, the callback is inert."
+        callback = IPLEpochStopper(enable_stop=False, stop_every_n_epochs=1)
+        trainer = SimpleNamespace(should_stop=False)
+
+        callback.on_train_epoch_end(trainer, None)
+
+        assert trainer.should_stop is False
+
+    @pytest.mark.unit
+    def test_enable_stop_true_requests_stop_after_n_epochs(self):
+        callback = IPLEpochStopper(enable_stop=True, stop_every_n_epochs=2)
+        trainer = SimpleNamespace(should_stop=False)
+
+        callback.on_train_epoch_end(trainer, None)
+        assert trainer.should_stop is False
+
+        callback.on_train_epoch_end(trainer, None)
+        assert trainer.should_stop is True


### PR DESCRIPTION
# What does this PR do ?

Makes `IPLEpochStopper.on_train_epoch_end` respect `enable_stop`, so `enable_stop=False` actually
leaves the callback inert as its own docstring promises.

**Collection**: [common]

# Changelog

- `ipl_epoch_stopper.py`: `on_train_epoch_end` now returns immediately when `self.enable_stop` is
  `False`, instead of unconditionally decrementing `stop_every_n_epochs` and requesting a stop once it
  reaches `0`. Also drops the stray `on_train_epoch_end`-local `super().__init__()` call it replaces —
  `Callback` defines no `__init__` of its own (it resolves to `object.__init__`), so the call was a
  no-op that reset no state.
- New `tests/collections/common/test_ipl_epoch_stopper.py`: `test_enable_stop_false_is_inert` asserts
  `trainer.should_stop` stays `False` after `on_train_epoch_end` when `enable_stop=False`;
  `test_enable_stop_true_requests_stop_after_n_epochs` checks the existing (correct) `enable_stop=True`
  countdown behaviour is unaffected.

# Usage

```python
from types import SimpleNamespace
from nemo.collections.common.callbacks.ipl_epoch_stopper import IPLEpochStopper

callback = IPLEpochStopper(enable_stop=False, stop_every_n_epochs=1)
trainer = SimpleNamespace(should_stop=False)
callback.on_train_epoch_end(trainer, None)
print(trainer.should_stop)  # now stays False
```

Negative control — `ipl_epoch_stopper.py` reverted to `main`, same tests kept:

```
FAILED tests/collections/common/test_ipl_epoch_stopper.py::TestIPLEpochStopper::test_enable_stop_false_is_inert - assert True is False
1 failed, 1 passed, 1 warning in 0.40s
```

With the fix: `2 passed, 1 warning in 0.08s`.

`git log -S` on the file shows a single commit ever, #13671 ("IPL callback and two scripts") — the bug
has been present, and untested, since the callback was introduced; no test anywhere pinned the current
"always stops" behaviour as intentional.

# GitHub Actions CI

Requires a maintainer `/ok to test <head-sha>`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

# Additional Information

- Related to #16182

Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>
