### PR TITLE
[draft]fix(speechlm2): load activation-checkpointed HF weights

### DIFF
--- a/docs/source/speechlm2/intro.rst
+++ b/docs/source/speechlm2/intro.rst
@@ -122,6 +122,14 @@ using MoE-specific optimizations (Grouped GEMM, DeepEP). It uses deferred initia
             audio_lens=audio_len,
         )
 
+Distributed checkpoint loading canonicalizes activation-checkpoint wrapper names before matching
+model tensors. With the default ``strict=False``, small compatibility gaps produce a warning, while
+global or per-top-level-component parameter coverage below 90% raises ``RuntimeError``.
+Pass ``strict=True`` to ``from_pretrained`` to additionally reject any missing parameter, missing
+persistent buffer, or unused checkpoint tensor. When a checkpoint stores multiple aliases for a tied tensor,
+one alias is loaded and the others are recognized with a warning rather than treated as unused. TransformerEngine
+``*_extra_state`` tensors have no direct load destination and are ignored with a warning in either mode.
+
 DuplexS2SModel
 **************
 

--- a/nemo/collections/speechlm2/parts/hf_hub.py
+++ b/nemo/collections/speechlm2/parts/hf_hub.py
@@ -21,6 +21,10 @@ from transformers.utils import cached_file
 
 SAFETENSORS_SINGLE_FILE = "model.safetensors"
 LLM_BACKBONE_DIR = "llm_backbone"
+# Distributed loading defaults to ``strict=False``. Allow small forward-
+# compatible gaps, but reject checkpoints that would leave a substantial
+# fraction of the model randomly initialized.
+_MIN_CHECKPOINT_PARAMETER_COVERAGE = 0.9
 
 
 class HFHubMixin(
@@ -59,6 +63,11 @@ class HFHubMixin(
         taken from the caller and overwrites any value stored in the downloaded
         checkpoint config so that a model repository cannot opt itself into
         executing remote code.
+
+        When ``strict=True``, distributed loading rejects missing model state
+        and unused checkpoint tensors. The default ``strict=False`` permits
+        small compatibility gaps with warnings, while still rejecting
+        catastrophic parameter mismatches.
         """
         if not isinstance(trust_remote_code, bool):
             raise TypeError(f"trust_remote_code must be a bool, got {type(trust_remote_code).__name__}")
@@ -123,6 +132,7 @@ class HFHubMixin(
             model_id=model_id,
             model_kwargs=model_kwargs,
             torch_dtype=torch_dtype,
+            strict=strict,
             distributed_setup=distributed_setup,
             cached_file_kwargs=_cached_file_kwargs,
         )
@@ -185,6 +195,7 @@ def _distributed_from_pretrained(
     model_id,
     model_kwargs,
     torch_dtype,
+    strict,
     distributed_setup,
     cached_file_kwargs,
 ):
@@ -212,42 +223,40 @@ def _distributed_from_pretrained(
     weight_file = cached_file(model_id, SAFETENSORS_SINGLE_FILE, **cached_file_kwargs)
     if weight_file is None:
         raise RuntimeError(f"Missing {SAFETENSORS_SINGLE_FILE} file for {model_id=}")
-    _load_state_dict_with_dtensors(instance, str(Path(weight_file).parent))
+    _load_state_dict_with_dtensors(instance, str(Path(weight_file).parent), strict=strict)
 
     return instance
 
 
-def _load_state_dict_with_dtensors(model, weight_dir):
+def _load_state_dict_with_dtensors(model, weight_dir, strict=False):
     """Load safetensors weights into a model with DTensor parameters using DCP.
 
     Uses ``torch.distributed.checkpoint`` with ``_HuggingFaceStorageReader``
     to load weights directly into model parameters in-place.  This mirrors
-    the loading path used by ``NeMoAutoModelForCausalLM``.
+    the loading path used by ``NeMoAutoModelForCausalLM``. Model names are
+    canonicalized before matching, and catastrophic parameter-coverage gaps
+    are rejected before any checkpoint data is copied.
 
     Args:
         model: The model with DTensor parameters (after ``configure_model``).
         weight_dir: Directory containing ``.safetensors`` file(s).
+        strict: Whether to reject every missing model tensor or unused
+            checkpoint tensor.
     """
-    from itertools import chain
-
     import torch.distributed.checkpoint as dcp
     from nemo_automodel.components.checkpoint._backports.hf_storage import _HuggingFaceStorageReader
 
-    # Build state dict from named_parameters/named_buffers.
-    # This avoids FSDP2 state-dict hooks that model.state_dict() triggers.
-    # DCP will write directly into these tensors in-place.
-    all_params = dict(chain(model.named_parameters(), model.named_buffers()))
-
     # DCP is strict by default — it errors on model keys missing from the
     # checkpoint (e.g. positional-encoding buffers computed at init).
-    # Read the checkpoint metadata first and keep only matching keys.
+    # Read the checkpoint metadata first and keep only matching model state.
     reader = _HuggingFaceStorageReader(path=weight_dir)
-    checkpoint_keys = reader.read_metadata().state_dict_metadata.keys()
-    state_dict = {k: v for k, v in all_params.items() if k in checkpoint_keys}
+    checkpoint_metadata = reader.read_metadata().state_dict_metadata
+    state_dict = _checkpoint_state_dict(model, checkpoint_metadata.keys(), strict=strict)
 
     # DCP + HF storage reader: parses safetensors header for byte offsets,
     # the planner narrows each tensor to the local DTensor shard,
     # and copies directly into model parameter storage.
+    # DefaultLoadPlanner rejects checkpoint/model shape mismatches before scheduling reads.
     dcp.load(state_dict, storage_reader=reader)
 
 
@@ -274,3 +283,152 @@ def _inject_local_artifact_paths(cfg: dict, model_id: str, cached_file_kwargs: d
         cfg["pretrained_llm"] = llm_backbone_path
     if "pretrained_lm_name" in cfg:
         cfg["pretrained_lm_name"] = llm_backbone_path
+
+
+def _checkpoint_state_dict(model, checkpoint_keys, strict=False):
+    """Map unique model tensors to stable checkpoint names and validate coverage."""
+    from nemo_automodel.shared.parameter_names import canonical_parameter_fqn
+
+    model_state = {}
+    state_groups = {}
+    parameter_group_ids = set()
+    parameter_groups_by_top_level = {}
+    persistent_buffer_group_ids = set()
+
+    def add_model_state(raw_name, value):
+        name = canonical_parameter_fqn(raw_name)
+        if name in model_state and model_state[name] is not value:
+            raise RuntimeError(f"Multiple model tensors map to checkpoint key {name!r}")
+        model_state[name] = value
+        group_id = id(value)
+        if group_id not in state_groups:
+            state_groups[group_id] = (value, [])
+        _, aliases = state_groups[group_id]
+        if name not in aliases:
+            aliases.append(name)
+        return name, group_id
+
+    # Safetensors keeps one state-dict name for tied parameters. Preserve every
+    # alias here so whichever name was saved can target the shared tensor.
+    for raw_name, value in model.named_parameters(remove_duplicate=False):
+        canonical_name, group_id = add_model_state(raw_name, value)
+        parameter_group_ids.add(group_id)
+        if "." in canonical_name:
+            top_level = canonical_name.partition(".")[0]
+            parameter_groups_by_top_level.setdefault(top_level, set()).add(group_id)
+
+    # Walk direct module buffers to preserve every alias while distinguishing
+    # persistent state from runtime-only buffers without invoking state_dict()
+    # and its FSDP2 hooks.
+    for module_name, module in model.named_modules(remove_duplicate=False):
+        for buffer_name, value in module._buffers.items():
+            if value is None:
+                continue
+            if buffer_name in module._non_persistent_buffers_set:
+                continue
+            raw_name = f"{module_name}.{buffer_name}" if module_name else buffer_name
+            _, group_id = add_model_state(raw_name, value)
+            persistent_buffer_group_ids.add(group_id)
+
+    checkpoint_keys = set(checkpoint_keys)
+    matched_parameters = []
+    missing_parameters = []
+    missing_persistent_buffers = []
+    matched_parameter_group_ids = set()
+    matched_checkpoint_keys = set()
+    duplicate_tied_alias_groups = []
+    state_dict = {}
+    for group_id, (value, aliases) in state_groups.items():
+        matched_aliases = [name for name in aliases if name in checkpoint_keys]
+        if matched_aliases:
+            # DCP should copy into each shared tensor only once, even when a
+            # checkpoint contains more than one tied alias.
+            matched_checkpoint_key = matched_aliases[0]
+            matched_checkpoint_keys.update(matched_aliases)
+            state_dict[matched_checkpoint_key] = value
+            if len(matched_aliases) > 1:
+                duplicate_tied_alias_groups.append(matched_aliases)
+
+        if group_id in parameter_group_ids:
+            if matched_aliases:
+                matched_parameters.append(value)
+                matched_parameter_group_ids.add(group_id)
+            else:
+                missing_parameters.append(aliases[0])
+        elif group_id in persistent_buffer_group_ids and not matched_aliases:
+            missing_persistent_buffers.append(aliases[0])
+
+    matched_numel = sum(value.numel() for value in matched_parameters)
+    model_numel = sum(state_groups[group_id][0].numel() for group_id in parameter_group_ids)
+    coverage = matched_numel / model_numel if model_numel else 1.0
+    undercovered_top_levels = []
+    for name, group_ids in parameter_groups_by_top_level.items():
+        component_numel = sum(state_groups[group_id][0].numel() for group_id in group_ids)
+        matched_component_numel = sum(
+            state_groups[group_id][0].numel() for group_id in group_ids & matched_parameter_group_ids
+        )
+        component_coverage = matched_component_numel / component_numel if component_numel else 1.0
+        if component_coverage < _MIN_CHECKPOINT_PARAMETER_COVERAGE:
+            undercovered_top_levels.append(
+                f"{name} ({component_coverage:.1%}, {matched_component_numel}/{component_numel})"
+            )
+    undercovered_top_levels.sort()
+    unmatched_checkpoint_keys = checkpoint_keys - matched_checkpoint_keys
+    ignored_extra_state_keys = sorted(key for key in unmatched_checkpoint_keys if key.endswith("_extra_state"))
+    unexpected_checkpoint_keys = sorted(key for key in unmatched_checkpoint_keys if not key.endswith("_extra_state"))
+
+    diagnostics = []
+    if missing_parameters:
+        diagnostics.append(
+            f"Safetensors checkpoint matched only {coverage:.1%} of model parameter elements "
+            f"({matched_numel}/{model_numel}); missing model parameters "
+            f"({len(missing_parameters)} groups, first 8): {sorted(missing_parameters)[:8]}"
+        )
+    if undercovered_top_levels:
+        diagnostics.append(
+            f"top-level model components below {_MIN_CHECKPOINT_PARAMETER_COVERAGE:.0%} parameter coverage "
+            f"(first 8): {undercovered_top_levels[:8]}"
+        )
+    if missing_persistent_buffers:
+        diagnostics.append(
+            f"missing persistent model buffers ({len(missing_persistent_buffers)}, first 8): "
+            f"{sorted(missing_persistent_buffers)[:8]}"
+        )
+    if unexpected_checkpoint_keys:
+        diagnostics.append(
+            f"unused checkpoint tensors ({len(unexpected_checkpoint_keys)}, first 8): "
+            f"{unexpected_checkpoint_keys[:8]}"
+        )
+
+    advisory_warnings = []
+    if ignored_extra_state_keys:
+        advisory_warnings.append(
+            f"Ignoring checkpoint extra-state tensors ({len(ignored_extra_state_keys)}, first 8): "
+            f"{ignored_extra_state_keys[:8]}. These tensors have no direct parameter or buffer load destination."
+        )
+    if duplicate_tied_alias_groups:
+        advisory_warnings.append(
+            f"Checkpoint stores multiple aliases for {len(duplicate_tied_alias_groups)} tied model tensors "
+            f"(first 8 groups): {duplicate_tied_alias_groups[:8]}. Each shared tensor is loaded once."
+        )
+
+    if advisory_warnings or diagnostics:
+        from nemo.utils import logging
+
+    if advisory_warnings:
+        for warning in advisory_warnings:
+            logging.warning(warning)
+
+    diagnostic_message = "; ".join(diagnostics)
+    if strict and diagnostics:
+        raise RuntimeError(f"Strict checkpoint loading failed: {diagnostic_message}")
+    if coverage < _MIN_CHECKPOINT_PARAMETER_COVERAGE or undercovered_top_levels:
+        raise RuntimeError(
+            f"Refusing to load checkpoint: global or per-top-level-component parameter coverage is below "
+            f"{_MIN_CHECKPOINT_PARAMETER_COVERAGE:.0%}: {diagnostic_message}"
+        )
+
+    if diagnostics:
+        logging.warning(f"{diagnostic_message}. Continuing because strict checkpoint loading is disabled.")
+
+    return state_dict

--- a/tests/collections/speechlm2/test_hf_hub.py
+++ b/tests/collections/speechlm2/test_hf_hub.py
@@ -12,11 +12,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+
 import pytest
 from huggingface_hub import PyTorchModelHubMixin
 
 import nemo.collections.speechlm2.parts.hf_hub as hf_hub
 from nemo.collections.speechlm2.parts.hf_hub import HFHubMixin, _inject_local_artifact_paths
+
+
+def _automodel_parameter_names_available():
+    try:
+        from nemo_automodel.shared.parameter_names import canonical_parameter_fqn
+    except ImportError:
+        return False
+    return canonical_parameter_fqn is not None
+
+
+def _automodel_storage_reader_available():
+    try:
+        from nemo_automodel.components.checkpoint._backports.hf_storage import _HuggingFaceStorageReader
+    except ImportError:
+        return False
+    return _HuggingFaceStorageReader is not None
+
+
+_AUTOMODEL_PARAMETER_NAMES_AVAILABLE = _automodel_parameter_names_available()
+_AUTOMODEL_STORAGE_READER_AVAILABLE = _automodel_storage_reader_available()
+requires_automodel_parameter_names = pytest.mark.skipif(
+    not _AUTOMODEL_PARAMETER_NAMES_AVAILABLE,
+    reason="nemo_automodel parameter-name canonicalization is not installed",
+)
+requires_automodel_dtensor_loader = pytest.mark.skipif(
+    not (_AUTOMODEL_PARAMETER_NAMES_AVAILABLE and _AUTOMODEL_STORAGE_READER_AVAILABLE),
+    reason="required nemo_automodel distributed-checkpoint symbols are not installed",
+)
+
+
+@pytest.fixture
+def torch():
+    return pytest.importorskip("torch")
+
+
+@pytest.fixture
+def checkpoint_wrapper(torch):
+    del torch
+    module = pytest.importorskip("torch.distributed.algorithms._checkpoint.checkpoint_wrapper")
+    return module.checkpoint_wrapper
 
 
 class _DummyHubModel(HFHubMixin):
@@ -102,6 +144,39 @@ def test_save_pretrained_does_not_persist_remote_code_trust(tmp_path, monkeypatc
     assert model.cfg["trust_remote_code"] is True
 
 
+def test_from_pretrained_distributed_forwards_strict(tmp_path, monkeypatch):
+    config_path = tmp_path / hf_hub.CONFIG_NAME
+    config_path.write_text("{}")
+    captured = {}
+    sentinel = object()
+
+    def fake_cached_file(_model_id, filename, **_kwargs):
+        return str(config_path) if filename == hf_hub.CONFIG_NAME else None
+
+    def fake_distributed_from_pretrained(**kwargs):
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(hf_hub, "cached_file", fake_cached_file)
+    monkeypatch.setattr(hf_hub, "_distributed_from_pretrained", fake_distributed_from_pretrained)
+    distributed_setup = SimpleNamespace(mesh_context=SimpleNamespace(device_mesh=object()))
+
+    result = _DummyHubModel._from_pretrained(
+        model_id="checkpoint",
+        revision=None,
+        cache_dir=None,
+        force_download=False,
+        local_files_only=True,
+        token=None,
+        strict=True,
+        distributed_setup=distributed_setup,
+    )
+
+    assert result is sentinel
+    assert captured["strict"] is True
+    assert captured["distributed_setup"] is distributed_setup
+
+
 def test_inject_local_artifact_paths_salm_config(tmp_path):
     _write_local_export_artifacts(tmp_path)
     cfg = {
@@ -141,3 +216,415 @@ def test_inject_local_artifact_paths_no_artifacts_keeps_old_config(tmp_path):
         "pretrained_llm": "remote-llm",
         "pretrained_weights": True,
     }
+
+
+@requires_automodel_parameter_names
+def test_checkpoint_state_dict_maps_activation_checkpoint_wrappers(torch, checkpoint_wrapper):
+    class WrappedModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            block = torch.nn.Linear(1, 1, bias=False)
+            block.register_buffer("running_mean", torch.zeros(1))
+            self.block = checkpoint_wrapper(block)
+            self.register_buffer("runtime_only", torch.zeros(1), persistent=False)
+
+    model = WrappedModel()
+
+    assert list(dict(model.named_parameters())) == ["block._checkpoint_wrapped_module.weight"]
+    assert list(model.state_dict()) == ["block.weight", "block.running_mean"]
+
+    state_dict = hf_hub._checkpoint_state_dict(model, {"block.weight", "block.running_mean"}, strict=True)
+
+    assert list(state_dict) == ["block.weight", "block.running_mean"]
+    assert state_dict["block.weight"] is model.block._checkpoint_wrapped_module.weight
+    assert state_dict["block.running_mean"] is model.block._checkpoint_wrapped_module.running_mean
+
+
+@requires_automodel_parameter_names
+def test_checkpoint_state_dict_rejects_partial_parameter_coverage(torch):
+    model = torch.nn.Sequential(torch.nn.Linear(1, 1, bias=False), torch.nn.Linear(1, 1, bias=False))
+
+    with pytest.raises(RuntimeError, match=r"matched only 50.0%.*missing model parameters.*1.weight"):
+        hf_hub._checkpoint_state_dict(model, {"0.weight"})
+
+
+@requires_automodel_parameter_names
+def test_checkpoint_state_dict_accepts_saved_tied_parameter_alias(torch):
+    class TiedModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.z = torch.nn.Linear(1, 1, bias=False)
+            self.a = torch.nn.Linear(1, 1, bias=False)
+            self.a.weight = self.z.weight
+
+    model = TiedModel()
+
+    assert list(dict(model.named_parameters())) == ["z.weight"]
+    assert [name for name, _ in model.named_parameters(remove_duplicate=False)] == ["z.weight", "a.weight"]
+
+    state_dict = hf_hub._checkpoint_state_dict(model, {"a.weight"})
+
+    assert list(state_dict) == ["a.weight"]
+    assert state_dict["a.weight"] is model.z.weight
+
+
+@requires_automodel_parameter_names
+def test_checkpoint_state_dict_warns_about_small_parameter_gap(monkeypatch, torch):
+    from nemo.utils import logging
+
+    class ModelWithRuntimeParameter(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.checkpointed = torch.nn.Parameter(torch.zeros(19))
+            self.runtime_only = torch.nn.Parameter(torch.zeros(1))
+
+    model = ModelWithRuntimeParameter()
+    warnings = []
+    monkeypatch.setattr(logging, "warning", warnings.append)
+
+    state_dict = hf_hub._checkpoint_state_dict(model, {"checkpointed"})
+
+    assert list(state_dict) == ["checkpointed"]
+    assert len(warnings) == 1
+    assert "matched only 95.0%" in warnings[0]
+    assert "runtime_only" in warnings[0]
+
+
+@requires_automodel_parameter_names
+def test_checkpoint_state_dict_loads_one_persistent_buffer_alias(monkeypatch, torch):
+    from nemo.utils import logging
+
+    class ModelWithTiedBuffer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            shared = torch.ones(1)
+            self.register_buffer("z", shared)
+            self.register_buffer("a", shared)
+
+    model = ModelWithTiedBuffer()
+    warnings = []
+    monkeypatch.setattr(logging, "warning", warnings.append)
+
+    assert list(dict(model.named_buffers())) == ["z"]
+    assert [name for name, _ in model.named_buffers(remove_duplicate=False)] == ["z", "a"]
+
+    state_dict = hf_hub._checkpoint_state_dict(model, {"z", "a"})
+
+    assert list(state_dict) == ["z"]
+    assert state_dict["z"] is model.z
+    assert len(warnings) == 1
+    assert "multiple aliases" in warnings[0]
+    assert "Each shared tensor is loaded once" in warnings[0]
+
+    warnings.clear()
+    hf_hub._checkpoint_state_dict(model, {"z", "a"}, strict=True)
+    assert len(warnings) == 1
+
+
+@requires_automodel_parameter_names
+def test_checkpoint_state_dict_accepts_distributed_export_tied_parameter_aliases(monkeypatch, torch):
+    from nemo.utils import logging
+
+    class TiedModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embed_tokens = torch.nn.Linear(1, 1, bias=False)
+            self.lm_head = torch.nn.Linear(1, 1, bias=False)
+            self.lm_head.weight = self.embed_tokens.weight
+
+    model = TiedModel()
+    warnings = []
+    monkeypatch.setattr(logging, "warning", warnings.append)
+
+    state_dict = hf_hub._checkpoint_state_dict(
+        model,
+        {"embed_tokens.weight", "lm_head.weight"},
+        strict=True,
+    )
+
+    assert list(state_dict) == ["embed_tokens.weight"]
+    assert state_dict["embed_tokens.weight"] is model.embed_tokens.weight
+    assert len(warnings) == 1
+    assert "multiple aliases" in warnings[0]
+    assert "lm_head.weight" in warnings[0]
+
+
+@requires_automodel_parameter_names
+def test_checkpoint_state_dict_rejects_canonical_name_collision(torch):
+    class CollidingModel:
+        def named_parameters(self, remove_duplicate=True):
+            del remove_duplicate
+            return iter(
+                [
+                    ("block.weight", torch.nn.Parameter(torch.zeros(1))),
+                    ("block._checkpoint_wrapped_module.weight", torch.nn.Parameter(torch.ones(1))),
+                ]
+            )
+
+        def named_modules(self, remove_duplicate=True):
+            del remove_duplicate
+            return iter(())
+
+    with pytest.raises(RuntimeError, match="Multiple model tensors map to checkpoint key 'block.weight'"):
+        hf_hub._checkpoint_state_dict(CollidingModel(), {"block.weight"})
+
+
+@requires_automodel_parameter_names
+def test_checkpoint_state_dict_rejects_unmatched_top_level_component(torch):
+    class TwoComponentModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.llm = torch.nn.Linear(97, 1, bias=False)
+            self.perception = torch.nn.Linear(3, 1, bias=False)
+
+    with pytest.raises(RuntimeError, match=r"97.0%.*top-level model components.*perception"):
+        hf_hub._checkpoint_state_dict(TwoComponentModel(), {"llm.weight"})
+
+
+@requires_automodel_parameter_names
+def test_checkpoint_state_dict_rejects_partially_unmatched_top_level_component(torch):
+    class PartiallyMatchedPerceptionModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.llm = torch.nn.Linear(9700, 1, bias=False)
+            self.perception = torch.nn.Module()
+            self.perception.adapter = torch.nn.Linear(3, 1, bias=False)
+            self.perception.encoder = torch.nn.Linear(300, 1, bias=False)
+
+    checkpoint_keys = {"llm.weight", "perception.adapter.weight"}
+
+    with pytest.raises(RuntimeError, match=r"97.0%.*top-level model components.*perception \(1.0%, 3/303\)"):
+        hf_hub._checkpoint_state_dict(PartiallyMatchedPerceptionModel(), checkpoint_keys)
+
+
+@requires_automodel_parameter_names
+def test_checkpoint_state_dict_warns_about_tolerated_top_level_component_gap(monkeypatch, torch):
+    from nemo.utils import logging
+
+    model = torch.nn.Module()
+    model.llm = torch.nn.Module()
+    model.llm.checkpointed = torch.nn.Parameter(torch.zeros(95))
+    model.llm.missing = torch.nn.Parameter(torch.zeros(5))
+    warnings = []
+    monkeypatch.setattr(logging, "warning", warnings.append)
+
+    state_dict = hf_hub._checkpoint_state_dict(model, {"llm.checkpointed"})
+
+    assert list(state_dict) == ["llm.checkpointed"]
+    assert len(warnings) == 1
+    assert "matched only 95.0%" in warnings[0]
+    assert "below 90%" not in warnings[0]
+
+
+@requires_automodel_parameter_names
+def test_checkpoint_state_dict_root_wrapper_keeps_root_parameter_policy(monkeypatch, torch, checkpoint_wrapper):
+    from nemo.utils import logging
+
+    model = torch.nn.Module()
+    model.checkpointed = torch.nn.Parameter(torch.zeros(95))
+    model.missing = torch.nn.Parameter(torch.zeros(5))
+    model = checkpoint_wrapper(model)
+    warnings = []
+    monkeypatch.setattr(logging, "warning", warnings.append)
+
+    state_dict = hf_hub._checkpoint_state_dict(model, {"checkpointed"})
+
+    assert list(state_dict) == ["checkpointed"]
+    assert len(warnings) == 1
+    assert "matched only 95.0%" in warnings[0]
+
+
+@requires_automodel_parameter_names
+def test_checkpoint_state_dict_strict_mode_rejects_small_gap(torch):
+    model = torch.nn.Module()
+    model.checkpointed = torch.nn.Parameter(torch.zeros(19))
+    model.missing = torch.nn.Parameter(torch.zeros(1))
+
+    with pytest.raises(RuntimeError, match=r"Strict checkpoint loading failed.*95.0%.*missing"):
+        hf_hub._checkpoint_state_dict(model, {"checkpointed"}, strict=True)
+
+
+@pytest.mark.parametrize(
+    ("matched_numel", "missing_numel", "raises"),
+    [
+        pytest.param(9, 1, False, id="exactly-90-percent-warns"),
+        pytest.param(89, 11, True, id="below-90-percent-raises"),
+    ],
+)
+@requires_automodel_parameter_names
+def test_checkpoint_state_dict_parameter_coverage_boundary(monkeypatch, matched_numel, missing_numel, raises, torch):
+    from nemo.utils import logging
+
+    model = torch.nn.Module()
+    model.checkpointed = torch.nn.Parameter(torch.zeros(matched_numel))
+    model.missing = torch.nn.Parameter(torch.zeros(missing_numel))
+    warnings = []
+    monkeypatch.setattr(logging, "warning", warnings.append)
+
+    if raises:
+        with pytest.raises(RuntimeError, match="matched only 89.0%"):
+            hf_hub._checkpoint_state_dict(model, {"checkpointed"})
+        assert not warnings
+    else:
+        hf_hub._checkpoint_state_dict(model, {"checkpointed"})
+        assert len(warnings) == 1
+        assert "matched only 90.0%" in warnings[0]
+
+
+@requires_automodel_parameter_names
+def test_checkpoint_state_dict_warns_about_missing_persistent_buffer_and_unused_key(monkeypatch, torch):
+    from nemo.utils import logging
+
+    model = torch.nn.Module()
+    model.register_buffer("persistent", torch.ones(1))
+    model.register_buffer("runtime_only", torch.zeros(1), persistent=False)
+    warnings = []
+    monkeypatch.setattr(logging, "warning", warnings.append)
+
+    state_dict = hf_hub._checkpoint_state_dict(model, {"old_persistent"})
+
+    assert state_dict == {}
+    assert len(warnings) == 1
+    assert "missing persistent model buffers" in warnings[0]
+    assert "['persistent']" in warnings[0]
+    assert "runtime_only" not in warnings[0]
+    assert "unused checkpoint tensors" in warnings[0]
+    assert "old_persistent" in warnings[0]
+
+
+@requires_automodel_parameter_names
+def test_checkpoint_state_dict_treats_non_persistent_checkpoint_buffer_as_unused(monkeypatch, torch):
+    from nemo.utils import logging
+
+    model = torch.nn.Module()
+    model.register_buffer("runtime_only", torch.zeros(1), persistent=False)
+    warnings = []
+    monkeypatch.setattr(logging, "warning", warnings.append)
+
+    state_dict = hf_hub._checkpoint_state_dict(model, {"runtime_only"})
+
+    assert state_dict == {}
+    assert len(warnings) == 1
+    assert "unused checkpoint tensors" in warnings[0]
+    assert "runtime_only" in warnings[0]
+
+    warnings.clear()
+    with pytest.raises(RuntimeError, match=r"Strict checkpoint loading failed.*runtime_only"):
+        hf_hub._checkpoint_state_dict(model, {"runtime_only"}, strict=True)
+    assert not warnings
+
+
+@requires_automodel_dtensor_loader
+def test_dtensor_loader_passes_metadata_keys_to_dcp(monkeypatch, tmp_path, torch, checkpoint_wrapper):
+    import torch.distributed.checkpoint as dcp
+    from nemo_automodel.components.checkpoint._backports.hf_storage import _HuggingFaceStorageReader
+
+    class WrappedModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            block = torch.nn.Linear(1, 1, bias=False)
+            block.register_buffer("running_mean", torch.zeros(1))
+            self.block = checkpoint_wrapper(block)
+
+    model = WrappedModel()
+    metadata = SimpleNamespace(state_dict_metadata={"block.weight": object(), "block.running_mean": object()})
+    loaded = {}
+
+    monkeypatch.setattr(_HuggingFaceStorageReader, "read_metadata", lambda _self: metadata)
+    monkeypatch.setattr(
+        dcp,
+        "load",
+        lambda state_dict, storage_reader: loaded.update(state_dict=state_dict, storage_reader=storage_reader),
+    )
+
+    hf_hub._load_state_dict_with_dtensors(model, str(tmp_path))
+
+    assert list(loaded["state_dict"]) == ["block.weight", "block.running_mean"]
+    assert loaded["state_dict"]["block.weight"] is model.block._checkpoint_wrapped_module.weight
+    assert loaded["state_dict"]["block.running_mean"] is model.block._checkpoint_wrapped_module.running_mean
+    assert isinstance(loaded["storage_reader"], _HuggingFaceStorageReader)
+
+
+@requires_automodel_parameter_names
+def test_checkpoint_state_dict_warns_when_ignoring_extra_state_in_strict_mode(monkeypatch, torch):
+    from nemo.utils import logging
+
+    model = torch.nn.Module()
+    model.weight = torch.nn.Parameter(torch.zeros(1))
+    warnings = []
+    monkeypatch.setattr(logging, "warning", warnings.append)
+
+    state_dict = hf_hub._checkpoint_state_dict(
+        model,
+        {"weight", "transformer.layer._extra_state"},
+        strict=True,
+    )
+
+    assert list(state_dict) == ["weight"]
+    assert len(warnings) == 1
+    assert "Ignoring checkpoint extra-state tensors" in warnings[0]
+    assert "transformer.layer._extra_state" in warnings[0]
+
+
+@requires_automodel_parameter_names
+def test_checkpoint_state_dict_warns_about_extra_state_before_strict_failure(monkeypatch, torch):
+    from nemo.utils import logging
+
+    model = torch.nn.Module()
+    model.weight = torch.nn.Parameter(torch.zeros(1))
+    model.register_buffer("persistent", torch.zeros(1))
+    warnings = []
+    monkeypatch.setattr(logging, "warning", warnings.append)
+
+    with pytest.raises(RuntimeError, match=r"Strict checkpoint loading failed.*missing persistent model buffers"):
+        hf_hub._checkpoint_state_dict(model, {"weight", "transformer.layer._extra_state"}, strict=True)
+
+    assert len(warnings) == 1
+    assert "Ignoring checkpoint extra-state tensors" in warnings[0]
+
+
+@requires_automodel_dtensor_loader
+def test_dtensor_loader_forwards_strict_to_checkpoint_validation(monkeypatch, tmp_path, torch):
+    from nemo_automodel.components.checkpoint._backports.hf_storage import _HuggingFaceStorageReader
+
+    model = torch.nn.Module()
+    model.weight = torch.nn.Parameter(torch.zeros(1))
+    metadata = SimpleNamespace(state_dict_metadata={"weight": object(), "unexpected": object()})
+    monkeypatch.setattr(_HuggingFaceStorageReader, "read_metadata", lambda _self: metadata)
+
+    with pytest.raises(RuntimeError, match=r"Strict checkpoint loading failed.*unused checkpoint.*unexpected"):
+        hf_hub._load_state_dict_with_dtensors(model, str(tmp_path), strict=True)
+
+
+def test_distributed_loader_forwards_strict(monkeypatch, tmp_path):
+    weight_file = tmp_path / hf_hub.SAFETENSORS_SINGLE_FILE
+    weight_file.touch()
+    loaded = {}
+
+    class FakeModel:
+        def __init__(self, cfg):
+            self.cfg = cfg
+
+        def configure_model(self, distributed_setup):
+            self.distributed_setup = distributed_setup
+
+    monkeypatch.setattr(hf_hub, "cached_file", lambda *_args, **_kwargs: str(weight_file))
+    monkeypatch.setattr(
+        hf_hub,
+        "_load_state_dict_with_dtensors",
+        lambda model, weight_dir, strict=False: loaded.update(model=model, weight_dir=weight_dir, strict=strict),
+    )
+
+    distributed_setup = object()
+    model = hf_hub._distributed_from_pretrained(
+        cls=FakeModel,
+        model_id="checkpoint",
+        model_kwargs={"cfg": {}},
+        torch_dtype=None,
+        strict=True,
+        distributed_setup=distributed_setup,
+        cached_file_kwargs={},
+    )
+
+    assert loaded == {"model": model, "weight_dir": str(tmp_path), "strict": True}
+    assert model.distributed_setup is distributed_setup


### PR DESCRIPTION
> [!IMPORTANT]
> The `Update branch` button must only be pressed in very rare occasions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do?

Fixes distributed loading of Hugging Face checkpoints for SpeechLM2 models that use activation checkpointing.

Activation-checkpoint wrappers change parameter names by adding `_checkpoint_wrapped_module`. Because the distributed checkpoint loader previously required exact key matches, wrapped parameters were skipped silently and could remain randomly initialized during fine-tuning.

This PR canonicalizes model parameter names before matching them against checkpoint keys and adds validation to prevent incomplete checkpoints from being loaded silently.

**Collection**: SpeechLM2

# Changelog

- Canonicalize activation-checkpoint wrapper names before matching model tensors with Hugging Face checkpoint keys.
- Forward the `strict` option through the distributed `from_pretrained` loading path.
- Validate both global and per-top-level-component parameter coverage before loading:
  - With the default `strict=False`, warn about small compatibility gaps.
  - Reject checkpoints with less than 90% global or per-component parameter coverage.
  - With `strict=True`, reject any missing parameter, missing persistent buffer, or unused checkpoint tensor.
- Support checkpoint aliases for tied parameters and buffers while loading each shared tensor only once.
- Ignore TransformerEngine `*_extra_state` tensors with a warning because they have no direct parameter or buffer destination.
- Add documentation describing distributed checkpoint-loading behavior.

# Usage

Existing distributed `from_pretrained` calls do not require changes.

Set `strict=True` when all model parameters, persistent buffers, and checkpoint tensors must match:

```python
model = Model.from_pretrained(
    checkpoint,
    distributed_setup=distributed_setup,
    strict=True,
)
```

# Testing

Added unit coverage for:

- Activation-checkpoint wrapper name canonicalization
- `strict` propagation through the distributed loading path
- Global and per-component parameter coverage validation
- The 90% coverage boundary
- Missing parameters and persistent buffers
- Unused and TransformerEngine extra-state checkpoint tensors
- Tied parameter and buffer aliases
- Canonical-name collisions
- DTensor checkpoint metadata matching

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

Trusted PRs run automatically through copy-pr-bot. For an untrusted PR, a maintainer can trigger CI by commenting `/ok to test <head-sha>`; repeat this after a new push if the PR remains untrusted.

# Before your PR is "Ready for review"

**Pre-checks**:

- [ ] Make sure you read and followed the [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install?
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items, you can still open a Draft PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
The [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md) contain specific people who can review PRs in various areas.

# Additional Information

No related issue.
