### PR TITLE
fix(asr): end the final VAD speech segment at the last frame's end

### DIFF
--- a/nemo/collections/asr/parts/utils/vad_utils.py
+++ b/nemo/collections/asr/parts/utils/vad_utils.py
@@ -558,7 +558,6 @@ def binarization(sequence: torch.Tensor, per_args: Dict[str, float]) -> torch.Te
 
     speech = False
     start = 0.0
-    i = 0
 
     speech_segments = torch.empty(0)
 
@@ -585,7 +584,9 @@ def binarization(sequence: torch.Tensor, per_args: Dict[str, float]) -> torch.Te
 
     # if it's speech at the end, add final segment
     if speech:
-        new_seg = torch.tensor([max(0, start - pad_onset), i * frame_length_in_sec + pad_offset]).unsqueeze(0)
+        # The last frame is active, so the segment ends where that frame ends, not where it starts.
+        seg_end = len(sequence) * frame_length_in_sec + pad_offset
+        new_seg = torch.tensor([max(0, start - pad_onset), seg_end]).unsqueeze(0)
         speech_segments = torch.cat((speech_segments, new_seg), 0)
 
     # Merge the overlapped speech segments due to padding

--- a/tests/collections/speaker_tasks/utils/test_vad_utils_speaker.py
+++ b/tests/collections/speaker_tasks/utils/test_vad_utils_speaker.py
@@ -19,6 +19,7 @@ from lhotse import SupervisionSegment
 
 from nemo.collections.asr.parts.utils.vad_utils import (
     align_labels_to_frames,
+    binarization,
     binarization_vectorized,
     convert_labels_to_speech_segments,
     frame_vad_construct_supervisions_per_file,
@@ -194,6 +195,30 @@ class TestVADUtils:
         )
 
         torch.testing.assert_close(segments, torch.tensor(expected))
+
+    @pytest.mark.parametrize(
+        ("predictions", "expected"),
+        [
+            pytest.param([0.6, 0.6], [[0.0, 0.16]], id="speech-runs-to-end-of-audio"),
+            pytest.param([0.1, 0.1, 0.9], [[0.16, 0.24]], id="lone-active-final-frame"),
+            pytest.param([0.9, 0.9, 0.1, 0.9, 0.9], [[0.0, 0.16], [0.24, 0.4]], id="trailing-matches-interior"),
+        ],
+    )
+    @pytest.mark.unit
+    def test_binarization_final_active_frame_uses_full_duration(self, predictions, expected):
+        per_args = {
+            'onset': 0.5,
+            'offset': 0.5,
+            'pad_onset': 0.0,
+            'pad_offset': 0.0,
+            'frame_length_in_sec': 0.08,
+        }
+        sequence = torch.tensor(predictions)
+
+        segments = binarization(sequence, per_args)
+
+        torch.testing.assert_close(segments, torch.tensor(expected))
+        torch.testing.assert_close(segments, binarization_vectorized(sequence, per_args))
 
     @pytest.mark.parametrize(
         "predictions",


### PR DESCRIPTION
# What does this PR do ?

`binarization()` closes a trailing speech segment at `i * frame_length_in_sec`, where `i` is the index of the last active frame, so the segment ends where that frame *starts*. Interior segments close at the index of the first inactive frame, i.e. at the end of the last active frame. A segment still active at the end of the sequence therefore comes out one full frame short, and a lone active final frame yields a zero-duration segment `[t, t]`.

`binarization_vectorized` in the same module does not have this. Its test `final-active-frame-uses-full-duration` expects `[[0.0, 0.16]]` for `[0.6, 0.6]` at 0.08 s frames; `binarization` returns `[[0.0, 0.08]]`. The affected callers are `generate_vad_segment_table_per_tensor` (frame-VAD speech segments and RTTM) and `ts_vad_post_processing`.

**Collection**: ASR

# Changelog

- `binarization()` now ends the trailing segment at `len(sequence) * frame_length_in_sec + pad_offset`.
- Dropped the pre-loop `i = 0`, which only existed to feed that expression.
- Added `test_binarization_final_active_frame_uses_full_duration`, which also asserts agreement with `binarization_vectorized`.

# Usage

```python
import torch
from nemo.collections.asr.parts.utils.vad_utils import binarization, binarization_vectorized

per_args = {'onset': 0.5, 'offset': 0.5, 'pad_onset': 0.0, 'pad_offset': 0.0, 'frame_length_in_sec': 0.08}

# Two speech runs of two frames each. Only the trailing one is truncated.
seq = torch.tensor([0.9, 0.9, 0.1, 0.9, 0.9])
binarization(seq, per_args)             # before: [[0.00, 0.16], [0.24, 0.32]]
binarization_vectorized(seq, per_args)  #         [[0.00, 0.16], [0.24, 0.40]]

# A single active final frame collapses to zero duration.
binarization(torch.tensor([0.1, 0.1, 0.9]), per_args)  # before: [[0.16, 0.16]]
```

# Checks run

- `pytest tests/collections/speaker_tasks/utils/ tests/collections/asr/utils/ -m "not pleasefixme" --cpu` -> 834 passed, 40 skipped. The three new cases fail before the fix and pass after.
- A differential fuzz of 5000 random sequences against `binarization_vectorized` (onset >= offset, frame lengths 0.01/0.02/0.08 s) goes from 3268 mismatches and 851 zero-duration segments to 0 and 0. Empty results are skipped there because `binarization` returns shape `[0]` while `binarization_vectorized` returns `(0, 2)`; that shape difference is left alone.
- `black --check`, `isort --check-only`, `flake8 --config=.flake8.speech`, `pylint --rcfile=.pylintrc.speech` -> clean, pylint 10.00/10.
- Skipped: GPU tests and the full ASR suite, neither reachable on this machine. `binarization` is `@torch.jit.script` and still compiles.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

@nithinraok per CONTRIBUTING.md for ASR.
