### PR TITLE
fix(asr): stop evaluate_eou returning negative false_negatives and missing

### DIFF
--- a/nemo/collections/asr/parts/utils/eou_utils.py
+++ b/nemo/collections/asr/parts/utils/eou_utils.py
@@ -171,8 +171,12 @@ def evaluate_eou(
         false_negatives += len(reference) - r_idx
         missing += len(reference) - r_idx
 
-    missing -= len(earlycut_ids)  # Remove the references that were missed due to early cutoff
-    false_negatives -= len(earlycut_ids)  # Remove the references that were missed due to early cutoff
+    # Only references counted by the block above can be discounted here. An early cutoff
+    # that r_idx already advanced past was never added, so subtracting it drives both
+    # counts negative.
+    counted_earlycut = sum(1 for idx in earlycut_ids if idx >= r_idx)
+    missing -= counted_earlycut  # Remove the references that were missed due to early cutoff
+    false_negatives -= counted_earlycut  # Remove the references that were missed due to early cutoff
     return EOUResult(
         latency=latency,
         early_cutoff=early_cutoff,

--- a/tests/collections/asr/test_asr_eou.py
+++ b/tests/collections/asr/test_asr_eou.py
@@ -20,6 +20,7 @@ import pytest
 from nemo.collections.asr.parts.utils.eou_utils import (
     EOUResult,
     cal_eou_metrics_from_frame_labels,
+    evaluate_eou,
     get_SegLST_from_frame_labels,
 )
 
@@ -138,3 +139,32 @@ class TestEOUMetrics:
         assert eou_metrics.missing == 0
         assert eou_metrics.early_cutoff == []
         assert np.allclose(eou_metrics.latency, [delay] * len(ref_eou_times))
+
+
+class TestEvaluateEOUCounts:
+    def test_counts_stay_non_negative_when_early_cutoff_is_skipped(self):
+        """An early cutoff that r_idx advances past is never counted, so it must not be subtracted."""
+        reference = [
+            {"start_time": 0.0, "end_time": 2.0},
+            {"start_time": 5.0, "end_time": 7.0},
+        ]
+        prediction = [
+            {"start_time": 0.0, "end_time": 1.0, "eou_prob": 0.9},
+            {"start_time": 5.5, "end_time": 7.0, "eou_prob": 0.9},
+        ]
+
+        result = evaluate_eou(prediction=prediction, reference=reference, threshold=None, collar=0.1)
+
+        assert result.false_negatives == 0
+        assert result.missing == 0
+
+    def test_trailing_early_cutoff_is_still_discounted(self):
+        """A trailing early cutoff is counted by the tail, so the discount must still apply."""
+        reference = [{"start_time": 0.0, "end_time": 2.0}]
+        prediction = [{"start_time": 0.0, "end_time": 1.0, "eou_prob": 0.9}]
+
+        result = evaluate_eou(prediction=prediction, reference=reference, threshold=None, collar=0.1)
+
+        assert result.false_negatives == 0
+        assert result.missing == 0
+        assert len(result.early_cutoff) == 1


### PR DESCRIPTION
`evaluate_eou` can return negative `false_negatives` and `missing`, which are counts.

When a prediction cuts a reference short, the reference index goes into `earlycut_ids`
and `r_idx` stays put. If a later prediction starts after that reference ends, the
`while` loop advances `r_idx` past it, so the trailing "unmatched references" block
never counts it. The unconditional `-= len(earlycut_ids)` still subtracts it, and both
counters go below zero.

Two references, one early cutoff followed by an exact hit:

```python
reference  = [{"start_time": 0.0, "end_time": 2.0}, {"start_time": 5.0, "end_time": 7.0}]
prediction = [{"start_time": 0.0, "end_time": 1.0, "eou_prob": 0.9},
              {"start_time": 5.5, "end_time": 7.0, "eou_prob": 0.9}]
evaluate_eou(prediction=prediction, reference=reference, threshold=None, collar=0.1)
# false_negatives = -1, missing = -1
```

The fix discounts only the early cutoffs the trailing block actually counted, so a
trailing early cutoff is still discounted as before. Two regression tests added; the
first fails on main, the second guards the existing behavior.

Existing `tests/collections/asr/test_asr_eou.py` passes before and after.
