### PR TITLE
docs: add adalat-ai/koyal-indic-600m-1.0 to featured community checkp…

### DIFF
--- a/docs/source/asr/featured_community_checkpoints.rst
+++ b/docs/source/asr/featured_community_checkpoints.rst
@@ -39,6 +39,9 @@ For NVIDIA-published checkpoints, see :doc:`./asr_checkpoints` and the `NVIDIA H
    * - `cstr/canary-1b-v2-GGUF <https://huggingface.co/cstr/canary-1b-v2-GGUF>`__
      - Quantised Canary 1B (Q4_K ~673 MB). Multilingual ASR and speech translation.
      - GGUF (`CrispASR <https://github.com/CrispStrobe/CrispASR>`__)
+   * - `adalat-ai/koyal-indic-600m-1.0 <https://huggingface.co/adalat-ai/koyal-indic-600m-1.0>`__
+     - Rich-orthography ASR (punctuation, numerals) for Hindi, Kannada, Malayalam, Telugu. Cache-aware FastConformer + prompt-RNNT (600M), fine-tuned from `nemotron-3.5-asr-streaming-0.6b <https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b>`__; one checkpoint, streaming or offline.
+     - NeMo
 
 
 .. _submit-a-community-checkpoint:


### PR DESCRIPTION
# What does this PR do ?

Submitting `koyal-indic-600m-1.0` for the Featured Community Checkpoints page: an open ASR model for Indian languages that emits document-ready text (punctuation and formatted numerals), released by [Adalat AI](https://huggingface.co/adalat-ai).

Release post: https://www.adalat.ai/blog/tech/koyal-model-release

**Collection**: ASR (docs)

### koyal-indic-600m-1.0 (Nemotron fine-tune)

- **Model:** https://huggingface.co/adalat-ai/koyal-indic-600m-1.0
- **NeMo base checkpoint:** [nvidia/nemotron-3.5-asr-streaming-0.6b](https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b) (encoder, kept cache-aware; new prompt-conditioned RNN-T decoder and 6k unified vocabulary for the four languages)
- **Task:** multilingual ASR with rich-orthography output; dual-mode — one checkpoint serves both streaming (0 ms to 1040 ms lookahead) and full-context offline decoding, selected at inference
- **Languages:** Hindi, Kannada, Malayalam, Telugu. To our knowledge the first open cache-aware streaming ASR covering Kannada, Malayalam, and Telugu (cf. #15793 on base-tokenizer script coverage)
- **Evaluation:** WER_SCRIBE on [FLEURS-RO](https://huggingface.co/datasets/adalat-ai/fleurs-ro) (rich-orthography FLEURS re-annotation, [scribe-eval](https://github.com/adalat-ai-tech/scribe-eval)): offline 12.33 (hi) / 12.75 (kn) / 18.58 (ml) / 20.65 (te); zero-lookahead streaming stays within 2.2 points of offline in every language. Per-operating-point tables and jiwer WER on the model card
- **Framework:** NeMo (≥ 3.0.0; uses the upstream prompt-conditioned RNN-T class)

# Changelog

- `docs/source/asr/featured_community_checkpoints.rst`: add one table row for `adalat-ai/koyal-indic-600m-1.0`.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests? — n/a, documentation only
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? — no

**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [x] Documentation