### PR TITLE
feat(tts): Optimize and harden EasyMagpie vLLM-Omni streaming at BS 32, 64, 128 

### DIFF
--- a/tests/collections/tts/easymagpie_vllm_omni/serving/test_backbone_patches.py
+++ b/tests/collections/tts/easymagpie_vllm_omni/serving/test_backbone_patches.py
@@ -21,7 +21,11 @@ import pytest
 torch = pytest.importorskip("torch")
 pytest.importorskip("vllm")
 
-from easymagpie_vllm_omni.backbone_patches import patch_shared_expert_activation  # noqa: E402
+import easymagpie_vllm_omni.backbone_patches as backbone_patches  # noqa: E402
+from easymagpie_vllm_omni.backbone_patches import (  # noqa: E402
+    patch_moe_router_logit_cast,
+    patch_shared_expert_activation,
+)
 from vllm.model_executor.layers.activation import ReLUSquaredActivation  # noqa: E402
 
 
@@ -57,3 +61,22 @@ def test_shared_expert_patch_rejects_unknown_upstream_implementation():
 
     with pytest.raises(RuntimeError, match="implementation changed"):
         patch_shared_expert_activation(backbone)
+
+
+def test_fp16_grouped_router_skips_logit_upcast(monkeypatch):
+    monkeypatch.setattr(backbone_patches.platforms, "current_platform", SimpleNamespace(is_cuda=lambda: True))
+    monkeypatch.setattr(backbone_patches.envs, "VLLM_USE_FUSED_MOE_GROUPED_TOPK", True)
+    router = type("GroupedTopKRouter", (), {})()
+    router.num_expert_group = 1
+    router.top_k = 4
+    router.scoring_func = "sigmoid"
+    router.e_score_correction_bias = torch.zeros(24)
+    gate = SimpleNamespace(weight=torch.empty(24, 1536, dtype=torch.float16), out_dtype=torch.float32)
+    mixer = NemotronHMoE(_relu_squared_without_vllm_context())
+    mixer.gate = gate
+    mixer.experts = SimpleNamespace(router=router)
+    backbone = SimpleNamespace(layers=[SimpleNamespace(mixer=mixer)])
+
+    assert patch_moe_router_logit_cast(backbone) == 1
+    assert gate.out_dtype == torch.float16
+    assert patch_moe_router_logit_cast(backbone) == 0

--- a/tests/collections/tts/easymagpie_vllm_omni/serving/test_benchmark_server.py
+++ b/tests/collections/tts/easymagpie_vllm_omni/serving/test_benchmark_server.py
@@ -66,9 +66,7 @@ def test_request_uses_openai_speech_endpoint_and_decodes_streaming_pcm(monkeypat
         "input": "Hello",
         "voice": "eng",
         "response_format": "pcm",
-        "stream": True,
         "stream_format": "audio",
-        "max_new_tokens": 128,
     }
     assert result.error is None
     assert result.num_samples == 2

--- a/tests/collections/tts/easymagpie_vllm_omni/serving/test_codec_kernels.py
+++ b/tests/collections/tts/easymagpie_vllm_omni/serving/test_codec_kernels.py
@@ -37,6 +37,22 @@ def test_packed_half_snake() -> None:
     torch.testing.assert_close(actual, expected, atol=2e-5, rtol=2e-5)
 
 
+def test_packed_half_snake_with_residual() -> None:
+    torch.manual_seed(18)
+    inputs = torch.randn(113, 32, device="cuda")
+    residual = torch.randn_like(inputs)
+    alpha = torch.rand(1, 16, 1, device="cuda") + 0.25
+    actual = packed_half_snake(inputs, alpha, residual)
+    combined = inputs + residual
+    snake_in = combined[:, :16]
+    scale = alpha.reshape(1, -1)
+    expected = torch.cat(
+        (snake_in + torch.sin(scale * snake_in).square() / (scale + 1e-9), F.leaky_relu(combined[:, 16:])),
+        dim=-1,
+    )
+    torch.testing.assert_close(actual, expected, atol=2e-5, rtol=2e-5)
+
+
 def test_packed_causal_conv1d() -> None:
     torch.manual_seed(19)
     device = torch.device("cuda")

--- a/tests/collections/tts/easymagpie_vllm_omni/serving/test_codec_model.py
+++ b/tests/collections/tts/easymagpie_vllm_omni/serving/test_codec_model.py
@@ -23,26 +23,102 @@ def _payload(frames: int, codebooks: int = 16) -> dict:
     return {"codes": {"audio": torch.arange(frames * codebooks).view(frames, codebooks)}}
 
 
+def _model(**overrides):
+    config = dict(
+        num_stacked_codebooks=16,
+        frame_stacking_factor=2,
+        codebook_size=1024,
+        samples_per_codec_frame=3,
+        samples_per_frame=6,
+    )
+    config.update(overrides)
+    model = EasyMagpieCodecForConditionalGeneration.__new__(EasyMagpieCodecForConditionalGeneration)
+    torch.nn.Module.__init__(model)
+    model.config = SimpleNamespace(**config)
+    return model
+
+
 def test_payload_codes_skips_active_but_unscheduled_requests():
-    model = SimpleNamespace(config=SimpleNamespace(num_stacked_codebooks=16))
+    model = _model()
     infos = [_payload(2), _payload(4), _payload(1)]
     spans = [(0, 2), (2, 2), (2, 3)]
 
-    codes, frame_counts = EasyMagpieCodecForConditionalGeneration._payload_codes(
+    codes, frame_counts, valid_sample_counts = EasyMagpieCodecForConditionalGeneration._payload_codes(
         model, infos, torch.device("cpu"), spans
     )
 
     assert codes.shape == (3, 16)
     assert frame_counts == [2, 1]
+    assert valid_sample_counts == [12, 6]
     assert torch.equal(codes[:2], infos[0]["codes"]["audio"])
     assert torch.equal(codes[2:], infos[2]["codes"]["audio"])
 
 
 def test_payload_codes_rejects_scheduled_frame_mismatch():
-    model = SimpleNamespace(config=SimpleNamespace(num_stacked_codebooks=16))
+    model = _model()
 
     with pytest.raises(ValueError, match="scheduled 1 placeholders.*2 frames"):
         EasyMagpieCodecForConditionalGeneration._payload_codes(model, [_payload(2)], torch.device("cpu"), [(0, 1)])
+
+
+def test_payload_codes_computes_valid_lengths_before_device_transfer():
+    model = _model(num_stacked_codebooks=4)
+    infos = [
+        {"codes": {"audio": torch.tensor([[1, 2, 101, 102], [3, 1025, 103, 1025]])}},
+        {"codes": {"audio": torch.tensor([[1, 2, 101, 102], [1025, 3, 1025, 103]])}},
+    ]
+
+    codes, frame_counts, valid_sample_counts = EasyMagpieCodecForConditionalGeneration._payload_codes(
+        model, infos, torch.device("meta")
+    )
+
+    assert codes.device.type == "meta"
+    assert frame_counts == [2, 2]
+    assert valid_sample_counts == [9, 6]
+
+
+def test_payload_codes_trim_multiple_padded_terminal_frames():
+    model = _model(num_stacked_codebooks=4)
+    info = {
+        "codes": {
+            "audio": torch.tensor(
+                [
+                    [1, 2, 101, 102],
+                    [3, 1025, 103, 1025],
+                    [-1, -1, -1, -1],
+                    [-1, -1, -1, -1],
+                ]
+            )
+        }
+    }
+
+    _, frame_counts, valid_sample_counts = EasyMagpieCodecForConditionalGeneration._payload_codes(
+        model, [info], torch.device("cpu"), [(0, 4)]
+    )
+
+    assert frame_counts == [4]
+    assert valid_sample_counts == [9]
+
+
+def test_payload_codes_only_trims_control_from_the_terminal_row():
+    model = _model(num_stacked_codebooks=4)
+    info = {
+        "codes": {
+            "audio": torch.tensor(
+                [
+                    [1, 2, 101, 102],
+                    [3, 1025, 103, 1025],
+                    [4, 5, 104, 105],
+                ]
+            )
+        }
+    }
+
+    _, _, valid_sample_counts = EasyMagpieCodecForConditionalGeneration._payload_codes(
+        model, [info], torch.device("cpu"), [(0, 3)]
+    )
+
+    assert valid_sample_counts == [18]
 
 
 class _FakeCodec(torch.nn.Module):
@@ -80,3 +156,24 @@ def test_forward_trims_terminal_control_subframes(terminal_row, expected_samples
 
     audio = output.multimodal_outputs["model_outputs"][0]
     torch.testing.assert_close(audio, torch.arange(expected_samples, dtype=torch.float32))
+
+
+def test_forward_keeps_request_offsets_when_terminal_audio_is_trimmed():
+    model = _model(num_stacked_codebooks=4)
+    model.config.output_sample_rate = 22050
+    model.vllm_config = SimpleNamespace(device_config=SimpleNamespace(device=torch.device("cpu")))
+    model.codec = _FakeCodec()
+    infos = [
+        {"codes": {"audio": torch.tensor([[1, 2, 101, 102], [3, 1025, 103, 1025]])}},
+        {"codes": {"audio": torch.tensor([[1, 2, 101, 102], [1025, 3, 1025, 103]])}},
+    ]
+
+    output = model.forward(
+        input_ids=torch.zeros(4, dtype=torch.long),
+        runtime_additional_information=infos,
+        request_token_spans=[(0, 2), (2, 4)],
+    )
+
+    first, second = output.multimodal_outputs["model_outputs"]
+    torch.testing.assert_close(first, torch.arange(9, dtype=torch.float32))
+    torch.testing.assert_close(second, torch.arange(12, 18, dtype=torch.float32))

--- a/tests/collections/tts/easymagpie_vllm_omni/serving/test_codec_packed.py
+++ b/tests/collections/tts/easymagpie_vllm_omni/serving/test_codec_packed.py
@@ -60,6 +60,7 @@ def metadata(frames: int, *, has_initial: bool, device: torch.device | str = "cp
     )
     result.codec_max_query_len = frames
     result.codec_uniform = True
+    result.codec_prefill_uniform = True
     return result
 
 
@@ -89,6 +90,7 @@ def decode_metadata(
         seq_lens=torch.full((num_decodes,), 2, dtype=torch.int32, device=device),
     )
     result.codec_uniform = True
+    result.codec_prefill_uniform = False
     return result
 
 
@@ -113,6 +115,35 @@ def mixed_metadata(prefill_frames: int, *, device: torch.device | str = "cpu") -
         seq_lens=torch.tensor([2, prefill_frames], dtype=torch.int32, device=device),
     )
     result.codec_max_query_len = prefill_frames
+    result.codec_uniform = False
+    result.codec_prefill_uniform = True
+    return result
+
+
+def ragged_metadata(lengths: tuple[int, ...], *, device: torch.device | str) -> Mamba1AttentionMetadata:
+    starts = torch.tensor([0, *torch.tensor(lengths).cumsum(0).tolist()], dtype=torch.int32, device=device)
+    result = Mamba1AttentionMetadata(
+        num_prefills=len(lengths),
+        num_prefill_tokens=sum(lengths),
+        num_decodes=0,
+        num_decode_tokens=0,
+        num_reqs=len(lengths),
+        has_initial_states_p=torch.zeros(len(lengths), dtype=torch.bool, device=device),
+        query_start_loc_p=starts,
+        num_computed_tokens_p=None,
+        state_indices_tensor_p=torch.arange(len(lengths), dtype=torch.int32, device=device),
+        state_indices_tensor_d=torch.empty((0, 1), dtype=torch.int32, device=device),
+        query_start_loc_d=None,
+        num_accepted_tokens=None,
+        block_idx_last_scheduled_token=None,
+        block_idx_first_scheduled_token_p=None,
+        block_idx_last_computed_token=None,
+        block_idx_last_scheduled_token_prev_step=None,
+        seq_lens=torch.tensor(lengths, dtype=torch.int32, device=device),
+    )
+    result.codec_max_query_len = max(lengths)
+    result.codec_uniform = False
+    result.codec_prefill_uniform = False
     return result
 
 
@@ -257,3 +288,62 @@ def test_cuda_packed_kernels_preserve_state_across_chunks() -> None:
             pieces.append(streamed(codes[0, frame : frame + 1]))
 
     torch.testing.assert_close(torch.cat(pieces), expected, atol=3e-5, rtol=3e-5)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for Triton integration")
+def test_cuda_ragged_batch_matches_separate_decode() -> None:
+    torch.manual_seed(31)
+    device = torch.device("cuda")
+    config = tiny_config()
+    vllm_config = VllmConfig()
+    with set_current_vllm_config(vllm_config):
+        full = PackedEasyMagpieCodec(config, dtype=torch.float32, prefix="full").to(device).eval()
+        packed = PackedEasyMagpieCodec(config, dtype=torch.float32, prefix="ragged").to(device).eval()
+    packed.load_state_dict(full.state_dict(), strict=True)
+
+    state_layers = [module for module in packed.modules() if isinstance(module, CodecStateLayer)]
+    for layer in state_layers:
+        layer.kv_cache = [torch.zeros((2, CODEC_STATE_ELEMENTS), device=device)]
+
+    sequences = [
+        torch.randint(0, config.codebook_size, (length, config.num_stacked_codebooks), device=device)
+        for length in (3, 2)
+    ]
+    layer_metadata = {layer.prefix: ragged_metadata((3, 2), device=device) for layer in state_layers}
+    with set_forward_context(layer_metadata, vllm_config):
+        actual = packed(torch.cat(sequences))
+    with set_forward_context(None, vllm_config):
+        expected = torch.cat([full(sequence) for sequence in sequences])
+
+    torch.testing.assert_close(actual, expected, atol=3e-5, rtol=3e-5)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for cuDNN integration")
+def test_cuda_mixed_decode_and_uniform_prefill_batch() -> None:
+    torch.manual_seed(37)
+    device = torch.device("cuda")
+    config = tiny_config()
+    vllm_config = VllmConfig()
+    with set_current_vllm_config(vllm_config):
+        full = PackedEasyMagpieCodec(config, dtype=torch.float32, prefix="full").to(device).eval()
+        packed = PackedEasyMagpieCodec(config, dtype=torch.float32, prefix="mixed").to(device).eval()
+    packed.load_state_dict(full.state_dict(), strict=True)
+
+    state_layers = [module for module in packed.modules() if isinstance(module, CodecStateLayer)]
+    for layer in state_layers:
+        layer.kv_cache = [torch.zeros((2, CODEC_STATE_ELEMENTS), device=device)]
+
+    decode_codes = torch.randint(0, config.codebook_size, (2, config.num_stacked_codebooks), device=device)
+    prefill_codes = torch.randint(0, config.codebook_size, (2, config.num_stacked_codebooks), device=device)
+    first_metadata = {layer.prefix: metadata(1, has_initial=False, device=device) for layer in state_layers}
+    with set_forward_context(first_metadata, vllm_config):
+        packed(decode_codes[:1])
+
+    layer_metadata = {layer.prefix: mixed_metadata(2, device=device) for layer in state_layers}
+    with set_forward_context(layer_metadata, vllm_config):
+        actual = packed(torch.cat((decode_codes[1:], prefill_codes)))
+
+    with set_forward_context(None, vllm_config):
+        decode_expected = full(decode_codes)[config.samples_per_frame :]
+        prefill_expected = full(prefill_codes)
+    torch.testing.assert_close(actual, torch.cat((decode_expected, prefill_expected)), atol=3e-5, rtol=3e-5)

--- a/tests/collections/tts/easymagpie_vllm_omni/serving/test_codec_utils.py
+++ b/tests/collections/tts/easymagpie_vllm_omni/serving/test_codec_utils.py
@@ -45,6 +45,17 @@ def test_fsq_decode() -> None:
     torch.testing.assert_close(actual, expected)
 
 
+def test_fsq_lookup_matches_arithmetic() -> None:
+    config = tiny_config()
+    decode = PackedFiniteScalarDequantizer(config)
+    indices = torch.arange(config.codebook_size).repeat(config.num_codebooks, 1).T
+    levels = torch.tensor(config.num_levels_per_group)
+    bases = torch.cumprod(torch.tensor([1, *config.num_levels_per_group[:-1]]), dim=0)
+    scale = torch.div(levels, 2, rounding_mode="floor")
+    expected = ((torch.div(indices[..., None], bases, rounding_mode="floor") % levels - scale) / scale).flatten(1)
+    torch.testing.assert_close(decode(indices), expected)
+
+
 def test_unstack_predictor_codes_preserves_codebook_and_time_order() -> None:
     # Each predictor row is [c0_t0, c0_t1, c1_t0, c1_t1, ...].
     stacked = torch.tensor(

--- a/tests/collections/tts/easymagpie_vllm_omni/serving/test_local_transformer.py
+++ b/tests/collections/tts/easymagpie_vllm_omni/serving/test_local_transformer.py
@@ -52,6 +52,29 @@ def _build_predictor(profile_kwargs: dict):
     return cp, arch
 
 
+def _full_buffer_codes(cp, dec_hidden, gumbel_noise, temperature):
+    """Reference the original loop that transforms all codebook positions."""
+    num_tokens = dec_hidden.shape[0]
+    num_codebooks = cp.num_codebooks
+    buf = dec_hidden.new_zeros(num_tokens, num_codebooks, cp.lt_hidden)
+    buf[:, 0, :] = cp.local_transformer_in_projection(dec_hidden)
+
+    codes = []
+    for k in range(num_codebooks):
+        hidden = cp.local_transformer(buf)
+        row = cp.local_transformer_audio_out_projection(hidden[:, k, :])
+        logits = cp.local_transformer_out_projections[k](row)
+        logits = logits.masked_fill(cp.forbidden_mask, float("-inf")) / temperature
+        vals, idxs = torch.topk(logits, cp._sample_top_k, dim=-1)
+        picked = (vals + gumbel_noise[:, k, :]).argmax(dim=-1, keepdim=True)
+        code = idxs.gather(-1, picked).squeeze(-1)
+        codes.append(code)
+        if k + 1 < num_codebooks:
+            emb = cp.audio_in_projection(cp.audio_embeddings[k](code))
+            buf[:, k + 1, :] = cp.local_transformer_in_projection(emb)
+    return torch.stack(codes, dim=1)
+
+
 @pytest.mark.unit
 def test_generate_codes_shape_dtype_and_range():
     """``generate_codes`` returns valid (num_tokens, num_codebooks) int64 codes within vocab."""
@@ -93,3 +116,21 @@ def test_generate_codes_deterministic_with_seed():
     second = cp.generate_codes(dec_hidden)
 
     assert torch.equal(first, second)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("profile", ARCH_PROFILES.values(), ids=ARCH_PROFILES)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["fp32", "bf16"])
+def test_code_loop_matches_full_buffer_reference(profile, dtype):
+    """Causal prefix execution preserves every sampled code from the original loop."""
+    cp, arch = _build_predictor(profile)
+    cp.to(dtype=dtype)
+    num_tokens = 3
+    dec_hidden = torch.randn(num_tokens, arch.hidden_dim, dtype=dtype)
+    gumbel_noise = torch.randn(num_tokens, arch.num_stacked_codebooks, cp._sample_top_k)
+    temperature = torch.tensor([0.7])
+
+    expected = _full_buffer_codes(cp, dec_hidden, gumbel_noise, temperature)
+    actual = cp._code_loop(dec_hidden, gumbel_noise, temperature)
+
+    assert torch.equal(actual, expected)

--- a/tests/collections/tts/easymagpie_vllm_omni/serving/test_local_transformer.py
+++ b/tests/collections/tts/easymagpie_vllm_omni/serving/test_local_transformer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for local-transformer sampling contracts."""
+
 from __future__ import annotations
 
 import pytest
@@ -20,8 +21,10 @@ torch = pytest.importorskip("torch")
 pytest.importorskip("vllm")
 
 from conftest import build_vllm_config  # noqa: E402
+from easymagpie_vllm_omni import local_transformer as local_transformer_module  # noqa: E402
 from easymagpie_vllm_omni.config import EasyMagpieOmniArch  # noqa: E402
 from easymagpie_vllm_omni.local_transformer import EasyMagpieCodePredictor  # noqa: E402
+from vllm.config import CUDAGraphMode  # noqa: E402
 
 # Cover identity and linear projection paths.
 ARCH_PROFILES = {
@@ -116,6 +119,36 @@ def test_generate_codes_deterministic_with_seed():
     second = cp.generate_codes(dec_hidden)
 
     assert torch.equal(first, second)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("raise_from_loop", [False, True], ids=["success", "failure"])
+def test_generate_codes_uses_full_cudagraph_mode_and_restores_outer_mode(monkeypatch, raise_from_loop):
+    """The independently compiled code loop must not inherit the outer PIECEWISE graph mode."""
+    cp, arch = _build_predictor(ARCH_PROFILES["equal_dims"])
+    outer_context = type("ForwardContext", (), {"cudagraph_runtime_mode": CUDAGraphMode.PIECEWISE})()
+    observed_modes = []
+
+    monkeypatch.setattr(local_transformer_module, "get_forward_context", lambda: outer_context, raising=False)
+    monkeypatch.setattr(local_transformer_module, "is_forward_context_available", lambda: True, raising=False)
+
+    def fake_code_loop(dec_hidden, _noise, _temperature):
+        observed_modes.append(outer_context.cudagraph_runtime_mode)
+        if raise_from_loop:
+            raise RuntimeError("code loop failed")
+        return torch.zeros(dec_hidden.shape[0], arch.num_stacked_codebooks, dtype=torch.long)
+
+    monkeypatch.setattr(cp._code_loop, "forward", fake_code_loop)
+    dec_hidden = torch.randn(3, arch.hidden_dim)
+
+    if raise_from_loop:
+        with pytest.raises(RuntimeError, match="code loop failed"):
+            cp.generate_codes(dec_hidden)
+    else:
+        cp.generate_codes(dec_hidden)
+
+    assert observed_modes == [CUDAGraphMode.FULL]
+    assert outer_context.cudagraph_runtime_mode == CUDAGraphMode.PIECEWISE
 
 
 @pytest.mark.unit

--- a/tests/collections/tts/easymagpie_vllm_omni/serving/test_model_prefill.py
+++ b/tests/collections/tts/easymagpie_vllm_omni/serving/test_model_prefill.py
@@ -11,10 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 from types import SimpleNamespace
 
+import pytest
 import torch
 from easymagpie_vllm_omni.easymagpie import EasyMagpieTTSForConditionalGeneration
+from safetensors.torch import save_file
 from torch import nn
 
 
@@ -46,3 +49,139 @@ def test_text_prefill_embeddings_add_phoneme_bos_at_position_three():
         rows,
         torch.tensor([[1, 0, 0], [2, 0, 0], [3, 0, 0], [4, 0, 10]], dtype=torch.float32),
     )
+
+
+def _speaker_model(model_path, embedding_dim=3):
+    model = EasyMagpieTTSForConditionalGeneration.__new__(EasyMagpieTTSForConditionalGeneration)
+    nn.Module.__init__(model)
+    model.model_path = str(model_path)
+    model.embedding_dim = embedding_dim
+    model._combined_embeddings = torch.zeros(1, embedding_dim)
+    model._speaker_embedding_buffers = {}
+    model._speaker_context_registry = {}
+    return model
+
+
+def test_context_bundle_is_preloaded_as_nonpersistent_buffers(tmp_path):
+    speaker_dir = tmp_path / "speaker_embeddings"
+    speaker_dir.mkdir()
+    registry = {
+        "schema_version": 1,
+        "contexts": {
+            "eng": {"tensor_key": "speaker.eng", "context_text": "[EN]", "prompt_len": 67},
+            "deu": {"tensor_key": "speaker.deu", "context_text": "[DE]", "prompt_len": 69},
+        },
+    }
+    (speaker_dir / "contexts.json").write_text(json.dumps(registry))
+    tensors = {"speaker.eng": torch.ones(2, 3), "speaker.deu": torch.full((4, 3), 2.0)}
+    save_file(tensors, speaker_dir / "contexts.safetensors")
+    model = _speaker_model(tmp_path)
+
+    model._preload_known_speaker_embeddings()
+
+    assert sorted(model._speaker_embedding_buffers) == ["deu", "eng"]
+    assert model._speaker_context_registry == registry["contexts"]
+    torch.testing.assert_close(
+        model._load_known_speaker_embedding("eng", torch.device("cpu"), torch.float32), tensors["speaker.eng"]
+    )
+    assert not any(name.startswith("_speaker_context_") for name in model.state_dict())
+
+
+def test_context_registry_drives_prompt_length_and_context_text(tmp_path):
+    speaker_dir = tmp_path / "speaker_embeddings"
+    speaker_dir.mkdir()
+    registry = {
+        "schema_version": 1,
+        "contexts": {"eng": {"tensor_key": "speaker.eng", "context_text": "[EN]", "prompt_len": 67}},
+    }
+    (speaker_dir / "contexts.json").write_text(json.dumps(registry))
+
+    assert EasyMagpieTTSForConditionalGeneration.get_prompt_len("eng", str(tmp_path), tokenize=list) == 67
+    with pytest.raises(FileNotFoundError, match="speaker_id 'deu'"):
+        EasyMagpieTTSForConditionalGeneration.get_prompt_len("deu", str(tmp_path), tokenize=list)
+
+    model = _speaker_model(tmp_path)
+    model._speaker_context_registry = registry["contexts"]
+    with pytest.raises(ValueError, match=r"requires context_text '\[EN\]'"):
+        model._build_prefill_embeds(torch.device("cpu"), {"speaker_id": "eng", "context_text": "[DE]"})
+
+
+def test_load_weights_uses_vllm_026_auto_loader(monkeypatch):
+    loaded_weights = []
+
+    class FakeAutoWeightsLoader:
+        def __init__(self, module):
+            assert isinstance(module, nn.Module)
+
+        def load_weights(self, weights):
+            loaded_weights.extend(weights)
+            return {"layer.weight"}
+
+    monkeypatch.setattr("vllm.model_executor.models.utils.AutoWeightsLoader", FakeAutoWeightsLoader)
+    model = EasyMagpieTTSForConditionalGeneration.__new__(EasyMagpieTTSForConditionalGeneration)
+    nn.Module.__init__(model)
+    model.backbone = nn.Module()
+    model.code_predictor = SimpleNamespace(init_forbidden_mask=lambda: None)
+
+    assert model.load_weights([]) == {"backbone.layer.weight"}
+    assert loaded_weights == []
+
+
+def test_phoneme_eos_is_fed_once_then_masked():
+    model = EasyMagpieTTSForConditionalGeneration.__new__(EasyMagpieTTSForConditionalGeneration)
+    nn.Module.__init__(model)
+    model.arch = SimpleNamespace(phoneme_stacking_factor=1, audio_bos_id=1025)
+    model.has_phoneme = True
+    model.phonemes_delay = 0
+    model.phoneme_bos_id = 10
+    model.phoneme_eos_id = 11
+    model.speech_delay = 99
+    model.embedding_dim = 3
+    model.num_codebooks = 2
+    model._combined_embeddings = torch.zeros(2, 3)
+    model._dec_text_tokens = torch.zeros(2, dtype=torch.long)
+    model._dec_text_mask = torch.zeros(2, dtype=torch.long)
+    model._dec_phoneme_tokens = torch.zeros(2, 1, dtype=torch.long)
+    model._dec_phoneme_valid = torch.zeros(2, dtype=torch.long)
+    model._dec_audio_codes = torch.zeros(2, 2, dtype=torch.long)
+    model._dec_audio_valid = torch.zeros(2, dtype=torch.long)
+    input_ids = torch.zeros(1, dtype=torch.long)
+
+    _, _, update = model._preprocess_decode(
+        input_ids,
+        0,
+        input_ids.device,
+        {"decode_offset": 1, "last_phoneme_token": torch.tensor([[model.phoneme_eos_id]])},
+    )
+
+    assert model._dec_phoneme_valid[0].item() == 1
+    assert update["phoneme_ended"].item() is True
+
+    model._preprocess_decode(
+        input_ids,
+        1,
+        input_ids.device,
+        {
+            "decode_offset": 2,
+            "last_phoneme_token": torch.tensor([[3]]),
+            "phoneme_ended": update["phoneme_ended"],
+        },
+    )
+
+    assert model._dec_phoneme_valid[1].item() == 0
+    assert "phoneme_ended" in model.gpu_resident_buffer_keys
+
+
+def test_two_stage_output_copies_codes_once_and_uses_async_output():
+    model = EasyMagpieTTSForConditionalGeneration.__new__(EasyMagpieTTSForConditionalGeneration)
+    nn.Module.__init__(model)
+    model._single_stage_audio = False
+    model._out_codes = torch.tensor([[1, 2], [3, 4]])
+    hidden = torch.zeros(2, 3)
+
+    output = model.make_omni_output(hidden)
+
+    assert set(output.multimodal_outputs) == {"codes"}
+    torch.testing.assert_close(output.multimodal_outputs["codes"]["audio"], model._out_codes)
+    assert model.use_async_omni_output
+    assert model.eager_omni_postprocess_before_async_output

--- a/tests/collections/tts/easymagpie_vllm_omni/serving/test_runner.py
+++ b/tests/collections/tts/easymagpie_vllm_omni/serving/test_runner.py
@@ -14,11 +14,19 @@
 """Tests for the vLLM-Omni 0.24 streaming runner compatibility layer."""
 from __future__ import annotations
 
+import json
+from types import SimpleNamespace
+
 import torch
 import yaml
 
+import easymagpie_vllm_omni.runner as runner_module
 from conftest import EASYMAGPIE_ROOT
-from easymagpie_vllm_omni.runner import merge_streaming_additional_information
+from easymagpie_vllm_omni.runner import (
+    EasyMagpieGPUARModelRunner,
+    batch_waveforms_to_cpu,
+    merge_streaming_additional_information,
+)
 
 WORKER_CLS = "easymagpie_vllm_omni.runner.EasyMagpieGPUARWorker"
 
@@ -53,8 +61,115 @@ def test_streaming_update_accumulates_declared_tensor_keys():
     torch.testing.assert_close(merged["hidden_states"]["output"], torch.tensor([[1.0], [2.0]]))
 
 
+def test_top_level_gpu_resident_updates_are_cloned_as_resident_state():
+    runner = object.__new__(EasyMagpieGPUARModelRunner)
+    request = SimpleNamespace()
+    runner.requests = {"request": request}
+    runner.model_intermediate_buffer = {}
+    runner.model = SimpleNamespace(
+        gpu_resident_buffer_keys={"last_audio_codes", ("hidden_states", "last")}
+    )
+    audio_codes = torch.tensor([[1, 2]])
+    hidden = torch.tensor([[3.0]])
+
+    runner._update_intermediate_buffer(
+        "request",
+        {"last_audio_codes": audio_codes, "hidden_states": {"last": hidden}},
+    )
+
+    cached = runner.model_intermediate_buffer["request"]
+    torch.testing.assert_close(cached["last_audio_codes"], audio_codes)
+    torch.testing.assert_close(cached["hidden_states"]["last"], hidden)
+    assert cached["last_audio_codes"].data_ptr() != audio_codes.data_ptr()
+    assert cached["hidden_states"]["last"].data_ptr() != hidden.data_ptr()
+    assert request.additional_information_cpu is cached
+
+
+def test_stage0_trace_records_exact_request_prediction(monkeypatch, tmp_path):
+    monkeypatch.setattr(runner_module, "_STAGE0_TRACE_DIR", tmp_path, raising=False)
+    runner = object.__new__(EasyMagpieGPUARModelRunner)
+    request = SimpleNamespace()
+    runner.requests = {"request": request}
+    runner.model_intermediate_buffer = {
+        "request": {"decode_offset": 8, "_omni_is_prefill": False}
+    }
+    runner.model = SimpleNamespace(
+        gpu_resident_buffer_keys={"last_audio_codes", "last_phoneme_token"}
+    )
+
+    runner._update_intermediate_buffer(
+        "request",
+        {
+            "last_audio_codes": torch.tensor([[1, 2]]),
+            "last_phoneme_token": torch.tensor([[3]]),
+        },
+    )
+
+    trace_file = next(tmp_path.glob("stage0.*.jsonl"))
+    row = json.loads(trace_file.read_text())
+    assert row == {
+        "request_id": "request",
+        "decode_offset": 7,
+        "phoneme_tokens": [3],
+        "audio_codes": [1, 2],
+    }
+    cached = runner.model_intermediate_buffer["request"]
+    torch.testing.assert_close(cached["last_audio_codes"], torch.tensor([[1, 2]]))
+    torch.testing.assert_close(cached["last_phoneme_token"], torch.tensor([[3]]))
+
+    cached["_omni_is_prefill"] = True
+    runner._update_intermediate_buffer(
+        "request",
+        {
+            "last_audio_codes": torch.tensor([[4, 5]]),
+            "last_phoneme_token": torch.tensor([[6]]),
+        },
+    )
+    assert len(trace_file.read_text().splitlines()) == 1
+
+
+def test_async_output_uses_padded_length_to_slice_codes():
+    runner = object.__new__(EasyMagpieGPUARModelRunner)
+    runner.model = SimpleNamespace(omni_pooler_payload_include_hidden=False)
+    hidden = torch.zeros(40, 3)
+    codes = torch.arange(80).view(40, 2)
+
+    snapshot = runner._build_omni_async_snapshot_payload(
+        hidden_states=hidden,
+        staged_hidden_states_cpu=None,
+        multimodal_outputs={"codes": {"audio": codes}},
+    )
+    output = runner._build_omni_mm_payload(
+        combined_multimodal_outputs=None,
+        mm_cpu={"codes.audio": codes},
+        rid="request-7",
+        idx=7,
+        start=7,
+        end=8,
+        audio_sparse_output=False,
+        sparse_mm_index={},
+        hidden_seq_len=snapshot["hidden_states"].shape[0],
+        scheduled_seq_len=34,
+    )
+
+    assert snapshot["hidden_states"].shape == (40, 0)
+    torch.testing.assert_close(output["codes.audio"], codes[7:8])
+
+
 def test_deploy_configs_select_compatibility_worker_for_lm():
     for filename in ("easymagpie_lm.yaml", "easymagpie.yaml"):
         deploy = yaml.safe_load((EASYMAGPIE_ROOT / "deploy" / filename).read_text())
         lm_stage = next(stage for stage in deploy["stages"] if stage["stage_id"] == 0)
         assert lm_stage["engine_extras"]["worker_cls"] == WORKER_CLS
+
+
+def test_batched_waveform_copy_preserves_bits_shapes_and_order():
+    first = torch.tensor([0, -2147483648, 1065353216, 2143294004], dtype=torch.int32).view(torch.float32).view(2, 2)
+    second = torch.tensor([1073741824], dtype=torch.int32).view(torch.float32)
+    third = torch.tensor([-1082130432, 1082130432], dtype=torch.int32).view(torch.float32).view(1, 2)
+
+    copied = batch_waveforms_to_cpu([first, second, third])
+
+    assert [x.shape for x in copied] == [first.shape, second.shape, third.shape]
+    for actual, expected in zip(copied, (first, second, third), strict=True):
+        assert torch.equal(actual.view(torch.int32), expected.view(torch.int32))

--- a/tests/collections/tts/easymagpie_vllm_omni/serving/test_scheduler.py
+++ b/tests/collections/tts/easymagpie_vllm_omni/serving/test_scheduler.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for the vLLM-Omni 0.24 async scheduler compatibility layer."""
+"""Tests for the vLLM-Omni scheduler compatibility layer."""
 from __future__ import annotations
 
 import threading
@@ -20,6 +20,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+import easymagpie_vllm_omni.scheduler as scheduler_module
 from easymagpie_vllm_omni.scheduler import (
     EasyMagpieARAsyncScheduler,
     EasyMagpieCodecScheduler,
@@ -27,6 +28,7 @@ from easymagpie_vllm_omni.scheduler import (
 )
 from vllm.v1.request import RequestStatus
 from vllm_omni.core.sched.omni_ar_scheduler import OmniARAsyncScheduler
+from vllm_omni.core.sched.omni_generation_scheduler import OmniGenerationScheduler
 from vllm_omni.distributed.omni_connectors.transfer_adapter.chunk_transfer_adapter import OmniChunkTransferAdapter
 
 
@@ -34,6 +36,7 @@ def test_no_stop_is_inert_for_non_resumable_requests(monkeypatch):
     """A plain HTTP request never hits a segment stop, so the override must pass
     ``super()`` through unchanged and leave request accounting untouched."""
     scheduler = object.__new__(EasyMagpieARAsyncScheduler)
+    monkeypatch.setattr(scheduler_module, "_UPSTREAM_HAS_SEGMENT_STOP_ACCOUNTING_FIX", False)
     request = SimpleNamespace(
         async_tokens_to_discard=0,
         num_computed_tokens=20,
@@ -62,6 +65,7 @@ def test_terminal_stop_without_discard_is_inert(monkeypatch):
     """HTTP requests end on a normal audio-EOS stop (not a resumable segment
     stop), so omni arms no discard and the override must not roll anything back."""
     scheduler = object.__new__(EasyMagpieARAsyncScheduler)
+    monkeypatch.setattr(scheduler_module, "_UPSTREAM_HAS_SEGMENT_STOP_ACCOUNTING_FIX", False)
     request = SimpleNamespace(
         async_tokens_to_discard=0,
         num_computed_tokens=20,
@@ -89,6 +93,7 @@ def test_terminal_stop_without_discard_is_inert(monkeypatch):
 @pytest.mark.parametrize("remaining_placeholders", [0, 1, 2])
 def test_segment_stop_discards_and_rolls_back_exact_inflight_count(monkeypatch, remaining_placeholders):
     scheduler = object.__new__(EasyMagpieARAsyncScheduler)
+    monkeypatch.setattr(scheduler_module, "_UPSTREAM_HAS_SEGMENT_STOP_ACCOUNTING_FIX", False)
     request = SimpleNamespace(
         async_tokens_to_discard=0,
         num_computed_tokens=20,
@@ -113,6 +118,19 @@ def test_segment_stop_discards_and_rolls_back_exact_inflight_count(monkeypatch, 
     assert outputs == "outputs"
     assert request.async_tokens_to_discard == remaining_placeholders
     assert request.num_computed_tokens == 20 - remaining_placeholders
+
+
+def test_vllm_026_uses_upstream_segment_stop_accounting(monkeypatch):
+    scheduler = object.__new__(EasyMagpieARAsyncScheduler)
+    monkeypatch.setattr(scheduler_module, "_UPSTREAM_HAS_SEGMENT_STOP_ACCOUNTING_FIX", True)
+    monkeypatch.setattr(
+        OmniARAsyncScheduler,
+        "update_from_output",
+        lambda self, scheduler_output, model_runner_output: "upstream",
+    )
+
+    assert scheduler.update_from_output(None, None) == "upstream"
+    assert not hasattr(scheduler, "_emp_stopped_this_step")
 
 
 def test_final_streaming_sentinel_marks_session_non_resumable(monkeypatch):
@@ -166,26 +184,252 @@ def test_resume_uses_exact_discard_count_and_forwards_chunk_metadata(monkeypatch
     assert session.additional_information == {"text_token": [2, 3]}
 
 
+def test_stage0_coalesces_only_new_idle_admissions(monkeypatch):
+    now = [10.0]
+    monkeypatch.setattr(scheduler_module, "monotonic", lambda: now[0])
+    scheduler = object.__new__(EasyMagpieARAsyncScheduler)
+    scheduler._admission_wait_s = 0.003
+    scheduler._admission_deadline = None
+    scheduler.max_num_running_reqs = 32
+    scheduler.running = []
+    scheduler.waiting = [SimpleNamespace(num_computed_tokens=0)]
+
+    assert scheduler._should_defer_waiting_admission() is True
+    scheduler.waiting.append(SimpleNamespace(num_computed_tokens=0))
+    now[0] += 0.002
+    assert scheduler._should_defer_waiting_admission() is True
+    now[0] += 0.001
+    assert scheduler._should_defer_waiting_admission() is False
+    assert scheduler._should_defer_waiting_admission() is False
+
+    scheduler.waiting.clear()
+    assert scheduler._should_defer_waiting_admission() is False
+    assert scheduler._admission_deadline is None
+
+    scheduler.waiting.append(SimpleNamespace(num_computed_tokens=0))
+    assert scheduler._should_defer_waiting_admission() is True
+
+
+@pytest.mark.parametrize("mode", ["disabled", "continuation", "full", "running"])
+def test_stage0_admission_coalescing_bypass(mode):
+    scheduler = object.__new__(EasyMagpieARAsyncScheduler)
+    scheduler._admission_wait_s = 0 if mode == "disabled" else 0.003
+    scheduler._admission_deadline = None
+    scheduler.max_num_running_reqs = 2
+    scheduler.running = [object()] if mode == "running" else []
+    computed = 1 if mode == "continuation" else 0
+    count = 2 if mode == "full" else 1
+    scheduler.waiting = [SimpleNamespace(num_computed_tokens=computed) for _ in range(count)]
+
+    assert scheduler._should_defer_waiting_admission() is False
+
+
+def test_codec_startup_coalescing_finishes_receive_pass(monkeypatch):
+    lock = threading.Lock()
+    first = SimpleNamespace(
+        request_id="first",
+        status=RequestStatus.WAITING_FOR_CHUNK,
+        num_computed_tokens=0,
+    )
+    second = SimpleNamespace(
+        request_id="second",
+        status=RequestStatus.WAITING_FOR_CHUNK,
+        num_computed_tokens=0,
+    )
+    adapter = SimpleNamespace(
+        _easymagpie_chunk_lock=lock,
+        _easymagpie_chunk_ready=threading.Condition(lock),
+        _finished_load_reqs={"first"},
+    )
+    scheduler = object.__new__(EasyMagpieCodecScheduler)
+    scheduler._codec_startup_wait_s = 0.002
+    scheduler._codec_busy_wait_s = 0
+    scheduler.chunk_transfer_adapter = adapter
+    scheduler.running = []
+    scheduler.waiting = [first, second]
+
+    def fake_sleep(delay):
+        assert delay == 0.002
+        assert not lock.locked()
+        with lock:
+            adapter._finished_load_reqs.add("second")
+
+    def fake_schedule(self, *args, **kwargs):
+        assert lock.locked()
+        return set(adapter._finished_load_reqs)
+
+    monkeypatch.setattr(scheduler_module, "sleep", fake_sleep)
+    monkeypatch.setattr(OmniGenerationScheduler, "schedule", fake_schedule)
+
+    assert scheduler.schedule() == {"first", "second"}
+
+
+@pytest.mark.parametrize("mode", ["disabled", "running", "not_ready", "continuation"])
+def test_codec_startup_coalescing_bypass(monkeypatch, mode):
+    lock = threading.Lock()
+    request = SimpleNamespace(
+        request_id="request",
+        status=RequestStatus.WAITING_FOR_CHUNK,
+        num_computed_tokens=1 if mode == "continuation" else 0,
+    )
+    adapter = SimpleNamespace(
+        _easymagpie_chunk_lock=lock,
+        _easymagpie_chunk_ready=threading.Condition(lock),
+        _finished_load_reqs=set() if mode == "not_ready" else {"request"},
+    )
+    scheduler = object.__new__(EasyMagpieCodecScheduler)
+    scheduler._codec_startup_wait_s = 0 if mode == "disabled" else 0.002
+    scheduler._codec_busy_wait_s = 0
+    scheduler.chunk_transfer_adapter = adapter
+    scheduler.running = [object()] if mode == "running" else []
+    scheduler.waiting = [request]
+
+    monkeypatch.setattr(scheduler_module, "sleep", lambda delay: pytest.fail("unexpected sleep"))
+
+    def fake_schedule(self, *args, **kwargs):
+        assert lock.locked()
+        return "scheduled"
+
+    monkeypatch.setattr(OmniGenerationScheduler, "schedule", fake_schedule)
+
+    assert scheduler.schedule() == "scheduled"
+
+
+def test_codec_busy_coalescing_collects_established_chunks(monkeypatch):
+    lock = threading.Lock()
+    first = SimpleNamespace(request_id="first", num_computed_tokens=8)
+    second = SimpleNamespace(request_id="second", num_computed_tokens=8)
+
+    class _ReadyCondition(threading.Condition):
+        def wait_for(self, predicate, timeout=None):
+            assert timeout == 0.001
+            assert predicate() is False
+            adapter._finished_load_reqs.add("second")
+            assert predicate() is True
+            return True
+
+    adapter = SimpleNamespace(
+        _easymagpie_chunk_lock=lock,
+        _easymagpie_chunk_ready=_ReadyCondition(lock),
+        _finished_load_reqs={"first"},
+    )
+    scheduler = object.__new__(EasyMagpieCodecScheduler)
+    scheduler._codec_startup_wait_s = 0
+    scheduler._codec_busy_wait_s = 0.001
+    scheduler.chunk_transfer_adapter = adapter
+    scheduler.running = [first, second]
+    scheduler.waiting = []
+
+    def fake_schedule(self, *args, **kwargs):
+        assert lock.locked()
+        return set(adapter._finished_load_reqs)
+
+    monkeypatch.setattr(OmniGenerationScheduler, "schedule", fake_schedule)
+
+    assert scheduler.schedule() == {"first", "second"}
+
+
+def test_codec_busy_coalescing_bypasses_full_ready_batch(monkeypatch):
+    lock = threading.Lock()
+    first = SimpleNamespace(request_id="first", num_computed_tokens=8)
+    second = SimpleNamespace(request_id="second", num_computed_tokens=8)
+    condition = threading.Condition(lock)
+    adapter = SimpleNamespace(
+        _easymagpie_chunk_lock=lock,
+        _easymagpie_chunk_ready=condition,
+        _finished_load_reqs={"first", "second"},
+    )
+    scheduler = object.__new__(EasyMagpieCodecScheduler)
+    scheduler._codec_startup_wait_s = 0
+    scheduler._codec_busy_wait_s = 0.001
+    scheduler.chunk_transfer_adapter = adapter
+    scheduler.running = [first, second]
+    scheduler.waiting = []
+
+    monkeypatch.setattr(condition, "wait_for", lambda *args, **kwargs: pytest.fail("unexpected wait"))
+    monkeypatch.setattr(OmniGenerationScheduler, "schedule", lambda self, *args, **kwargs: "scheduled")
+
+    assert scheduler.schedule() == "scheduled"
+
+
+def test_codec_busy_coalescing_wakes_for_first_audio(monkeypatch):
+    lock = threading.Lock()
+    established = SimpleNamespace(request_id="established", num_computed_tokens=8)
+    startup = SimpleNamespace(request_id="startup", num_computed_tokens=0)
+
+    class _ReadyCondition(threading.Condition):
+        def wait_for(self, predicate, timeout=None):
+            assert predicate() is False
+            adapter._finished_load_reqs.add("startup")
+            assert predicate() is True
+            return True
+
+    adapter = SimpleNamespace(
+        _easymagpie_chunk_lock=lock,
+        _easymagpie_chunk_ready=_ReadyCondition(lock),
+        _finished_load_reqs={"established"},
+    )
+    scheduler = object.__new__(EasyMagpieCodecScheduler)
+    scheduler._codec_startup_wait_s = 0
+    scheduler._codec_busy_wait_s = 0.001
+    scheduler.chunk_transfer_adapter = adapter
+    scheduler.running = [established, startup]
+    scheduler.waiting = []
+
+    monkeypatch.setattr(OmniGenerationScheduler, "schedule", lambda self, *args, **kwargs: "scheduled")
+
+    assert scheduler.schedule() == "scheduled"
+
+
+def test_codec_busy_coalescing_bypasses_ready_first_audio(monkeypatch):
+    lock = threading.Lock()
+    established = SimpleNamespace(request_id="established", num_computed_tokens=8)
+    startup = SimpleNamespace(request_id="startup", num_computed_tokens=0)
+    condition = threading.Condition(lock)
+    adapter = SimpleNamespace(
+        _easymagpie_chunk_lock=lock,
+        _easymagpie_chunk_ready=condition,
+        _finished_load_reqs={"established", "startup"},
+    )
+    scheduler = object.__new__(EasyMagpieCodecScheduler)
+    scheduler._codec_startup_wait_s = 0
+    scheduler._codec_busy_wait_s = 0.001
+    scheduler.chunk_transfer_adapter = adapter
+    scheduler.running = [established, startup]
+    scheduler.waiting = []
+
+    monkeypatch.setattr(condition, "wait_for", lambda *args, **kwargs: pytest.fail("unexpected wait"))
+    monkeypatch.setattr(OmniGenerationScheduler, "schedule", lambda self, *args, **kwargs: "scheduled")
+
+    assert scheduler.schedule() == "scheduled"
+
+
 def test_native_codec_chunk_appends_prompt_without_resetting_state(monkeypatch):
     adapter = object.__new__(OmniChunkTransferAdapter)
     adapter._easymagpie_num_quantizers = 2
     adapter._easymagpie_chunk_lock = threading.Lock()
+    adapter._easymagpie_chunk_ready = threading.Condition(adapter._easymagpie_chunk_lock)
     adapter.get_req_chunk = {"request": 1}
+    new_codes = torch.arange(6, dtype=torch.long).reshape(3, 2)
     request = SimpleNamespace(
         prompt_token_ids=[0, 0],
         request_id="request",
         _all_token_ids=[0, 0],
         num_computed_tokens=2,
         num_prompt_tokens=2,
-        additional_information=None,
+        additional_information={"codes": {"audio": torch.full((2, 2), 99, dtype=torch.long)}},
         update_block_hashes=lambda: None,
     )
 
     def fake_poll(self, req):
+        assert self._easymagpie_chunk_lock.locked()
         req.prompt_token_ids = [0]
         req._all_token_ids[:] = []
         req.num_computed_tokens = 0
-        req.additional_information = {"codes": {"audio": torch.ones((3, 2), dtype=torch.long)}}
+        info = dict(req.additional_information or {})
+        info["codes"] = {**info.get("codes", {}), "audio": new_codes}
+        info["meta"] = {"is_segment_finished": True}
+        req.additional_information = info
         return True
 
     monkeypatch.setattr(OmniChunkTransferAdapter, "_poll_single_request", fake_poll)
@@ -195,7 +439,8 @@ def test_native_codec_chunk_appends_prompt_without_resetting_state(monkeypatch):
     assert request._all_token_ids == [0, 0, 0, 0, 0]
     assert request.num_prompt_tokens == 5
     assert request.num_computed_tokens == 2
-    assert request.additional_information["codes"]["audio"].shape == (3, 2)
+    assert request.additional_information["codes"]["audio"] is new_codes
+    assert request.additional_information["meta"]["is_segment_finished"] is True
 
     prewarm_request = SimpleNamespace(
         prompt_token_ids=[0],
@@ -216,6 +461,7 @@ def test_native_codec_empty_segment_marker_does_not_reset_state(monkeypatch):
     adapter = object.__new__(OmniChunkTransferAdapter)
     adapter._easymagpie_num_quantizers = 2
     adapter._easymagpie_chunk_lock = threading.Lock()
+    adapter._easymagpie_chunk_ready = threading.Condition(adapter._easymagpie_chunk_lock)
     request = SimpleNamespace(
         prompt_token_ids=[0, 0, 0],
         request_id="request",
@@ -243,6 +489,86 @@ def test_native_codec_empty_segment_marker_does_not_reset_state(monkeypatch):
     assert request._all_token_ids == [0, 0, 0]
     assert request.num_prompt_tokens == 3
     assert request.num_computed_tokens == 3
+
+
+def test_native_codec_loaded_empty_segment_marker_is_not_scheduled(monkeypatch):
+    adapter = object.__new__(OmniChunkTransferAdapter)
+    adapter._easymagpie_num_quantizers = 2
+    adapter._easymagpie_chunk_lock = threading.Lock()
+    adapter._easymagpie_chunk_ready = threading.Condition(adapter._easymagpie_chunk_lock)
+    adapter._finished_load_reqs = {"request"}
+    request = SimpleNamespace(
+        prompt_token_ids=[0, 0, 0],
+        request_id="request",
+        _all_token_ids=[0, 0, 0],
+        num_computed_tokens=3,
+        num_prompt_tokens=3,
+        additional_information={"codes": {"audio": torch.ones((3, 2), dtype=torch.long)}},
+        update_block_hashes=lambda: None,
+    )
+
+    def fake_poll(self, req):
+        req.prompt_token_ids = []
+        req._all_token_ids[:] = []
+        req.num_prompt_tokens = 0
+        req.num_computed_tokens = 0
+        req.additional_information = {"meta": {"is_segment_finished": True}}
+        return True
+
+    monkeypatch.setattr(OmniChunkTransferAdapter, "_poll_single_request", fake_poll)
+
+    assert _poll_native_codec_chunk(adapter, request) is False
+    assert request.prompt_token_ids == [0, 0, 0]
+    assert request._all_token_ids == [0, 0, 0]
+    assert request.num_prompt_tokens == 3
+    assert request.num_computed_tokens == 3
+    assert adapter._finished_load_reqs == set()
+
+
+@pytest.mark.parametrize("marker", ["finished", "is_segment_finished"])
+def test_native_codec_loaded_control_marker_does_not_replay_previous_chunk(monkeypatch, marker):
+    adapter = object.__new__(OmniChunkTransferAdapter)
+    adapter._easymagpie_num_quantizers = 2
+    adapter._easymagpie_chunk_lock = threading.Lock()
+    adapter._easymagpie_chunk_ready = threading.Condition(adapter._easymagpie_chunk_lock)
+    adapter._finished_load_reqs = set()
+    ref = torch.tensor([0.1, -0.1])
+    request = SimpleNamespace(
+        prompt_token_ids=[0, 0, 0],
+        request_id="request",
+        _all_token_ids=[0, 0, 0],
+        num_computed_tokens=3,
+        num_prompt_tokens=3,
+        additional_information={
+            "codes": {"audio": torch.ones((3, 2), dtype=torch.long), "ref": ref},
+            "meta": {"chunk_seq": 1},
+        },
+        update_block_hashes=lambda: None,
+    )
+
+    def fake_poll(self, req):
+        # vLLM-Omni merges a control marker into the previous payload.
+        info = dict(req.additional_information)
+        info["meta"] = {**info.get("meta", {}), marker: True}
+        req.additional_information = info
+        req.prompt_token_ids = [0]
+        req._all_token_ids[:] = []
+        req.num_prompt_tokens = 1
+        req.num_computed_tokens = 0
+        self._finished_load_reqs.add(req.request_id)
+        return True
+
+    monkeypatch.setattr(OmniChunkTransferAdapter, "_poll_single_request", fake_poll)
+
+    assert _poll_native_codec_chunk(adapter, request) is False
+    assert request.prompt_token_ids == [0, 0, 0]
+    assert request._all_token_ids == [0, 0, 0]
+    assert request.num_prompt_tokens == 3
+    assert request.num_computed_tokens == 3
+    assert "audio" not in request.additional_information["codes"]
+    assert request.additional_information["codes"]["ref"] is ref
+    assert request.additional_information["meta"][marker] is True
+    assert request.request_id not in adapter._finished_load_reqs
 
 
 def test_native_codec_streaming_update_preserves_state_and_resumes_polling():

--- a/tests/collections/tts/easymagpie_vllm_omni/serving/test_stage_processors.py
+++ b/tests/collections/tts/easymagpie_vllm_omni/serving/test_stage_processors.py
@@ -166,7 +166,27 @@ def test_async_codec_forwards_terminal_audio_eos_row():
     )
 
     assert bool(terminal.meta.finished)
-    torch.testing.assert_close(terminal.codes.audio, torch.tensor([[1, 101], [2, 102], [1025, 777]]))
+    torch.testing.assert_close(
+        terminal.codes.audio,
+        torch.tensor([[1, 101], [2, 102], [1025, 777], [-1, -1]]),
+    )
+
+
+def test_async_codec_pads_short_terminal_chunk_to_steady_size():
+    manager = _manager()
+    manager.config.hf_config.streaming_speech_delay = 0
+    manager.connector.config["extra"]["codec_chunk_frames"] = 4
+    request = _Request()
+    request.resumable = False
+
+    assert talker2code2wav_async_chunk(manager, _output(1), request) is None
+    request.finished = True
+    terminal = talker2code2wav_async_chunk(manager, _output(2), request, is_finished=True)
+
+    torch.testing.assert_close(
+        terminal.codes.audio,
+        torch.tensor([[1, 101], [2, 102], [-1, -1], [-1, -1]]),
+    )
 
 
 def test_async_codec_buffer_drops_emitted_rows():
@@ -226,6 +246,26 @@ def test_async_codec_allows_larger_first_chunk_than_steady_state():
     first = talker2code2wav_async_chunk(manager, _output(5), request)
     assert first is not None
     torch.testing.assert_close(first.codes.audio, torch.tensor([[1, 101], [2, 102], [3, 103], [4, 104], [5, 105]]))
+
+
+def test_async_codec_gives_rolling_admissions_more_headroom():
+    manager = _manager()
+    manager.config.hf_config.streaming_speech_delay = 0
+    manager.connector.config["extra"].update(
+        {
+            "codec_chunk_frames": 4,
+            "codec_startup_chunk_frames": [2],
+            "codec_busy_startup_chunk_frames": [3],
+        }
+    )
+    manager._emp_emitted_chunks = defaultdict(int, existing=1)
+    request = _Request()
+
+    assert talker2code2wav_async_chunk(manager, _output(1), request) is None
+    assert talker2code2wav_async_chunk(manager, _output(2), request) is None
+    first = talker2code2wav_async_chunk(manager, _output(3), request)
+
+    torch.testing.assert_close(first.codes.audio, torch.tensor([[1, 101], [2, 102], [3, 103]]))
 
 
 def test_async_codec_rejects_invalid_startup_chunk_ramp():

--- a/tools/easymagpie_vllm_omni/Dockerfile.runtime
+++ b/tools/easymagpie_vllm_omni/Dockerfile.runtime
@@ -1,0 +1,13 @@
+ARG BASE_IMAGE=nemotron-speech:frontend-prefill
+FROM ${BASE_IMAGE}
+
+USER root
+COPY . /tmp/easymagpie_vllm_omni
+RUN python3 -m pip install --no-deps --no-build-isolation --no-cache-dir \
+        --upgrade --target /opt/nemotron-speech/engine/python \
+        /tmp/easymagpie_vllm_omni \
+    && install -m 0755 /tmp/easymagpie_vllm_omni/scripts/launch_engines.py \
+        /opt/nemotron-speech/bin/launch_easymagpie_engines.py \
+    && rm -rf /tmp/easymagpie_vllm_omni
+
+USER 65532:65532

--- a/tools/easymagpie_vllm_omni/deploy/easymagpie.yaml
+++ b/tools/easymagpie_vllm_omni/deploy/easymagpie.yaml
@@ -17,21 +17,28 @@ connectors:
       connector_get_max_wait_first_chunk: 3000
       connector_get_max_wait: 300
       # Native vLLM state pages retain the decoder's exact causal history.
-      # Two startup chunks provide playback headroom before steady-state streaming.
+      # Short startup chunks reduce TTFA and preserve playback headroom.
       codec_chunk_frames: 8
-      codec_startup_chunk_frames: [6, 6]
+      codec_startup_chunk_frames: [2, 2, 2, 4]
+      codec_busy_startup_chunk_frames: [8]
+      stage0_admission_coalesce_ms: 10
+      codec_startup_coalesce_ms: 2
+      codec_busy_coalesce_ms: 4
 
 stages:
   # Keep engine settings flat at the stage level; nested settings are not parsed.
   - stage_id: 0
-    max_num_seqs: 32
-    gpu_memory_utilization: 0.5
+    num_replicas: 2
+    max_num_seqs: 64
+    gpu_memory_utilization: 0.18
+    kv_cache_memory_bytes: 2147483648
     enforce_eager: false
     async_scheduling: true
     enable_prefix_caching: false
     enable_chunked_prefill: true
     max_num_batched_tokens: 4096
     max_model_len: 4096
+    max_cudagraph_capture_size: 64
     devices: "0"
     output_connectors:
       to_stage_1: connector_of_shared_memory
@@ -45,8 +52,10 @@ stages:
       max_tokens: 2048
 
   - stage_id: 1
-    max_num_seqs: 32
-    gpu_memory_utilization: 0.35
+    num_replicas: 1
+    max_num_seqs: 128
+    gpu_memory_utilization: 0.04
+    kv_cache_memory_bytes: 268435456
     # FP16 is faster, but introduces audible codec artifacts.
     dtype: float32
     enforce_eager: true
@@ -54,11 +63,14 @@ stages:
     enable_prefix_caching: false
     # Codec chunks are atomic: never split one request's state update across steps.
     enable_chunked_prefill: false
-    max_num_batched_tokens: 512
-    max_model_len: 512
+    max_num_batched_tokens: 1536
+    # Leave room for up to seven synthetic terminal padding frames.
+    max_model_len: 520
     devices: "0"
     input_connectors:
       from_stage_0: connector_of_shared_memory
+    engine_extras:
+      worker_cls: easymagpie_vllm_omni.runner.EasyMagpieCodecGPUGenerationWorker
     default_sampling_params:
       temperature: 0.0
       max_tokens: 65536

--- a/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/backbone_patches.py
+++ b/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/backbone_patches.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import torch
 import vllm.v1.attention.backends.mamba_attn as _mamba_attn
+from vllm import envs, platforms
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import ReLUSquaredActivation, get_act_fn
 
@@ -103,4 +104,48 @@ def patch_moe_routed_scale(backbone) -> int:
         mixer.register_forward_hook(_scale_output)
         patched += 1
     logger.info("FP16 MoE routed-scale fix installed on %d layers", patched)
+    return patched
+
+
+def patch_moe_router_logit_cast(backbone) -> int:
+    """Let the fused grouped router consume FP16 gate logits directly."""
+    if not platforms.current_platform.is_cuda() or not envs.VLLM_USE_FUSED_MOE_GROUPED_TOPK:
+        return 0
+
+    patched = 0
+    for layer in backbone.layers:
+        mixer = getattr(layer, "mixer", None)
+        if mixer is None or mixer.__class__.__name__ != "NemotronHMoE":
+            continue
+        gate = getattr(mixer, "gate", None)
+        router = getattr(getattr(mixer, "experts", None), "router", None)
+        weight = getattr(gate, "weight", None)
+        num_experts = weight.shape[0] if isinstance(weight, torch.Tensor) else 0
+        num_groups = getattr(router, "num_expert_group", 0)
+        specialized_gate = any(
+            getattr(gate, name, False)
+            for name in (
+                "allow_ll_bf16_gemm",
+                "allow_dsv3_router_gemm",
+                "allow_fp32_router_gemm",
+                "allow_bf16x3_router_gemm",
+                "allow_cublas_router_gemm",
+            )
+        )
+        if (
+            getattr(gate, "out_dtype", None) != torch.float32
+            or getattr(weight, "dtype", None) != torch.float16
+            or specialized_gate
+            or router.__class__.__name__ != "GroupedTopKRouter"
+            or getattr(router, "scoring_func", None) != "sigmoid"
+            or getattr(router, "e_score_correction_bias", None) is None
+            or not 0 < num_groups <= 32
+            or num_experts <= num_groups
+            or num_experts % num_groups
+            or getattr(router, "top_k", 33) > 32
+        ):
+            continue
+        gate.out_dtype = torch.float16
+        patched += 1
+    logger.info("FP16 fused-router logit cast removed on %d layers", patched)
     return patched

--- a/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/codec/kernels.py
+++ b/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/codec/kernels.py
@@ -27,17 +27,22 @@ from vllm.triton_utils import tl, triton
 @triton.jit
 def _packed_half_snake_kernel(
     input_ptr,
+    residual_ptr,
     alpha_ptr,
     output_ptr,
     numel,
     channels: tl.constexpr,
     snake_channels: tl.constexpr,
+    HAS_RESIDUAL: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
     offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
     mask = offsets < numel
     channel = offsets % channels
-    values = tl.load(input_ptr + offsets, mask=mask).to(tl.float32)
+    values = tl.load(input_ptr + offsets, mask=mask)
+    if HAS_RESIDUAL:
+        values += tl.load(residual_ptr + offsets, mask=mask)
+    values = values.to(tl.float32)
     alpha = tl.load(alpha_ptr + channel, mask=mask & (channel < snake_channels), other=1.0).to(tl.float32)
     sine = tl.sin(alpha * values)
     periodic = values + sine * sine / (alpha + 1.0e-9)
@@ -45,20 +50,28 @@ def _packed_half_snake_kernel(
     tl.store(output_ptr + offsets, tl.where(channel < snake_channels, periodic, leaky), mask=mask)
 
 
-def packed_half_snake(inputs: torch.Tensor, alpha: torch.Tensor) -> torch.Tensor:
+def packed_half_snake(
+    inputs: torch.Tensor,
+    alpha: torch.Tensor,
+    residual: torch.Tensor | None = None,
+) -> torch.Tensor:
     """Fused HalfSnake and leaky-ReLU over packed ``[tokens, channels]`` input."""
     inputs = inputs.contiguous()
+    if residual is not None:
+        residual = residual.contiguous()
     channels = inputs.shape[1]
     snake_channels = alpha.numel()
     outputs = torch.empty_like(inputs)
     block = 256
     _packed_half_snake_kernel[(triton.cdiv(inputs.numel(), block),)](
         inputs,
+        inputs if residual is None else residual,
         alpha,
         outputs,
         inputs.numel(),
         channels,
         snake_channels,
+        HAS_RESIDUAL=residual is not None,
         BLOCK=block,
     )
     return outputs

--- a/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/codec/model.py
+++ b/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/codec/model.py
@@ -85,10 +85,11 @@ class EasyMagpieCodecForConditionalGeneration(nn.Module):
         runtime_infos: list[dict[str, Any]],
         device: torch.device,
         request_token_spans: list[tuple[int, int]] | None = None,
-    ) -> tuple[torch.Tensor, list[int]]:
+    ) -> tuple[torch.Tensor, list[int], list[int]]:
         q = self.config.num_stacked_codebooks
         packed: list[torch.Tensor] = []
         frame_counts: list[int] = []
+        valid_sample_counts: list[int] = []
         if request_token_spans is not None and len(request_token_spans) != len(runtime_infos):
             raise ValueError(f"got {len(request_token_spans)} request spans for {len(runtime_infos)} codec payloads")
         for index, info in enumerate(runtime_infos):
@@ -100,7 +101,7 @@ class EasyMagpieCodecForConditionalGeneration(nn.Module):
                     continue
             codes = info.get("codes", {}) if isinstance(info, dict) else {}
             audio = codes.get("audio") if isinstance(codes, dict) else None
-            tensor = torch.as_tensor(audio, dtype=torch.long, device=device)
+            tensor = torch.as_tensor(audio, dtype=torch.long)
             if tensor.ndim == 2:
                 if tensor.shape[1] != q:
                     raise ValueError(f"expected codec payload [frames, {q}], got {tuple(tensor.shape)}")
@@ -120,9 +121,39 @@ class EasyMagpieCodecForConditionalGeneration(nn.Module):
                 )
             packed.append(rows)
             frame_counts.append(int(rows.shape[0]))
+            valid_sample_counts.append(self._valid_sample_count(rows))
         if not packed:
-            return torch.empty((0, q), dtype=torch.long, device=device), []
-        return torch.cat(packed, dim=0), frame_counts
+            empty = torch.empty((0, q), dtype=torch.long, device=device)
+            return empty, [], []
+        if all(rows.device.type == "cpu" for rows in packed):
+            codes = torch.cat(packed, dim=0).to(device=device, non_blocking=True)
+        else:
+            codes = torch.cat([rows.to(device=device, non_blocking=True) for rows in packed], dim=0)
+        return codes, frame_counts, valid_sample_counts
+
+    def _valid_sample_count(self, rows: torch.Tensor) -> int:
+        frames = int(rows.shape[0])
+        if frames == 0:
+            return 0
+
+        values = rows.detach()
+        if values.device.type != "cpu":
+            values = values.to(device="cpu")
+        padding = values.lt(0).all(dim=1).nonzero(as_tuple=False)
+        valid_frames = int(padding[0].item()) if padding.numel() else frames
+        if valid_frames == 0:
+            return 0
+
+        control = values[valid_frames - 1].view(-1, self.config.frame_stacking_factor).ge(
+            self.config.codebook_size
+        ).any(dim=0)
+        indices = control.nonzero(as_tuple=False)
+        if indices.numel():
+            valid_subframes = int(indices[0].item())
+            return (valid_frames - 1) * self.config.samples_per_frame + (
+                valid_subframes * self.config.samples_per_codec_frame
+            )
+        return valid_frames * self.config.samples_per_frame
 
     @torch.no_grad()
     def forward(
@@ -141,10 +172,12 @@ class EasyMagpieCodecForConditionalGeneration(nn.Module):
             input_ids = torch.empty((0,), dtype=torch.long, device=self.vllm_config.device_config.device)
 
         if codec_codes is not None:
-            codes = codec_codes.to(device=input_ids.device, dtype=torch.long)
+            source_codes = codec_codes.to(dtype=torch.long)
+            valid_sample_counts = [self._valid_sample_count(source_codes)]
+            codes = source_codes.to(device=input_ids.device, non_blocking=True)
             frame_counts = [int(codes.shape[0])]
         elif runtime_additional_information:
-            codes, frame_counts = self._payload_codes(
+            codes, frame_counts, valid_sample_counts = self._payload_codes(
                 runtime_additional_information,
                 input_ids.device,
                 request_token_spans,
@@ -159,6 +192,7 @@ class EasyMagpieCodecForConditionalGeneration(nn.Module):
                 device=input_ids.device,
             )
             frame_counts = [frames]
+            valid_sample_counts = [frames * self.config.samples_per_frame]
 
         if codes.shape[0] != input_ids.numel():
             raise ValueError(
@@ -167,21 +201,10 @@ class EasyMagpieCodecForConditionalGeneration(nn.Module):
             )
         packed_audio = self.codec(codes)
         outputs: list[torch.Tensor] = []
-        frame_offset = 0
         offset = 0
-        for frames in frame_counts:
+        for frames, valid_samples in zip(frame_counts, valid_sample_counts, strict=True):
             samples = frames * self.config.samples_per_frame
-            valid_samples = samples
-            if frames > 0:
-                last = codes[frame_offset + frames - 1].view(-1, self.config.frame_stacking_factor)
-                control = (last >= self.config.codebook_size).any(dim=0)
-                if control.any():
-                    valid_subframes = int(control.to(torch.int64).argmax().item())
-                    valid_samples -= (self.config.frame_stacking_factor - valid_subframes) * (
-                        self.config.samples_per_codec_frame
-                    )
             outputs.append(packed_audio[offset : offset + valid_samples].float())
-            frame_offset += frames
             offset += samples
         sample_rate = torch.tensor(self.config.output_sample_rate, dtype=torch.int32)
         return OmniOutput(

--- a/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/codec/packed.py
+++ b/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/codec/packed.py
@@ -49,6 +49,7 @@ CODEC_STATE_ELEMENTS = 4608
 @dataclass
 class CodecStateMetadata(Mamba1AttentionMetadata):
     codec_uniform: bool = False
+    codec_prefill_uniform: bool = False
     codec_max_query_len: int | None = None
 
 
@@ -66,13 +67,20 @@ class CodecStateMetadataBuilder(Mamba1AttentionMetadataBuilder):
     ) -> CodecStateMetadata:
         metadata = super().build(common_prefix_len, common_attn_metadata, fast_build=fast_build, **kwargs)
         uniform = metadata.num_decodes == 0 or metadata.num_prefills == 0
+        prefill_uniform = False
         max_query_len = None
         if metadata.num_prefills:
             starts = common_attn_metadata.query_start_loc_cpu[-metadata.num_prefills - 1 :]
             lengths = torch.diff(starts)
-            uniform = uniform and bool(torch.all(lengths == lengths[0]).item())
+            prefill_uniform = bool(torch.all(lengths == lengths[0]).item())
+            uniform = uniform and prefill_uniform
             max_query_len = int(lengths.max().item())
-        return replace(metadata, codec_uniform=uniform, codec_max_query_len=max_query_len)
+        return replace(
+            metadata,
+            codec_uniform=uniform,
+            codec_prefill_uniform=prefill_uniform,
+            codec_max_query_len=max_query_len,
+        )
 
     def build_for_cudagraph_capture(
         self,
@@ -107,14 +115,13 @@ class PackedFiniteScalarDequantizer(nn.Module):
             torch.tensor([1, *config.num_levels_per_group[:-1]], dtype=torch.int64),
             dim=0,
         )
-        self.num_groups = config.num_codebooks
-        self.register_buffer("levels", levels, persistent=False)
-        self.register_buffer("bases", bases, persistent=False)
+        indices = torch.arange(config.codebook_size, dtype=torch.int64).unsqueeze(-1)
+        scale = torch.div(levels, 2, rounding_mode="floor")
+        lookup = ((torch.div(indices, bases, rounding_mode="floor") % levels - scale) / scale).float()
+        self.register_buffer("lookup", lookup, persistent=False)
 
     def forward(self, indices: torch.Tensor) -> torch.Tensor:
-        nonnegative = torch.div(indices.unsqueeze(-1), self.bases, rounding_mode="floor") % self.levels
-        scale = torch.div(self.levels, 2, rounding_mode="floor")
-        return ((nonnegative - scale) / scale).flatten(start_dim=1)
+        return F.embedding(indices, self.lookup).flatten(start_dim=1)
 
 
 class PackedHalfSnake(nn.Module):
@@ -124,11 +131,13 @@ class PackedHalfSnake(nn.Module):
         # Preserve the NeMo checkpoint shape.
         self.alpha = nn.Parameter(torch.ones(1, self.snake_channels, 1))
 
-    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+    def forward(self, inputs: torch.Tensor, residual: torch.Tensor | None = None) -> torch.Tensor:
         if inputs.is_cuda:
             from easymagpie_vllm_omni.codec.kernels import packed_half_snake
 
-            return packed_half_snake(inputs, self.alpha)
+            return packed_half_snake(inputs, self.alpha, residual)
+        if residual is not None:
+            inputs = inputs + residual
         snake_in = inputs[:, : self.snake_channels]
         alpha = self.alpha.reshape(1, -1)
         snake_out = snake_in + torch.sin(alpha * snake_in).square() / (alpha + 1e-9)
@@ -343,20 +352,7 @@ class PackedCausalConv1d(CodecStateLayer):
             parts = []
             decode_rows = metadata.num_decode_tokens * self.time_factor
             if metadata.num_decodes:
-                state_indices_d = self._decode_state_indices(metadata)
-                parts.append(
-                    packed_causal_conv1d(
-                        inputs[:decode_rows],
-                        self.conv.weight,
-                        self.conv.bias,
-                        self.kv_cache[0],
-                        state_indices_d,
-                        state_indices_d,
-                        state_indices_d,
-                        time_factor=self.time_factor,
-                        is_decode=True,
-                    )
-                )
+                parts.append(self._uniform_cuda(inputs[:decode_rows], metadata, is_decode=True))
             if metadata.num_prefills:
                 if (
                     metadata.query_start_loc_p is None
@@ -364,19 +360,23 @@ class PackedCausalConv1d(CodecStateLayer):
                     or metadata.has_initial_states_p is None
                 ):
                     raise RuntimeError("incomplete codec prefill metadata")
-                parts.append(
-                    packed_causal_conv1d(
-                        inputs[decode_rows:],
-                        self.conv.weight,
-                        self.conv.bias,
-                        self.kv_cache[0],
-                        metadata.query_start_loc_p,
-                        metadata.state_indices_tensor_p,
-                        metadata.has_initial_states_p,
-                        time_factor=self.time_factor,
-                        max_query_len=self._prefill_max_query_len(metadata),
+                prefill_inputs = inputs[decode_rows:]
+                if getattr(metadata, "codec_prefill_uniform", False):
+                    parts.append(self._uniform_cuda(prefill_inputs, metadata, is_decode=False))
+                else:
+                    parts.append(
+                        packed_causal_conv1d(
+                            prefill_inputs,
+                            self.conv.weight,
+                            self.conv.bias,
+                            self.kv_cache[0],
+                            metadata.query_start_loc_p,
+                            metadata.state_indices_tensor_p,
+                            metadata.has_initial_states_p,
+                            time_factor=self.time_factor,
+                            max_query_len=self._prefill_max_query_len(metadata),
+                        )
                     )
-                )
             if len(parts) == 1:
                 outputs = parts[0]
             else:
@@ -422,52 +422,6 @@ class PackedCausalConvTranspose1d(CodecStateLayer):
         state.copy_(joined[-1:])
         return self.activation(outputs)
 
-    def _uniform_cuda(
-        self,
-        inputs: torch.Tensor,
-        metadata: Mamba1AttentionMetadata,
-        *,
-        is_decode: bool,
-    ) -> torch.Tensor:
-        """Run a uniform packed batch through one batched cuDNN deconvolution."""
-        from easymagpie_vllm_omni.codec.kernels import gather_packed_state_inputs, update_packed_state
-
-        inputs = inputs.contiguous()
-        if is_decode:
-            state_indices = self._decode_state_indices(metadata)
-            query_start_loc = state_indices
-            has_initial = state_indices
-        else:
-            state_indices = metadata.state_indices_tensor_p
-            query_start_loc = metadata.query_start_loc_p
-            has_initial = metadata.has_initial_states_p
-            if state_indices is None or query_start_loc is None or has_initial is None:
-                raise RuntimeError("incomplete codec prefill metadata")
-
-        joined = gather_packed_state_inputs(
-            inputs,
-            self.kv_cache[0],
-            state_indices,
-            has_initial,
-            history=1,
-            is_decode=is_decode,
-        )
-        outputs = self.conv(joined.transpose(1, 2))[:, :, self.stride : -self.stride]
-        outputs = outputs.transpose(1, 2).contiguous()
-
-        update_packed_state(
-            inputs,
-            self.kv_cache[0],
-            query_start_loc,
-            state_indices,
-            has_initial,
-            channels=self.in_channels,
-            history=1,
-            time_factor=self.time_factor,
-            is_decode=is_decode,
-        )
-        return outputs.reshape(-1, self.conv.out_channels)
-
     def forward(self, inputs: torch.Tensor) -> torch.Tensor:
         metadata = self._metadata()
         if metadata is None:
@@ -478,12 +432,6 @@ class PackedCausalConvTranspose1d(CodecStateLayer):
             raise RuntimeError(f"codec metadata describes {expected_rows} rows, got {inputs.shape[0]}")
         if inputs.is_cuda:
             from easymagpie_vllm_omni.codec.kernels import packed_causal_conv_transpose1d
-
-            if getattr(metadata, "codec_uniform", False):
-                if metadata.num_decodes and metadata.num_prefills:
-                    raise NotImplementedError("uniform codec batches cannot mix prefill and decode")
-                outputs = self._uniform_cuda(inputs, metadata, is_decode=bool(metadata.num_decodes))
-                return self.activation(outputs)
 
             parts = []
             decode_rows = metadata.num_decode_tokens * self.time_factor
@@ -571,7 +519,7 @@ class PackedResidualBlock(nn.Module):
         self.output_activation = PackedHalfSnake(channels)
 
     def forward(self, inputs: torch.Tensor) -> torch.Tensor:
-        return self.output_activation(inputs + self.skip_conv(self.input_conv(inputs)))
+        return self.output_activation(self.skip_conv(self.input_conv(inputs)), inputs)
 
 
 class PackedResNetDecoder(nn.Module):

--- a/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/easymagpie.py
+++ b/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/easymagpie.py
@@ -26,6 +26,9 @@ terminate the stream with ``text_eos_id``.
 from __future__ import annotations
 
 import bisect
+import glob
+import json
+import os
 from collections.abc import Callable, Iterable
 from typing import Any, Optional
 
@@ -33,6 +36,7 @@ import torch
 from easymagpie_vllm_omni.backbone_patches import (
     patch_mamba_streaming_decode,
     patch_moe_routed_scale,
+    patch_moe_router_logit_cast,
     patch_shared_expert_activation,
 )
 from easymagpie_vllm_omni.config import EasyMagpieOmniArch
@@ -90,6 +94,8 @@ def _merge_streaming_text_chunk(
 
 # Context text used when the request omits ``context_text``
 _DEFAULT_CONTEXT_TEXT = "[EN]"
+_CONTEXT_REGISTRY_FILE = "contexts.json"
+_CONTEXT_BUNDLE_FILE = "contexts.safetensors"
 
 
 # This class is not wrapped in ``@support_torch_compile``: the Nemotron-H
@@ -120,6 +126,9 @@ class EasyMagpieTTSForConditionalGeneration(
     has_preprocess: bool = True
     has_postprocess: bool = True
     have_multimodal_outputs: bool = True
+    use_async_omni_output: bool = True
+    eager_omni_postprocess_before_async_output: bool = True
+    postprocess_uses_req_infos: bool = False
 
     # Stage 1 (Code2Wav) consumes only the sampled codes (multimodal outputs),
     # never the backbone hidden states. Opt out of attaching ``hidden`` to the
@@ -131,6 +140,7 @@ class EasyMagpieTTSForConditionalGeneration(
     gpu_resident_buffer_keys: set[str] = {
         "last_audio_codes",
         "last_phoneme_token",
+        "phoneme_ended",
         "last_hidden",
     }
 
@@ -171,6 +181,7 @@ class EasyMagpieTTSForConditionalGeneration(
         # ignoring the checkpoint's mlp_hidden_act. Restore the configured
         # activation (no-op when the backbone has no MoE layers).
         patch_shared_expert_activation(self.backbone)
+        patch_moe_router_logit_cast(self.backbone)
         # vLLM's FusedMoE defers routed_scaling_factor to the decoder layer in
         # FP16, but NemotronH's decoder layer never compensates, so the MoE
         # output is under-scaled by routed_scaling_factor. Restore it (no-op in
@@ -270,18 +281,99 @@ class EasyMagpieTTSForConditionalGeneration(
         # ``compute_logits``
         self._sample_stop = torch.zeros(max_num_tokens, dtype=torch.bool)
 
-        # ── Assembled prefill context embeddings (the only context cache) ──
+        # ── Resident speaker contexts + assembled prefill cache ───────────
         # ``preprocess`` runs on the host, once per request, serially on the
         # runner's critical path, so per-request speaker-tensor transfer + the
         # tokenize/embed/cat dominate TTFT under concurrency. Cache the *whole*
         # assembled context ``[task | speaker | context_text]`` per
         # ``(task_mode_id, speaker_id, context_text, device)`` (see
         # :meth:`_build_prefill_embeds`): for a known speaker it is identical on
-        # every request, so the cache subsumes a separate speaker-embedding table
-        # — the speaker ``.pt`` is read from disk only on the (first) cache miss
-        # for that combo (see :meth:`_load_known_speaker_embedding`), then never
-        # again. Custom raw-tensor voices are one-off and skip the cache.
+        # every request. All bundle-defined speaker tensors are loaded eagerly
+        # and registered as non-persistent buffers so there is no request-path
+        # file I/O; the assembled cache still avoids repeated tokenize/embed/cat.
+        # Custom raw-tensor voices are one-off and skip the cache.
+        self._speaker_embedding_buffers: dict[str, str] = {}
+        self._speaker_context_registry: dict[str, dict[str, Any]] = {}
+        self._preload_known_speaker_embeddings()
         self._prefill_cache: dict[tuple, torch.Tensor] = {}
+
+    def _register_speaker_embedding(self, speaker_id: str, embedding: torch.Tensor) -> None:
+        if not isinstance(embedding, torch.Tensor) or embedding.ndim != 2:
+            raise RuntimeError(
+                f"EasyMagpieTTS speaker {speaker_id!r} must have a 2-D (T_audio, embedding_dim) tensor, "
+                f"got {type(embedding).__name__}"
+            )
+        if embedding.shape[0] <= 0 or embedding.shape[1] != self.embedding_dim:
+            raise RuntimeError(
+                f"EasyMagpieTTS speaker {speaker_id!r} has incompatible shape {tuple(embedding.shape)}; "
+                f"expected (*, {self.embedding_dim})"
+            )
+        if not bool(torch.isfinite(embedding).all()):
+            raise RuntimeError(f"EasyMagpieTTS speaker {speaker_id!r} contains non-finite values")
+        buffer_name = f"_speaker_context_{len(self._speaker_embedding_buffers)}"
+        self.register_buffer(
+            buffer_name,
+            embedding.to(device=self._combined_embeddings.device, dtype=self._combined_embeddings.dtype),
+            persistent=False,
+        )
+        self._speaker_embedding_buffers[speaker_id] = buffer_name
+
+    def _preload_known_speaker_embeddings(self) -> None:
+        """Load every bundle-defined speaker tensor during Stage-0 initialization."""
+        speaker_dir = os.path.join(self.model_path, "speaker_embeddings")
+        registry_path = os.path.join(speaker_dir, _CONTEXT_REGISTRY_FILE)
+        bundle_path = os.path.join(speaker_dir, _CONTEXT_BUNDLE_FILE)
+        if os.path.exists(registry_path) or os.path.exists(bundle_path):
+            if not os.path.isfile(registry_path) or not os.path.isfile(bundle_path):
+                raise RuntimeError(
+                    "EasyMagpieTTS requires both speaker_embeddings/contexts.json and "
+                    "speaker_embeddings/contexts.safetensors"
+                )
+            with open(registry_path, encoding="utf-8") as stream:
+                registry = json.load(stream)
+            contexts = registry.get("contexts")
+            if registry.get("schema_version") != 1 or not isinstance(contexts, dict) or not contexts:
+                raise RuntimeError("EasyMagpieTTS context registry is invalid")
+            from safetensors.torch import load_file
+
+            tensors = load_file(bundle_path, device="cpu")
+            expected_keys = set()
+            for speaker_id in sorted(contexts):
+                entry = contexts[speaker_id]
+                if not isinstance(entry, dict):
+                    raise RuntimeError(f"EasyMagpieTTS context registry entry {speaker_id!r} is invalid")
+                tensor_key = entry.get("tensor_key")
+                context_text = entry.get("context_text")
+                prompt_len = entry.get("prompt_len")
+                if (
+                    not isinstance(tensor_key, str)
+                    or not isinstance(context_text, str)
+                    or not context_text
+                    or not isinstance(prompt_len, int)
+                    or prompt_len <= 0
+                ):
+                    raise RuntimeError(f"EasyMagpieTTS context registry entry {speaker_id!r} is invalid")
+                expected_keys.add(tensor_key)
+                if tensor_key not in tensors:
+                    raise RuntimeError(
+                        f"EasyMagpieTTS context tensor key {tensor_key!r} for speaker {speaker_id!r} is missing"
+                    )
+                self._register_speaker_embedding(speaker_id, tensors[tensor_key])
+                self._speaker_context_registry[speaker_id] = entry
+            if set(tensors) != expected_keys:
+                raise RuntimeError("EasyMagpieTTS context bundle keys do not match contexts.json")
+        else:
+            for path in sorted(glob.glob(os.path.join(speaker_dir, "*.pt"))):
+                speaker_id = os.path.splitext(os.path.basename(path))[0]
+                try:
+                    loaded = torch.load(path, map_location="cpu", weights_only=True)
+                except TypeError:
+                    loaded = torch.load(path, map_location="cpu")
+                embedding = loaded["speaker_encoding"] if isinstance(loaded, dict) else loaded
+                self._register_speaker_embedding(speaker_id, embedding)
+        logger.info(
+            "EasyMagpieTTS preloaded %d speaker context tensor(s)", len(self._speaker_embedding_buffers)
+        )
 
     # ------------------------------------------------------------------
     # Embedding helpers
@@ -571,10 +663,8 @@ class EasyMagpieTTSForConditionalGeneration(
     def make_omni_output(self, model_outputs, **_: Any) -> OmniOutput:
         """Surface the sampled codes (``BT x num_codebooks``).
 
-        The codes are exposed under **two** keys so the same model serves both
-        deployment shapes:
+        The output key follows the deployment shape:
 
-        * ``audio_codes`` — the flat single-stage key read by :meth:`postprocess`.
         * ``codes.audio`` — the nested :class:`~vllm_omni.data_entry_keys.OmniPayload`
           layout consumed by the in-engine two-stage pipeline (Code2Wav). The
           AR runner's ``flatten_payload`` turns this into the ``codes.audio``
@@ -598,7 +688,7 @@ class EasyMagpieTTSForConditionalGeneration(
             )
         return OmniOutput(
             text_hidden_states=hidden,
-            multimodal_outputs={"audio_codes": audio_codes, "codes": {"audio": audio_codes}},
+            multimodal_outputs={"codes": {"audio": audio_codes}},
         )
 
     # ------------------------------------------------------------------
@@ -750,6 +840,15 @@ class EasyMagpieTTSForConditionalGeneration(
         """
         speaker_id = info_dict.get("speaker_id")
         context_text = info_dict.get("context_text") or _DEFAULT_CONTEXT_TEXT
+        registered_context = self._speaker_context_registry.get(speaker_id)
+        if registered_context is not None:
+            expected_context_text = registered_context["context_text"]
+            if context_text != expected_context_text:
+                raise ValueError(
+                    f"EasyMagpieTTS speaker {speaker_id!r} requires context_text "
+                    f"{expected_context_text!r}, got {context_text!r}"
+                )
+            context_text = expected_context_text
         if self.task_embedding is not None:
             task_mode_id = int(info_dict.get("task_mode_id", 0) or 0)
             task_mode_id = max(0, min(task_mode_id, self.num_task_embeddings - 1))
@@ -826,13 +925,9 @@ class EasyMagpieTTSForConditionalGeneration(
     def _resolve_speaker_embedding(self, device: torch.device, info_dict: dict[str, Any]) -> torch.Tensor:
         """Return the speaker context-audio embedding on ``device`` in model dtype.
 
-        For a known ``speaker_id`` the embedding is read from disk by
-        :meth:`_load_known_speaker_embedding`; this only ever runs on a
-        prefill-cache miss (see :meth:`_build_prefill_embeds`), i.e. once per
-        ``(speaker_id, context_text, task)`` combo, so there is no separate
-        speaker-embedding table — the assembled prefill cache subsumes it. Falls
-        back to a raw ``speaker_embedding`` tensor (custom / one-off voice),
-        copied H2D here. Exactly one of the two must be supplied.
+        Known ``speaker_id`` tensors are preloaded during model initialization.
+        Falls back to a raw ``speaker_embedding`` tensor (custom / one-off
+        voice), copied H2D here. Exactly one of the two must be supplied.
         """
         dtype = self._combined_embeddings.dtype
         speaker_id = info_dict.get("speaker_id")
@@ -849,36 +944,16 @@ class EasyMagpieTTSForConditionalGeneration(
         return speaker_embedding.to(device=device, dtype=dtype)
 
     def _load_known_speaker_embedding(self, speaker_id: str, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
-        """Read one known speaker's embedding from ``<model_path>/speaker_embeddings/<id>.pt``.
-
-        The file holds either a bare ``(T_audio, embedding_dim)`` tensor or a dict
-        with a ``speaker_encoding`` key (the converter/caller layout); it is moved
-        to ``device`` in model dtype. Called only on a prefill-cache miss, so each
-        known speaker is read at most once per ``(context_text, task)`` combo and
-        the result is then baked into ``self._prefill_cache``. Read from disk (not
-        via :meth:`load_weights`) so known speakers work even under
-        ``--load-format dummy``, which skips weight loading.
-        """
-        import glob
-        import os
-
-        spk_dir = os.path.join(self.model_path, "speaker_embeddings")
-        path = os.path.join(spk_dir, f"{speaker_id}.pt")
-        if not os.path.exists(path):
-            known = sorted(os.path.splitext(os.path.basename(p))[0] for p in glob.glob(os.path.join(spk_dir, "*.pt")))
+        """Return a known speaker tensor that was loaded during initialization."""
+        buffer_name = self._speaker_embedding_buffers.get(speaker_id)
+        if buffer_name is None:
+            known = sorted(self._speaker_embedding_buffers)
             raise AssertionError(
                 f"EasyMagpieTTS preprocess got unknown speaker_id {speaker_id!r}; known speakers: {known}. "
-                "Register it under the checkpoint's speaker_embeddings/ dir, or pass a raw "
-                "speaker_embedding tensor for a custom voice."
+                "Register it in the checkpoint context bundle, or pass a raw speaker_embedding "
+                "tensor for a custom voice."
             )
-        loaded = torch.load(path, map_location="cpu")
-        embedding = loaded["speaker_encoding"] if isinstance(loaded, dict) else loaded
-        assert isinstance(embedding, torch.Tensor) and embedding.ndim == 2, (
-            f"EasyMagpieTTS: speaker embedding {path} must be a 2-D (T_audio, embedding_dim) tensor; "
-            f"got {type(embedding).__name__}"
-            + (f" with ndim={embedding.ndim}" if isinstance(embedding, torch.Tensor) else "")
-        )
-        return embedding.to(device=device, dtype=dtype)
+        return getattr(self, buffer_name).to(device=device, dtype=dtype)
 
     def _maybe_set_lt_sampling_params(self, info_dict: dict[str, Any]) -> None:
         """Apply per-request audio sampling params to the local transformer.
@@ -976,8 +1051,15 @@ class EasyMagpieTTSForConditionalGeneration(
         instance (``context_text`` / ``has_task_embedding`` are intentionally not
         params — they must match the precomputed checkpoint, not be overridden).
         """
-        import json
-        import os
+        registry_path = os.path.join(model_path, "speaker_embeddings", _CONTEXT_REGISTRY_FILE)
+        if os.path.isfile(registry_path):
+            with open(registry_path, encoding="utf-8") as stream:
+                registry = json.load(stream)
+            contexts = registry.get("contexts")
+            entry = contexts.get(speaker_id) if isinstance(contexts, dict) else None
+            if not isinstance(entry, dict) or not isinstance(entry.get("prompt_len"), int):
+                raise FileNotFoundError(f"EasyMagpieTTS: no registered context for speaker_id {speaker_id!r}")
+            return int(entry["prompt_len"])
 
         path = os.path.join(model_path, "speaker_embeddings", f"{speaker_id}.pt")
         if not os.path.exists(path):
@@ -1049,24 +1131,24 @@ class EasyMagpieTTSForConditionalGeneration(
         # with phoneme BOS), then feeds back the previous step's prediction, and
         # closes one step after the model emits the phoneme EOS (sticky flag).
         if self.has_phoneme:
-            phoneme_ended = bool(info_dict.get("phoneme_ended", False))
-            feed_eos = False
-            if phoneme_ended or decode_offset < self.phonemes_delay:
+            phoneme_ended = torch.as_tensor(
+                info_dict.get("phoneme_ended", False), device=device, dtype=torch.bool
+            ).reshape(())
+            if decode_offset < self.phonemes_delay:
                 self._dec_phoneme_valid[start] = 0
             elif decode_offset == self.phonemes_delay:
                 self._dec_phoneme_tokens[start].fill_(self.phoneme_bos_id)
-                self._dec_phoneme_valid[start] = 1
+                self._dec_phoneme_valid[start].copy_((~phoneme_ended).to(torch.long))
             else:
                 last_phon = info_dict.get("last_phoneme_token")
                 if isinstance(last_phon, torch.Tensor) and last_phon.numel() > 0:
                     p = last_phon.to(device=device, dtype=torch.long).reshape(-1)[: self.arch.phoneme_stacking_factor]
                     self._dec_phoneme_tokens[start, : p.shape[0]].copy_(p)
-                    self._dec_phoneme_valid[start] = 1
-                    feed_eos = bool((p == self.phoneme_eos_id).any())
+                    self._dec_phoneme_valid[start].copy_((~phoneme_ended).to(torch.long))
+                    phoneme_ended = phoneme_ended | (p == self.phoneme_eos_id).any()
                 else:
                     self._dec_phoneme_valid[start] = 0
-            if phoneme_ended or feed_eos:
-                info_update["phoneme_ended"] = True
+            info_update["phoneme_ended"] = phoneme_ended
 
         # ── Audio channel ── opens at decode step == ``speech_delay`` (seeded with
         # audio BOS), then feeds back the previous frame's codes. For the leading
@@ -1200,7 +1282,13 @@ class EasyMagpieTTSForConditionalGeneration(
         # Nemotron-H names. The wrapper's ``backbone -> model`` prefix rule is a
         # no-op here because we already stripped the ``decoder.`` prefix.
         backbone_weights = list(NemotronHForCausalLM.hf_to_vllm_mapper.apply(backbone_weights))
-        backbone_loaded = self.backbone.load_weights(backbone_weights)
+        if hasattr(self.backbone, "load_weights"):
+            backbone_loaded = self.backbone.load_weights(backbone_weights)
+        else:
+            # vLLM 0.26 moved generic loading from the inner model to the causal-LM wrapper.
+            from vllm.model_executor.models.utils import AutoWeightsLoader
+
+            backbone_loaded = AutoWeightsLoader(self.backbone).load_weights(backbone_weights)
         loaded |= {f"backbone.{n}" for n in backbone_loaded}
 
         # Derived runtime state.

--- a/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/local_transformer.py
+++ b/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/local_transformer.py
@@ -195,7 +195,7 @@ class EasyMagpieCodeLoop(nn.Module):
         forbidden = cp.forbidden_mask
         codes: list[torch.Tensor] = []
         for k in range(n):
-            hidden = cp.local_transformer(buf)
+            hidden = cp.local_transformer(buf[:, : k + 1, :])
             row = cp.local_transformer_audio_out_projection(hidden[:, k, :])
             logits = cp.local_transformer_out_projections[k](row)
             logits = logits.masked_fill(forbidden, float("-inf")) / temperature

--- a/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/local_transformer.py
+++ b/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/local_transformer.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Autoregressive intra-frame codebook predictor for EasyMagpieTTS."""
+
 from __future__ import annotations
 
 import torch
 from easymagpie_vllm_omni.config import EasyMagpieOmniArch
 from torch import nn
 from vllm.compilation.decorators import support_torch_compile
-from vllm.config import VllmConfig
+from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.forward_context import get_forward_context, is_forward_context_available
 
 # Default top-k width for audio-codebook sampling. Because ``torch.topk``'s ``k``
 # shapes tensors inside the captured graph, this becomes a capture-time constant.
@@ -351,4 +353,18 @@ class EasyMagpieCodePredictor(nn.Module):
         noise.log_().neg_().log_().neg_()
 
         self._temperature_buf.fill_(max(float(self.temperature), _MIN_SAMPLING_TEMPERATURE))
-        return self._code_loop(in_buf, noise, self._temperature_buf)
+        if not is_forward_context_available():
+            return self._code_loop(in_buf, noise, self._temperature_buf)
+
+        # This dense submodel has no attention split points, so its independently
+        # compiled graph must not inherit PIECEWISE mode from a mixed
+        # prefill/decode pass through the outer hybrid model.
+        ctx = get_forward_context()
+        runtime_mode = ctx.cudagraph_runtime_mode
+        if runtime_mode != CUDAGraphMode.PIECEWISE:
+            return self._code_loop(in_buf, noise, self._temperature_buf)
+        ctx.cudagraph_runtime_mode = CUDAGraphMode.FULL
+        try:
+            return self._code_loop(in_buf, noise, self._temperature_buf)
+        finally:
+            ctx.cudagraph_runtime_mode = runtime_mode

--- a/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/runner.py
+++ b/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/runner.py
@@ -21,13 +21,23 @@ preserving model-generated state such as ``decode_offset`` and ``text_tokens``.
 """
 from __future__ import annotations
 
+import json
+import os
+from collections.abc import Mapping
+from pathlib import Path
 from typing import Any
 
 import torch
 from vllm_omni.engine.serialization import deserialize_additional_information
 from vllm_omni.worker import gpu_ar_worker
+from vllm_omni.worker import gpu_generation_worker
 from vllm_omni.worker.gpu_ar_model_runner import GPUARModelRunner
 from vllm_omni.worker.gpu_ar_worker import GPUARWorker
+from vllm_omni.worker.gpu_generation_model_runner import GPUGenerationModelRunner
+from vllm_omni.worker.gpu_generation_worker import GPUGenerationWorker
+
+_trace_dir = os.environ.get("EASYMAGPIE_STAGE0_TRACE_DIR")
+_STAGE0_TRACE_DIR = Path(_trace_dir) if _trace_dir else None
 
 
 def merge_streaming_additional_information(
@@ -65,6 +75,66 @@ def merge_streaming_additional_information(
 class EasyMagpieGPUARModelRunner(GPUARModelRunner):
     """GPU AR runner that restores streaming chunk metadata propagation."""
 
+    def _build_omni_async_snapshot_payload(
+        self,
+        *,
+        hidden_states: torch.Tensor,
+        staged_hidden_states_cpu: torch.Tensor | None,
+        multimodal_outputs: Any,
+    ) -> dict[str, Any]:
+        payload = super()._build_omni_async_snapshot_payload(
+            hidden_states=hidden_states,
+            staged_hidden_states_cpu=staged_hidden_states_cpu,
+            multimodal_outputs=multimodal_outputs,
+        )
+        payload.setdefault("hidden_states", hidden_states[:, :0])
+        return payload
+
+    def _update_intermediate_buffer(self, req_id: str, upd: dict) -> None:
+        if not isinstance(upd, dict) or not upd:
+            return
+        request = self.requests.get(req_id)
+        if request is None:
+            return
+
+        model = getattr(self, "model", None)
+        gpu_keys = getattr(model, "gpu_resident_buffer_keys", set())
+        top_level_gpu_keys = {key for key in gpu_keys if isinstance(key, str)}
+        nested_gpu_keys = {key for key in gpu_keys if isinstance(key, tuple) and len(key) == 2}
+        existing = self.model_intermediate_buffer.setdefault(req_id, {})
+        for key, value in upd.items():
+            if isinstance(value, dict):
+                existing_sub = existing.setdefault(key, {})
+                resident_qualifiers = {qualifier for type_key, qualifier in nested_gpu_keys if type_key == key}
+                for qualifier, subvalue in value.items():
+                    self._store_value(existing_sub, qualifier, subvalue, resident_qualifiers)
+            else:
+                self._store_value(existing, key, value, top_level_gpu_keys)
+        self._trace_stage0_prediction(req_id, upd, existing)
+        request.additional_information_cpu = existing
+
+    @staticmethod
+    def _trace_stage0_prediction(req_id: str, upd: dict, existing: dict) -> None:
+        if _STAGE0_TRACE_DIR is None or existing.get("_omni_is_prefill", False):
+            return
+        audio = upd.get("last_audio_codes")
+        phoneme = upd.get("last_phoneme_token")
+        if not isinstance(audio, torch.Tensor) or not isinstance(phoneme, torch.Tensor):
+            return
+
+        phoneme_count = phoneme.numel()
+        values = torch.cat((phoneme.reshape(-1), audio.reshape(-1))).to("cpu").tolist()
+        row = {
+            "request_id": req_id,
+            "decode_offset": int(existing.get("decode_offset", 1)) - 1,
+            "phoneme_tokens": values[:phoneme_count],
+            "audio_codes": values[phoneme_count:],
+        }
+        _STAGE0_TRACE_DIR.mkdir(parents=True, exist_ok=True)
+        path = _STAGE0_TRACE_DIR / f"stage0.{os.getpid()}.jsonl"
+        with path.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(row) + "\n")
+
     def _update_streaming_request(self, req_id, new_req_data):
         payload = getattr(new_req_data, "additional_information", None)
         incoming = deserialize_additional_information(payload)
@@ -92,3 +162,43 @@ class EasyMagpieGPUARWorker(GPUARWorker):
             return super().init_device()
         finally:
             gpu_ar_worker.GPUARModelRunner = original_runner_cls
+
+
+def batch_waveforms_to_cpu(outputs: Any) -> Any:
+    """Copy a per-request waveform list to CPU in one transfer."""
+    if not isinstance(outputs, list) or len(outputs) < 2 or not all(isinstance(x, torch.Tensor) for x in outputs):
+        return outputs
+    if len({(x.device, x.dtype) for x in outputs}) != 1:
+        return outputs
+
+    sizes = [x.numel() for x in outputs]
+    shapes = [x.shape for x in outputs]
+    packed = torch.cat([x.detach().reshape(-1) for x in outputs]).to("cpu").contiguous()
+    return [part.view(shape) for part, shape in zip(packed.split(sizes), shapes, strict=True)]
+
+
+class EasyMagpieCodecGPUGenerationModelRunner(GPUGenerationModelRunner):
+    """Batch Stage-1 waveform D2H before upstream output handling."""
+
+    def sample_tokens(self, grammar_output=None):
+        state = self.execute_model_state
+        if state is not None and isinstance(state.multimodal_outputs, Mapping):
+            multimodal_outputs = dict(state.multimodal_outputs)
+            outputs = multimodal_outputs.get("model_outputs")
+            batched = batch_waveforms_to_cpu(outputs)
+            if batched is not outputs:
+                multimodal_outputs["model_outputs"] = batched
+                self.execute_model_state = state._replace(multimodal_outputs=multimodal_outputs)
+        return super().sample_tokens(grammar_output)
+
+
+class EasyMagpieCodecGPUGenerationWorker(GPUGenerationWorker):
+    """Construct the codec runner through the upstream worker."""
+
+    def init_device(self):
+        original_runner_cls = gpu_generation_worker.GPUGenerationModelRunner
+        gpu_generation_worker.GPUGenerationModelRunner = EasyMagpieCodecGPUGenerationModelRunner
+        try:
+            return super().init_device()
+        finally:
+            gpu_generation_worker.GPUGenerationModelRunner = original_runner_cls

--- a/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/scheduler.py
+++ b/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/scheduler.py
@@ -20,13 +20,25 @@ Configure it on a single-stage deployment with::
 from __future__ import annotations
 
 import threading
+from importlib.metadata import version
+from time import monotonic, sleep
 from types import MethodType
 
 import torch
+from packaging.version import Version
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
 from vllm_omni.core.sched.omni_ar_scheduler import OmniARAsyncScheduler
 from vllm_omni.core.sched.omni_generation_scheduler import OmniGenerationScheduler
 from vllm_omni.distributed.omni_connectors.transfer_adapter.chunk_transfer_adapter import OmniChunkTransferAdapter
+
+_UPSTREAM_HAS_SEGMENT_STOP_ACCOUNTING_FIX = Version(version("vllm-omni")) >= Version("0.26.0")
+
+
+def _connector_extra(vllm_config) -> dict:
+    connector = getattr(vllm_config.model_config, "stage_connector_config", {})
+    if isinstance(connector, dict):
+        return connector.get("extra", {}) or {}
+    return getattr(connector, "extra", {}) or {}
 
 
 class EasyMagpieARAsyncScheduler(OmniARAsyncScheduler):
@@ -64,6 +76,30 @@ class EasyMagpieARAsyncScheduler(OmniARAsyncScheduler):
     branch), then drop this override.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        wait_ms = float(_connector_extra(self.vllm_config).get("stage0_admission_coalesce_ms", 0))
+        if not 0 <= wait_ms <= 10:
+            raise ValueError("stage0_admission_coalesce_ms must be in [0, 10]")
+        self._admission_wait_s = wait_ms / 1000
+        self._admission_deadline = None
+
+    def _should_defer_waiting_admission(self) -> bool:
+        if not self._admission_wait_s or not self.waiting or self.running:
+            self._admission_deadline = None
+            return False
+        if any(request.num_computed_tokens > 0 for request in self.waiting):
+            self._admission_deadline = None
+            return False
+        if len(self.waiting) >= self.max_num_running_reqs:
+            self._admission_deadline = 0.0
+            return False
+
+        now = monotonic()
+        if self._admission_deadline is None:
+            self._admission_deadline = now + self._admission_wait_s
+        return now < self._admission_deadline
+
     def _update_request_with_output(self, request: Request, new_token_ids):
         new_token_ids, stopped = super()._update_request_with_output(request, new_token_ids)
         if stopped:
@@ -80,6 +116,9 @@ class EasyMagpieARAsyncScheduler(OmniARAsyncScheduler):
         return new_token_ids, stopped
 
     def update_from_output(self, scheduler_output, model_runner_output):
+        if _UPSTREAM_HAS_SEGMENT_STOP_ACCOUNTING_FIX:
+            return super().update_from_output(scheduler_output, model_runner_output)
+
         self._emp_stopped_this_step = []
         try:
             outputs = super().update_from_output(scheduler_output, model_runner_output)
@@ -146,37 +185,59 @@ def _codec_payload_frames(info, num_quantizers: int) -> int:
     raise ValueError(f"invalid native codec payload shape: {tuple(audio.shape)}")
 
 
+def _without_consumed_codec_audio(info):
+    """Copy request metadata without the previous chunk's audio codes."""
+    if not isinstance(info, dict):
+        return info
+    codes = info.get("codes")
+    if not isinstance(codes, dict) or "audio" not in codes:
+        return info
+    return {**info, "codes": {key: value for key, value in codes.items() if key != "audio"}}
+
+
 def _poll_native_codec_chunk_unlocked(adapter: OmniChunkTransferAdapter, request: Request) -> bool:
     """Receive a chunk without resetting the vLLM state-cache position."""
     old_num_computed_tokens = request.num_computed_tokens
+    old_additional_information = request.additional_information
     # Async-chunk prewarm may install one unscheduled placeholder before the
     # first real payload. Only tokens with materialized state are retained.
     old_prompt = list(request.prompt_token_ids or [])[:old_num_computed_tokens]
     old_all_token_ids = list(request._all_token_ids)[:old_num_computed_tokens]
 
+    # vLLM-Omni merges incoming generation payloads into this object. Remove
+    # consumed audio so a control-only boundary cannot inherit and replay it.
+    poll_information = _without_consumed_codec_audio(old_additional_information)
+    request.additional_information = poll_information
     received = OmniChunkTransferAdapter._poll_single_request(adapter, request)
-    if not received:
-        request.prompt_token_ids = old_prompt
-        request._all_token_ids[:] = old_all_token_ids
-        request.num_prompt_tokens = len(old_prompt)
-        request.num_computed_tokens = old_num_computed_tokens
-        request.update_block_hashes()
-        return False
+    if received:
+        frames = _codec_payload_frames(request.additional_information, adapter._easymagpie_num_quantizers)
+        if frames > 0:
+            placeholders = [0] * frames
+            request.prompt_token_ids = old_prompt + placeholders
+            request._all_token_ids[:] = old_all_token_ids + placeholders
+            request.num_prompt_tokens = len(request.prompt_token_ids)
+            request.num_computed_tokens = old_num_computed_tokens
+            request.update_block_hashes()
+            return True
+        adapter._finished_load_reqs.discard(request.request_id)
+    elif request.additional_information is poll_information:
+        request.additional_information = old_additional_information
 
-    frames = _codec_payload_frames(request.additional_information, adapter._easymagpie_num_quantizers)
-    placeholders = [0] * frames
-    request.prompt_token_ids = old_prompt + placeholders
-    request._all_token_ids[:] = old_all_token_ids + placeholders
-    request.num_prompt_tokens = len(request.prompt_token_ids)
+    request.prompt_token_ids = old_prompt
+    request._all_token_ids[:] = old_all_token_ids
+    request.num_prompt_tokens = len(old_prompt)
     request.num_computed_tokens = old_num_computed_tokens
     request.update_block_hashes()
-    return True
+    return False
 
 
 def _poll_native_codec_chunk(adapter: OmniChunkTransferAdapter, request: Request) -> bool:
     """Publish connector readiness only after the request payload is coherent."""
-    with adapter._easymagpie_chunk_lock:
-        return _poll_native_codec_chunk_unlocked(adapter, request)
+    with adapter._easymagpie_chunk_ready:
+        received = _poll_native_codec_chunk_unlocked(adapter, request)
+        if received:
+            adapter._easymagpie_chunk_ready.notify_all()
+        return received
 
 
 class EasyMagpieCodecScheduler(OmniGenerationScheduler):
@@ -191,7 +252,16 @@ class EasyMagpieCodecScheduler(OmniGenerationScheduler):
         num_quantizers = int(getattr(config, "num_stacked_codebooks", 0))
         if num_quantizers <= 0:
             raise ValueError("native EasyMagpie codec config has no stacked codebooks")
+        wait_ms = float(_connector_extra(self.vllm_config).get("codec_startup_coalesce_ms", 0))
+        if not 0 <= wait_ms <= 2:
+            raise ValueError("codec_startup_coalesce_ms must be in [0, 2]")
+        self._codec_startup_wait_s = wait_ms / 1000
+        busy_wait_ms = float(_connector_extra(self.vllm_config).get("codec_busy_coalesce_ms", 0))
+        if not 0 <= busy_wait_ms <= 4:
+            raise ValueError("codec_busy_coalesce_ms must be in [0, 4]")
+        self._codec_busy_wait_s = busy_wait_ms / 1000
         adapter._easymagpie_chunk_lock = threading.Lock()
+        adapter._easymagpie_chunk_ready = threading.Condition(adapter._easymagpie_chunk_lock)
         adapter._easymagpie_num_quantizers = num_quantizers
         adapter._poll_single_request = MethodType(_poll_native_codec_chunk, adapter)
 
@@ -259,6 +329,46 @@ class EasyMagpieCodecScheduler(OmniGenerationScheduler):
             self._easymagpie_stopped_sessions = None
         return outputs
 
+    def _should_coalesce_codec_startup(self) -> bool:
+        if not self._codec_startup_wait_s or self.running:
+            return False
+        adapter = self.chunk_transfer_adapter
+        with adapter._easymagpie_chunk_lock:
+            return any(
+                request.status == RequestStatus.WAITING_FOR_CHUNK
+                and request.num_computed_tokens == 0
+                and request.request_id in adapter._finished_load_reqs
+                for request in self.waiting
+            )
+
+    def _ready_codec_requests(self):
+        ready = self.chunk_transfer_adapter._finished_load_reqs
+        return [request for request in (*self.running, *self.waiting) if request.request_id in ready]
+
+    def _codec_busy_wait_done(self) -> bool:
+        ready = self.chunk_transfer_adapter._finished_load_reqs
+        return self._has_ready_codec_start() or all(request.request_id in ready for request in self.running)
+
+    def _has_ready_codec_start(self) -> bool:
+        return any(request.num_computed_tokens == 0 for request in self._ready_codec_requests())
+
+    def _should_coalesce_codec_busy(self) -> bool:
+        if not self._codec_busy_wait_s or len(self.running) < 2:
+            return False
+        ready = self._ready_codec_requests()
+        return (
+            any(request.num_computed_tokens > 0 for request in ready)
+            and not self._codec_busy_wait_done()
+        )
+
     def schedule(self, *args, **kwargs):
-        with self.chunk_transfer_adapter._easymagpie_chunk_lock:
+        adapter = self.chunk_transfer_adapter
+        if self._should_coalesce_codec_startup():
+            sleep(self._codec_startup_wait_s)
+        with adapter._easymagpie_chunk_ready:
+            if self._should_coalesce_codec_busy():
+                adapter._easymagpie_chunk_ready.wait_for(
+                    self._codec_busy_wait_done,
+                    timeout=self._codec_busy_wait_s,
+                )
             return super().schedule(*args, **kwargs)

--- a/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/serving_stream.py
+++ b/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/serving_stream.py
@@ -219,6 +219,16 @@ class EasyMagpieInputStream:
 class EasyMagpieStreamingSpeechHandler(OmniStreamingSpeechHandler):
     """Use resumable EasyMagpie requests while preserving the generic handler."""
 
+    async def _receive_config(self, websocket: WebSocket):
+        raw = await asyncio.wait_for(websocket.receive_text(), timeout=self._config_timeout)
+        msg = await self._parse_message(websocket, raw)
+        if msg is None:
+            return None
+        if msg.get("type") != "session.config":
+            await self._send_error(websocket, f"Expected session.config, got: {msg.get('type')}")
+            return None
+        return await self._build_config(websocket, msg)
+
     async def handle_session(self, websocket: WebSocket) -> None:
         if getattr(self._speech_service, "_tts_model_type", None) != _MODEL_TYPE:
             await super().handle_session(websocket)

--- a/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/stage_processors.py
+++ b/tools/easymagpie_vllm_omni/easymagpie_vllm_omni/stage_processors.py
@@ -32,6 +32,7 @@ logger = init_logger(__name__)
 
 # Base codebook size, excluding control tokens.
 _CODEBOOK_SIZE = 1024
+_CODEC_PADDING = -1
 
 
 def _empty_finished_payload() -> dict[str, Any]:
@@ -335,10 +336,18 @@ def talker2code2wav_async_chunk(
             f"must be a list, got {type(raw_startup_chunks).__name__}"
         )
     startup_chunk_sizes = [int(value) for value in raw_startup_chunks]
-    if chunk_size <= 0 or any(value <= 0 for value in startup_chunk_sizes):
+    raw_busy_chunks = cfg.get("codec_busy_startup_chunk_frames", raw_startup_chunks)
+    if not isinstance(raw_busy_chunks, (list, tuple)):
+        raise ValueError(
+            "Invalid EasyMagpie codec chunk config: codec_busy_startup_chunk_frames "
+            f"must be a list, got {type(raw_busy_chunks).__name__}"
+        )
+    busy_chunk_sizes = [int(value) for value in raw_busy_chunks]
+    if chunk_size <= 0 or any(value <= 0 for value in startup_chunk_sizes + busy_chunk_sizes):
         raise ValueError(
             f"Invalid EasyMagpie codec chunk config: codec_chunk_frames={chunk_size}, "
-            f"codec_startup_chunk_frames={startup_chunk_sizes}"
+            f"codec_startup_chunk_frames={startup_chunk_sizes}, "
+            f"codec_busy_startup_chunk_frames={busy_chunk_sizes}"
         )
     # Track one absolute emission high-water mark across resumable text
     # segments so repeated segment-finish notifications cannot duplicate frames.
@@ -352,12 +361,21 @@ def talker2code2wav_async_chunk(
     emitted = emitted_state[request_id]
     emitted_chunks_state = _persistent_state(transfer_manager, "_emp_emitted_chunks")
     emitted_chunks = emitted_chunks_state[request_id]
+    request_startup_chunks = getattr(transfer_manager, "_emp_request_startup_chunks", None)
+    if request_startup_chunks is None:
+        request_startup_chunks = {}
+        transfer_manager._emp_request_startup_chunks = request_startup_chunks
+    if request_id not in request_startup_chunks:
+        busy = any(key != request_id and value > 0 for key, value in emitted_chunks_state.items())
+        request_startup_chunks[request_id] = busy_chunk_sizes if busy else startup_chunk_sizes
+    startup_chunk_sizes = request_startup_chunks[request_id]
 
     true_finished = _is_true_request_finish(request)
 
     def _cleanup() -> None:
         emitted_state.pop(request_id, None)
         emitted_chunks_state.pop(request_id, None)
+        request_startup_chunks.pop(request_id, None)
         _persistent_state(transfer_manager, "_emp_seen_frames").pop(request_id, None)
         _persistent_state(transfer_manager, "_emp_request_speech_delay").pop(request_id, None)
         base_state.pop(request_id, None)
@@ -394,6 +412,12 @@ def talker2code2wav_async_chunk(
     relative_start = emitted - base_index
     relative_end = new_end - base_index
     code_predictor_codes = torch.stack(buffer[relative_start:relative_end], dim=0).contiguous()
+    if true_finished and context_length < chunk_size:
+        padding = code_predictor_codes.new_full(
+            (chunk_size - context_length, code_predictor_codes.shape[1]),
+            _CODEC_PADDING,
+        )
+        code_predictor_codes = torch.cat((code_predictor_codes, padding), dim=0)
 
     emitted_state[request_id] = new_end
     emitted_chunks_state[request_id] += 1

--- a/tools/easymagpie_vllm_omni/scripts/benchmark_server.py
+++ b/tools/easymagpie_vllm_omni/scripts/benchmark_server.py
@@ -48,6 +48,7 @@ class RequestResult:
 
 
 def _save_wav(path: Path, audio: np.ndarray, sample_rate: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
     audio = np.clip(audio, -1.0, 1.0)
     pcm = (audio * 32767.0).astype(np.int16)
     with wave.open(str(path), "wb") as wf:
@@ -65,9 +66,7 @@ def _do_request(task: dict) -> RequestResult:
         "input": task["text"],
         "voice": task["speaker_id"] or "eng",
         "response_format": "pcm",
-        "stream": True,
         "stream_format": "audio",
-        "max_new_tokens": task["max_new_tokens"],
     }
 
     t0 = time.perf_counter()
@@ -126,6 +125,8 @@ def _load_items(text_file: str) -> list[tuple[str, str]]:
             if not line.strip():
                 continue
             parts = line.split("\t", 1)
+            if len(parts) != 2:
+                parts = line.split("|", 1)
             if len(parts) != 2:
                 raise ValueError(f"Expected '<uttid>\\t<text>' per line, got: {line!r}")
             uttid, text = parts[0].strip(), parts[1].strip()
@@ -339,9 +340,11 @@ def main() -> None:
     parser.add_argument("--max-new-tokens", type=int, default=1024)
     parser.add_argument("--sample-rate", type=int, default=22050, help="Raw PCM sample rate (default: %(default)s)")
     parser.add_argument("--timeout", type=float, default=300, help="Per-request timeout, s (default: 300)")
+    parser.add_argument("--seed", type=int, default=0, help="Request selection seed (default: %(default)s)")
     parser.add_argument("--no-warmup", action="store_true", help="Skip warmup phase (concurrency requests)")
     parser.add_argument("--output-dir", default=None, help="If set, write each waveform to <output-dir>/<uttid>.wav")
     args = parser.parse_args()
+    random.seed(args.seed)
 
     items = _load_items(args.text_file)
     if not items:

--- a/tools/easymagpie_vllm_omni/scripts/launch_engines.py
+++ b/tools/easymagpie_vllm_omni/scripts/launch_engines.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Launch the two EasyMagpie vLLM-Omni stages."""
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import Any
+
+
+def _replica_count(stage: Any) -> int:
+    count = int(getattr(stage.runtime, "num_replicas", 1))
+    if not 1 <= count <= 16:
+        raise ValueError(f"stage {stage.stage_id} num_replicas must be in 1..=16")
+    return count
+
+
+@contextmanager
+def _stage_mps_priority(stage_id: int) -> Iterator[None]:
+    key = f"EASYMAGPIE_STAGE{stage_id}_MPS_CLIENT_PRIORITY"
+    value = os.environ.get(key)
+    if value is None:
+        yield
+        return
+    if value not in ("0", "1"):
+        raise ValueError(f"{key} must be 0 or 1")
+
+    old_value = os.environ.get("CUDA_MPS_CLIENT_PRIORITY")
+    os.environ["CUDA_MPS_CLIENT_PRIORITY"] = value
+    try:
+        yield
+    finally:
+        if old_value is None:
+            os.environ.pop("CUDA_MPS_CLIENT_PRIORITY", None)
+        else:
+            os.environ["CUDA_MPS_CLIENT_PRIORITY"] = old_value
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--deploy-config", required=True)
+    parser.add_argument("--stage0-handshake", default="tcp://127.0.0.1:62100")
+    parser.add_argument("--stage1-handshake", default="tcp://127.0.0.1:62101")
+    parser.add_argument("--log-stats", action="store_true")
+    return parser.parse_args()
+
+
+def _supervise_stages(start_stage: Callable[[int], Any]) -> None:
+    managers = []
+    stopping = False
+
+    def stop(_signum: int, _frame: object) -> None:
+        nonlocal stopping
+        stopping = True
+
+    signal.signal(signal.SIGINT, stop)
+    signal.signal(signal.SIGTERM, stop)
+    try:
+        for stage_id in (0, 1):
+            if stopping:
+                break
+            managers.append(start_stage(stage_id))
+
+        while not stopping:
+            for stage_id, manager in enumerate(managers):
+                finished = manager.finished_procs()
+                if finished:
+                    raise RuntimeError(f"EasyMagpie stage {stage_id} exited unexpectedly: {finished}")
+            time.sleep(0.25)
+    finally:
+        for manager in reversed(managers):
+            manager.shutdown()
+
+
+def main() -> None:
+    args = _parse_args()
+
+    import vllm_plugin_easymagpie_omni
+
+    vllm_plugin_easymagpie_omni.register()
+
+    from vllm_omni.distributed.omni_connectors.utils.initialization import (
+        resolve_omni_kv_config_for_stage,
+    )
+    from vllm_omni.engine.stage_engine_core_proc_manager import StageEngineCoreProcManager
+    from vllm_omni.engine.stage_init_utils import (
+        build_engine_args_dict,
+        build_vllm_config,
+        get_stage_connector_spec,
+        inject_omni_kv_connector_config,
+        load_omni_transfer_config_for_model,
+        prepare_engine_environment,
+    )
+    from vllm_omni.entrypoints.utils import load_and_resolve_stage_configs
+
+    config_path, stage_configs, _ = load_and_resolve_stage_configs(
+        args.model,
+        None,
+        {},
+        trust_remote_code=True,
+        deploy_config_path=args.deploy_config,
+    )
+    stages = {stage.stage_id: stage for stage in stage_configs}
+    missing = {0, 1} - stages.keys()
+    if missing:
+        raise ValueError(f"deploy config is missing stages: {sorted(missing)}")
+    if any(stages[index].stage_type == "diffusion" for index in (0, 1)):
+        raise ValueError("the Rust transport requires two LLM stages")
+    replica_counts = {stage_id: _replica_count(stage) for stage_id, stage in stages.items()}
+    if replica_counts[1] != 1:
+        raise ValueError("the Rust transport requires exactly one Stage 1 replica")
+
+    prepare_engine_environment()
+    transfer_config = load_omni_transfer_config_for_model(args.model, config_path)
+    handshakes = {0: args.stage0_handshake, 1: args.stage1_handshake}
+
+    def start_stage(stage_id: int) -> Any:
+        stage_config = stages[stage_id]
+        connector_config = resolve_omni_kv_config_for_stage(transfer_config, stage_id)
+        connector_spec = get_stage_connector_spec(
+            omni_transfer_config=transfer_config,
+            stage_id=stage_id,
+            async_chunk=True,
+        )
+        engine_args = build_engine_args_dict(
+            stage_config,
+            args.model,
+            stage_connector_spec=connector_spec,
+            cli_tokenizer=None,
+        )
+        inject_omni_kv_connector_config(engine_args, connector_config, stage_id)
+        vllm_config, executor_class = build_vllm_config(
+            stage_config,
+            args.model,
+            stage_connector_spec=connector_spec,
+            engine_args_dict=engine_args,
+            headless=True,
+        )
+        with _stage_mps_priority(stage_id):
+            return StageEngineCoreProcManager(
+                local_engine_count=replica_counts[stage_id],
+                start_index=0,
+                local_start_index=0,
+                vllm_config=vllm_config,
+                local_client=True,
+                handshake_address=handshakes[stage_id],
+                executor_class=executor_class,
+                log_stats=args.log_stats,
+                omni_stage_id=stage_id,
+            )
+
+    _supervise_stages(start_stage)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
 This PR optimizes and hardens the two-stage EasyMagpie vLLM-Omni streaming path for concurrent TTS serving up to batch size 128. It improves GPU utilization and batching, fixes large-batch output slicing and codec-state correctness, adds vLLM-Omni 0.26 compatibility, and provides runtime deployment tooling.                                                   
    
 ## Correctness and compatibility                                                                                                                                                      
                                                                                                                                                                                        
  - Fix CUDA-graph-padded asynchronous output slicing at large batch sizes.                                                                                                             
      - Stage 0 now keeps an empty hidden-state payload shaped (padded_batch, 0).                                                                                                       
      - This preserves the request-axis hint without copying hidden activations to the host.                                                                                            
      - Acoustic codes are consequently sliced per request instead of sharing a padded graph row.                                                                                       
                                                                                                                                                                                        
  - Keep recurrent audio, phoneme, and hidden state on the GPU between decoding steps.                                                                                                  
  - Preserve Stage 1 codec cache state across resumable text segments.
  - Prevent empty or control-only segment markers from replaying the previous codec payload. 
  - Pad short terminal codec chunks with an explicit sentinel and trim the padding from the returned waveform.
  - Feed phoneme EOS once and mask subsequent phoneme input.
  - Add compatibility for vLLM-Omni 0.26:
      - Use AutoWeightsLoader where the inner backbone no longer exposes load_weights.
      - Defer to upstream segment-stop accounting when the installed version contains the fix.
      - Adapt WebSocket session configuration handling to the current interface.

  ## Performance

  - Preload registered speaker contexts from contexts.json and contexts.safetensors.
  - Cache assembled speaker and context-text prefill embeddings.
  - Avoid transporting unused Stage 0 hidden activations.
  - Batch per-request waveform device-to-host copies.
  - Use uniform codec execution for equal-length prefill batches while retaining ragged and mixed-batch fallbacks.
  - Replace arithmetic FSQ dequantization with a precomputed lookup table.
  - Run only the required causal prefix during each local-transformer codebook step.
  - Fuse residual addition into the Triton HalfSnake activation.
  - Remove the redundant FP32 router-logit cast only for the validated CUDA FP16 grouped-top-k configuration.
  - Add bounded, configurable admission and codec coalescing windows.
  - Use separate codec startup chunk schedules for idle and busy execution.

  ## Scaling and deployment
  - Configure two Stage 0 replicas with 64 sequences each.
  - Configure one Stage 1 codec engine for up to 128 sequences.
  - Add explicit KV-cache, CUDA graph, token-budget, and model-length limits.
  - Add a runtime overlay Dockerfile.
  - Add a supervised engine launcher with:
      - Replica-count validation.
      - Clean signal handling and child shutdown.
      - Optional per-stage CUDA MPS priorities.

  - Add opt-in Stage 0 prediction tracing through EASYMAGPIE_STAGE0_TRACE_DIR.
  - Make benchmark request selection reproducible and accept tab- or pipe-delimited input.

  # Performance

  Measured end-to-end on an NVIDIA H100 80 GB with a warmed runtime cache:
+--------------------------+----------+----------+----------+------------+
| Scenario                 | RTFx     | Mean TTFA| p95 TTFA | Underruns  |
+--------------------------+----------+----------+----------+------------+
| 32                       | 124.55x  | 139.8 ms | 149.9 ms | 0 / 432    |
| 64                       | 168.60x  | 232.6 ms | 241.6 ms | 0 / 2,687 |
| 128 (concurrency 64)     | 155.75x  | 367.7 ms | 581.6 ms | 0 / 1,627  |
| 128 (concurrency 128)    | 230.90x  | 346.1 ms | 362.0 ms | 0 / 1,803  |
+--------------------------+----------+----------+----------+------------+

  The concurrency-64 TTFA includes queueing across 128 requests and is not directly comparable to a single-batch result.

  Nsight Systems confirmed that serving-time MoE router, alignment, expert, and reduction work remained on one CUDA stream. Approximate routing was rejected: the exact router was
  already a small part of Stage 0, and the retained FP16 cast optimization produced bitwise-identical expert IDs and weights across 68,244 comparison rows.

 # Usage

  Build the runtime overlay against the prepared frontend image:

  docker build \
    -f tools/easymagpie_vllm_omni/Dockerfile.runtime \
    --build-arg BASE_IMAGE=<frontend-image> \
    -t <easymagpie-runtime-image> \
    tools/easymagpie_vllm_omni

  Launch the two engine stages inside the runtime image:

  ```bash
  python /opt/nemotron-speech/bin/launch_easymagpie_engines.py \
    --model /path/to/easymagpie-model \
    --deploy-config /path/to/easymagpie.yaml

                                                                                                                                                                                        
  # Reviewer guidance                                                                                                                                                                   

  The most sensitive areas are:

  1. runner.py: padded asynchronous output slicing and GPU-resident state.
  2. scheduler.py and stage_processors.py: segment boundaries, codec continuity, and coalescing.
  3. codec/ and local_transformer.py: optimized paths must remain numerically equivalent.
  4. backbone_patches.py: the router optimization is deliberately restricted to the validated configuration.
  5. easymagpie.yaml: the current capacity and memory settings were tuned on an H100 80 GB.
  6. Shape-complete warmup is required after clearing the runtime kernel cache.
  7. The replicated Stage 0 configuration requires the companion nemotron-speech frontend MR.

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

Trusted PRs run automatically through copy-pr-bot. For an untrusted PR, a maintainer can trigger CI by commenting
`/ok to test <head-sha>`; repeat this after a new push if the PR remains untrusted.

  # Before your PR is ready for review

  Pre-checks:

  - [ ] Confirm contributor guidelines were reviewed
  - [x] Added necessary regression and numerical-equivalence tests
  - [x] Documented deployment configuration and launcher options
  - [x] This affects the optional EasyMagpie vLLM-Omni runtime
      - [ ] Reviewer: confirm optional dependency isolation remains correct

  PR Type:

  - [x] New Feature
  - [x] Bugfix
  - [ ] Documentation

# Additional Information

- Related to # (issue)
