### PR TITLE
Speed up the cache-aware streaming RNNT pipeline

### DIFF
--- a/examples/asr/asr_streaming_inference/asr_streaming_infer.py
+++ b/examples/asr/asr_streaming_inference/asr_streaming_infer.py
@@ -93,8 +93,15 @@ def main(cfg):
     # Build the pipeline
     pipeline = PipelineBuilder.build_pipeline(cfg)
 
-    # Read the audio once, outside the timed region: RTFx measures the pipeline, not disk I/O.
-    audio_samples = [read_audio(path, target_sr=cfg.streaming.sample_rate, mono=True) for path in audio_filepaths]
+    # Read the audio once, outside the timed region, so RTFx measures the pipeline and not disk I/O.
+    # Every file then stays in host memory for the whole run: set preload_audio=false for a manifest
+    # that does not fit, and the pipeline reads from disk as before, with the RTFx below including that.
+    data_dur, durations = calculate_duration(audio_filepaths)
+    audio_samples = None
+    if cfg.get("preload_audio", True):
+        needed_gib = data_dur * cfg.streaming.sample_rate * 4 / 1024**3  # mono float32 samples
+        logging.info(f"Preloading {len(audio_filepaths)} audio files into host memory, about {needed_gib:.1f} GiB")
+        audio_samples = [read_audio(path, target_sr=cfg.streaming.sample_rate, mono=True) for path in audio_filepaths]
 
     # Warmup and run the pipeline
     timer = SimpleTimer()
@@ -107,9 +114,7 @@ def main(cfg):
         progress_bar = TQDMProgressBar()
         timer.reset()
         timer.start(device=pipeline.device)
-        output = pipeline.run(
-            audio_filepaths, progress_bar=progress_bar, options=options, audio_samples=audio_samples
-        )
+        output = pipeline.run(audio_filepaths, progress_bar=progress_bar, options=options, audio_samples=audio_samples)
         timer.stop(pipeline.device)
         if run_step >= cfg.warmup_steps:
             measurements.append(timer.total_sec())
@@ -119,7 +124,6 @@ def main(cfg):
         logging.warning(
             "RTFx measurement enabled, but warmup_steps=0. At least one warmup step is recommended to measure RTFx."
         )
-    data_dur, durations = calculate_duration(audio_filepaths)
     exec_dur = sum(measurements) / len(measurements)
     rtfx = data_dur / exec_dur if exec_dur > 0 else float('inf')
     logging.info(f"RTFx: {rtfx:.2f} ({data_dur:.2f}s / {exec_dur:.2f}s)")

--- a/examples/asr/asr_streaming_inference/asr_streaming_infer.py
+++ b/examples/asr/asr_streaming_inference/asr_streaming_infer.py
@@ -48,6 +48,7 @@ import hydra
 
 from nemo.collections.asr.inference.factory.pipeline_builder import PipelineBuilder
 
+from nemo.collections.asr.inference.utils.audio_io import read_audio
 from nemo.collections.asr.inference.utils.manifest_io import calculate_duration, dump_output, prepare_audio_data
 from nemo.collections.asr.inference.utils.pipeline_eval import (
     calculate_asr_laal,
@@ -92,6 +93,9 @@ def main(cfg):
     # Build the pipeline
     pipeline = PipelineBuilder.build_pipeline(cfg)
 
+    # Read the audio once, outside the timed region: RTFx measures the pipeline, not disk I/O.
+    audio_samples = [read_audio(path, target_sr=cfg.streaming.sample_rate, mono=True) for path in audio_filepaths]
+
     # Warmup and run the pipeline
     timer = SimpleTimer()
     measurements = []
@@ -103,7 +107,9 @@ def main(cfg):
         progress_bar = TQDMProgressBar()
         timer.reset()
         timer.start(device=pipeline.device)
-        output = pipeline.run(audio_filepaths, progress_bar=progress_bar, options=options)
+        output = pipeline.run(
+            audio_filepaths, progress_bar=progress_bar, options=options, audio_samples=audio_samples
+        )
         timer.stop(pipeline.device)
         if run_step >= cfg.warmup_steps:
             measurements.append(timer.total_sec())

--- a/examples/asr/conf/asr_streaming_inference/buffered_ctc.yaml
+++ b/examples/asr/conf/asr_streaming_inference/buffered_ctc.yaml
@@ -83,6 +83,7 @@ streaming:
 # ========================
 # Pipeline settings
 # ========================
+preload_audio: true                           # Read all audio into host memory before the timed loop, so RTFx measures inference and not disk I/O; set false for a manifest that does not fit in memory
 matmul_precision: high                        # Matrix multiplication precision: highest, high, medium
 log_level: 20                                 # Logging level: 0 (NOTSET), 10 (DEBUG), 20 (INFO), 30 (WARNING), 40 (ERROR), 50 (CRITICAL)
 pipeline_type: buffered                       # Pipeline type: buffered, cache_aware

--- a/examples/asr/conf/asr_streaming_inference/buffered_rnnt.yaml
+++ b/examples/asr/conf/asr_streaming_inference/buffered_rnnt.yaml
@@ -115,6 +115,7 @@ streaming:
 # ========================
 # Pipeline settings
 # ========================
+preload_audio: true                           # Read all audio into host memory before the timed loop, so RTFx measures inference and not disk I/O; set false for a manifest that does not fit in memory
 matmul_precision: high                     # Matrix multiplication precision: highest, high, medium
 log_level: 20                              # Logging level: 0 (NOTSET), 10 (DEBUG), 20 (INFO), 30 (WARNING), 40 (ERROR), 50 (CRITICAL)
 pipeline_type: buffered                    # Pipeline type: buffered, cache_aware

--- a/examples/asr/conf/asr_streaming_inference/buffered_salm.yaml
+++ b/examples/asr/conf/asr_streaming_inference/buffered_salm.yaml
@@ -69,6 +69,7 @@ streaming:
 # ========================
 # Pipeline settings
 # ========================
+preload_audio: true                           # Read all audio into host memory before the timed loop, so RTFx measures inference and not disk I/O; set false for a manifest that does not fit in memory
 matmul_precision: high                        # Matrix multiplication precision: highest, high, medium
 log_level: 20                                 # Logging level: 0 (NOTSET), 10 (DEBUG), 20 (INFO), 30 (WARNING), 40 (ERROR), 50 (CRITICAL)
 pipeline_type: buffered                       # Pipeline type: buffered, cache_aware

--- a/examples/asr/conf/asr_streaming_inference/cache_aware_ctc.yaml
+++ b/examples/asr/conf/asr_streaming_inference/cache_aware_ctc.yaml
@@ -84,6 +84,7 @@ streaming:
 # ========================
 # Pipeline settings
 # ========================
+preload_audio: true                           # Read all audio into host memory before the timed loop, so RTFx measures inference and not disk I/O; set false for a manifest that does not fit in memory
 matmul_precision: high                        # Matrix multiplication precision: highest, high, medium
 log_level: 20                                 # Logging level: 0 (NOTSET), 10 (DEBUG), 20 (INFO), 30 (WARNING), 40 (ERROR), 50 (CRITICAL)
 pipeline_type: cache_aware                    # Pipeline type: buffered, cache_aware

--- a/examples/asr/conf/asr_streaming_inference/cache_aware_rnnt.yaml
+++ b/examples/asr/conf/asr_streaming_inference/cache_aware_rnnt.yaml
@@ -135,6 +135,7 @@ streaming:
 # ========================
 # Pipeline settings
 # ========================
+preload_audio: true                           # Read all audio into host memory before the timed loop, so RTFx measures inference and not disk I/O; set false for a manifest that does not fit in memory
 matmul_precision: high                        # Matrix multiplication precision: highest, high, medium
 log_level: 20                                 # Logging level: 0 (NOTSET), 10 (DEBUG), 20 (INFO), 30 (WARNING), 40 (ERROR), 50 (CRITICAL)
 pipeline_type: cache_aware                    # Pipeline type: buffered, cache_aware

--- a/nemo/collections/asr/inference/model_wrappers/cache_aware_asr_inference_wrapper.py
+++ b/nemo/collections/asr/inference/model_wrappers/cache_aware_asr_inference_wrapper.py
@@ -16,6 +16,7 @@
 
 from typing import Any
 
+import torch
 from torch import Tensor
 
 from nemo.collections.asr.inference.model_wrappers.asr_inference_wrapper import ASRInferenceWrapper
@@ -139,6 +140,29 @@ class CacheAwareASRInferenceWrapper(ASRInferenceWrapper):
             enabled: (bool) whether to enable CUDA graphs for the encoder streaming step.
         """
         self.asr_model.encoder.set_streaming_cuda_graphs(enabled=enabled)
+
+    def compile_encoder_layers(self) -> int:
+        """
+        Wrap each encoder layer in ``torch.compile`` so inductor fuses the layer's elementwise work.
+
+        Cache-aware streaming spends far more host time launching kernels than the device spends
+        running them, so fusing a layer into fewer, larger kernels is what shortens the step. Mode is
+        the default one, not ``reduce-overhead``: that mode replays through CUDA graphs, which this
+        pipeline deliberately does not use. Shapes are marked dynamic because the batch shrinks as
+        streams finish, and a static compile would recompile on every new width.
+
+        Compilation happens on the first call and therefore inside the warmup iteration. Fusion
+        changes the order of low-precision arithmetic, so decoded text can differ from eager in the
+        last bits; a run that must match eager exactly should not call this.
+        Returns:
+            (int) number of layers compiled.
+        """
+        layers = getattr(self.asr_model.encoder, "layers", None)
+        if layers is None:
+            return 0
+        for i, layer in enumerate(layers):
+            layers[i] = torch.compile(layer, dynamic=True)
+        return len(layers)
 
     def stream_step(self, *args, **kwargs) -> Any:
         """

--- a/nemo/collections/asr/inference/model_wrappers/cache_aware_asr_inference_wrapper.py
+++ b/nemo/collections/asr/inference/model_wrappers/cache_aware_asr_inference_wrapper.py
@@ -143,26 +143,38 @@ class CacheAwareASRInferenceWrapper(ASRInferenceWrapper):
 
     def compile_encoder_layers(self) -> int:
         """
-        Wrap each encoder layer in ``torch.compile`` so inductor fuses the layer's elementwise work.
+        Compile the encoder body with ``torch.compile`` so inductor fuses its elementwise work.
 
         Cache-aware streaming spends far more host time launching kernels than the device spends
-        running them, so fusing a layer into fewer, larger kernels is what shortens the step. Mode is
-        the default one, not ``reduce-overhead``: that mode replays through CUDA graphs, which this
-        pipeline deliberately does not use. Shapes are marked dynamic because the batch shrinks as
-        streams finish, and a static compile would recompile on every new width.
+        running them, so fusing the encoder into fewer, larger kernels is what shortens the step.
+        The whole body is compiled as one graph rather than layer by layer, which lets inductor fuse
+        across layer boundaries. Mode is the default one, not ``reduce-overhead``: that mode replays
+        through CUDA graphs, which this pipeline deliberately does not use. The batch width stays
+        dynamic, since it shrinks as streams finish, but the chunk's feature length is pinned; see
+        the note in the wrapper below.
 
         Compilation happens on the first call and therefore inside the warmup iteration. Fusion
         changes the order of low-precision arithmetic, so decoded text can differ from eager in the
         last bits; a run that must match eager exactly should not call this.
         Returns:
-            (int) number of layers compiled.
+            (int) 1 when the encoder was compiled, 0 when it has no compilable body.
         """
-        layers = getattr(self.asr_model.encoder, "layers", None)
-        if layers is None:
+        encoder = self.asr_model.encoder
+        if not hasattr(encoder, "forward_internal"):
             return 0
-        for i, layer in enumerate(layers):
-            layers[i] = torch.compile(layer, dynamic=True)
-        return len(layers)
+        compiled = torch.compile(encoder.forward_internal, dynamic=True)
+
+        def forward_internal(audio_signal, length, bypass_pre_encode=False, **kwargs):
+            if not bypass_pre_encode:
+                # A cache-aware chunk always carries the bufferer's feature length, so pinning that
+                # dimension states a fact about the workload rather than constraining it. Left
+                # symbolic, the subsampling output length becomes an expression the shape solver
+                # cannot divide by, and it gives up once per layer per distinct batch width.
+                torch._dynamo.mark_static(audio_signal, 2)
+            return compiled(audio_signal, length, bypass_pre_encode=bypass_pre_encode, **kwargs)
+
+        encoder.forward_internal = forward_internal
+        return 1
 
     def stream_step(self, *args, **kwargs) -> Any:
         """

--- a/nemo/collections/asr/inference/model_wrappers/cache_aware_rnnt_inference_wrapper.py
+++ b/nemo/collections/asr/inference/model_wrappers/cache_aware_rnnt_inference_wrapper.py
@@ -94,7 +94,7 @@ class CacheAwareRNNTInferenceWrapper(CacheAwareASRInferenceWrapper):
         processed_signal_length: Tensor,
         context: CacheAwareContext,
         drop_extra_pre_encoded: int | None,
-        keep_all_outputs: bool,
+        keep_all_outputs: bool | Tensor,
         drop_left_context: int | None = None,
         valid_out_len: int | None = None,
         prompt_vectors: Tensor | None = None,
@@ -106,13 +106,17 @@ class CacheAwareRNNTInferenceWrapper(CacheAwareASRInferenceWrapper):
             processed_signal_length: (Tensor) input signal length tensor.
             context: (CacheAwareContext) context object.
             drop_extra_pre_encoded: (int | None) number of extra pre-encoded frames to drop.
-            keep_all_outputs: (bool) whether to keep all outputs or not.
+            keep_all_outputs: (bool | Tensor) whether to keep all outputs; a bool vector of shape [B]
+                keeps them per stream, which serves a batch mixing last and non-last chunks.
             drop_left_context: (int | None) number of left context frames to drop.
             valid_out_len: (int | None) number of valid output frames.
             prompt_vectors: (Tensor | None) per-stream one-hot language prompts of shape [B, num_prompts].
         Returns:
             (tuple[Tensor, Tensor, CacheAwareContext]) encoder output, encoder output lengths, and new context.
         """
+        # a boolean vector asks for a mixed batch: the encoder keeps every output and the per-stream
+        # right context is trimmed afterwards by clamping the lengths, which the decoder honours
+        per_sample_keep = isinstance(keep_all_outputs, Tensor)
         (
             encoded,
             encoded_len,
@@ -125,7 +129,7 @@ class CacheAwareRNNTInferenceWrapper(CacheAwareASRInferenceWrapper):
             cache_last_channel=context.cache_last_channel,
             cache_last_time=context.cache_last_time,
             cache_last_channel_len=context.cache_last_channel_len,
-            keep_all_outputs=keep_all_outputs,
+            keep_all_outputs=True if per_sample_keep else keep_all_outputs,
             drop_extra_pre_encoded=drop_extra_pre_encoded,
         )
         new_context = CacheAwareContext(
@@ -139,7 +143,12 @@ class CacheAwareRNNTInferenceWrapper(CacheAwareASRInferenceWrapper):
             encoded = encoded[:, :, drop_left_context:]
             encoded_len = encoded_len - drop_left_context
 
-        if valid_out_len and not keep_all_outputs:
+        if valid_out_len and per_sample_keep:
+            # drop right context per stream: the streams that are not last keep valid_out_len frames
+            encoded_len = torch.where(
+                keep_all_outputs, encoded_len, torch.full_like(encoded_len, valid_out_len)
+            )
+        elif valid_out_len and not keep_all_outputs:
             # drop right context if any
             encoded = encoded[:, :, :valid_out_len]
             encoded_len = torch.ones_like(encoded_len) * valid_out_len
@@ -158,7 +167,7 @@ class CacheAwareRNNTInferenceWrapper(CacheAwareASRInferenceWrapper):
         context: CacheAwareContext,
         previous_hypotheses: list[Hypothesis] | None,
         drop_extra_pre_encoded: int | None,
-        keep_all_outputs: bool,
+        keep_all_outputs: bool | Tensor,
         drop_left_context: int | None = None,
         valid_out_len: int | None = None,
         prompt_vectors: Tensor | None = None,
@@ -171,7 +180,8 @@ class CacheAwareRNNTInferenceWrapper(CacheAwareASRInferenceWrapper):
             context: (CacheAwareContext) context object.
             previous_hypotheses: (list[Hypothesis] | None) list of previous hypotheses for RNNT decoding.
             drop_extra_pre_encoded: (int | None) number of extra pre-encoded frames to drop.
-            keep_all_outputs: (bool) whether to keep all outputs or not.
+            keep_all_outputs: (bool | Tensor) whether to keep all outputs; a bool vector of shape [B]
+                keeps them per stream, which serves a batch mixing last and non-last chunks.
             drop_left_context: (int | None) number of left context frames to drop.
             valid_out_len: (int | None) number of valid output frames.
             prompt_vectors: (Tensor | None) Optional prompt vectors of shape [B, num_prompts].
@@ -202,7 +212,7 @@ class CacheAwareRNNTInferenceWrapper(CacheAwareASRInferenceWrapper):
         processed_signal_length: Tensor,
         context: CacheAwareContext,
         drop_extra_pre_encoded: int | None,
-        keep_all_outputs: bool,
+        keep_all_outputs: bool | Tensor,
         drop_left_context: int | None = None,
         valid_out_len: int | None = None,
         prompt_vectors: Tensor | None = None,
@@ -278,7 +288,7 @@ class CacheAwareRNNTInferenceWrapper(CacheAwareASRInferenceWrapper):
         context: CacheAwareContext = None,
         previous_hypotheses: list[Hypothesis] | None = None,
         drop_extra_pre_encoded: int | None = None,
-        keep_all_outputs: bool = False,
+        keep_all_outputs: bool | Tensor = False,
         drop_left_context: int | None = None,
         valid_out_len: int | None = None,
         prompt_vectors: Tensor | None = None,
@@ -291,7 +301,8 @@ class CacheAwareRNNTInferenceWrapper(CacheAwareASRInferenceWrapper):
             context: (CacheAwareContext) context object.
             previous_hypotheses: (list[Hypothesis] | None) list of previous hypotheses for RNNT decoding.
             drop_extra_pre_encoded: (int | None) number of extra pre-encoded frames to drop.
-            keep_all_outputs: (bool) whether to keep all outputs or not.
+            keep_all_outputs: (bool | Tensor) whether to keep all outputs; a bool vector of shape [B]
+                keeps them per stream, which serves a batch mixing last and non-last chunks.
             drop_left_context: (int | None) number of left context frames to drop.
             valid_out_len: (int | None) number of valid output frames.
             prompt_vectors: (Tensor | None) Optional prompt vectors of shape [B, num_prompts].

--- a/nemo/collections/asr/inference/model_wrappers/cache_aware_rnnt_inference_wrapper.py
+++ b/nemo/collections/asr/inference/model_wrappers/cache_aware_rnnt_inference_wrapper.py
@@ -145,9 +145,7 @@ class CacheAwareRNNTInferenceWrapper(CacheAwareASRInferenceWrapper):
 
         if valid_out_len and per_sample_keep:
             # drop right context per stream: the streams that are not last keep valid_out_len frames
-            encoded_len = torch.where(
-                keep_all_outputs, encoded_len, torch.full_like(encoded_len, valid_out_len)
-            )
+            encoded_len = torch.where(keep_all_outputs, encoded_len, torch.full_like(encoded_len, valid_out_len))
         elif valid_out_len and not keep_all_outputs:
             # drop right context if any
             encoded = encoded[:, :, :valid_out_len]

--- a/nemo/collections/asr/inference/pipelines/base_pipeline.py
+++ b/nemo/collections/asr/inference/pipelines/base_pipeline.py
@@ -589,6 +589,7 @@ class BasePipeline(PipelineInterface):
         audio_filepaths: list[str],
         options: list[ASRRequestOptions] | None = None,
         progress_bar: ProgressBar | None = None,
+        audio_samples: list[Tensor] | None = None,
     ) -> dict:
         """
         Orchestrates reading from audio_filepaths in a streaming manner,
@@ -597,6 +598,8 @@ class BasePipeline(PipelineInterface):
             audio_filepaths (list[str]): List of audio filepaths to transcribe.
             options (list[ASRRequestOptions] | None): List of RequestOptions for each stream.
             progress_bar (ProgressBar | None): Progress bar to show the progress. Default is None.
+            audio_samples (list[Tensor] | None): Preloaded audio samples, one tensor per filepath, already at
+                the pipeline's sample rate. When given, no audio file is read from disk during the run.
         Returns:
             dict: A dictionary containing transcriptions and segments for each stream.
         """
@@ -611,7 +614,7 @@ class BasePipeline(PipelineInterface):
             raise ValueError("options must be the same length as audio_filepaths")
 
         request_generator = self.get_request_generator()
-        request_generator.set_audio_filepaths(audio_filepaths, options)
+        request_generator.set_audio_filepaths(audio_filepaths, options, audio_samples=audio_samples)
         request_generator.set_progress_bar(progress_bar)
 
         pipeline_output = {}

--- a/nemo/collections/asr/inference/pipelines/cache_aware_ctc_pipeline.py
+++ b/nemo/collections/asr/inference/pipelines/cache_aware_ctc_pipeline.py
@@ -338,6 +338,8 @@ class CacheAwareCTCPipeline(BasePipeline):
             frames: (list[Frame]) List of frames to transcribe.
         """
         all_fbuffers, right_paddings = self.bufferer.update(frames)
+        # the bufferer keeps the batch together for the RNNT pipeline; this one still works per stream
+        all_fbuffers, right_paddings = list(all_fbuffers.unbind(0)), right_paddings.tolist()
 
         ready_state_ids = set()
         if len(all_fbuffers) > 0:

--- a/nemo/collections/asr/inference/pipelines/cache_aware_rnnt_pipeline.py
+++ b/nemo/collections/asr/inference/pipelines/cache_aware_rnnt_pipeline.py
@@ -279,15 +279,31 @@ class CacheAwareRNNTPipeline(BasePipeline):
         """Return the separator for the text processor."""
         return self.sep
 
-    def preprocess(self, buffers: list[Tensor], right_paddings: list[int] | None = None) -> tuple[Tensor, Tensor]:
+    def preprocess(
+        self,
+        buffers: list[Tensor] | Tensor,
+        right_paddings: list[int] | Tensor | None = None,
+    ) -> tuple[Tensor, Tensor]:
         """
         Preprocess the feature buffers by stacking them and computing the lengths
         Args:
-            buffers: (list[Tensor]) List of feature buffers.
-            right_paddings: (list[int] | None) List of right paddings.
+            buffers: (list[Tensor] | Tensor) List of feature buffers, or one batched (B, F, T) tensor.
+            right_paddings: (list[int] | Tensor | None) Right paddings, per stream or batched.
         Returns:
             (tuple[Tensor, Tensor]) Processed feature buffers and their lengths.
         """
+        if isinstance(buffers, Tensor):
+            # already batched by the bufferer: no stacking, and no host round trip for the lengths
+            feature_buffers = drop_trailing_features(buffers, self.expected_feature_buffer_len)
+            feature_buffer_lens = torch.full(
+                (feature_buffers.shape[0],), feature_buffers.shape[2], device=self.device, dtype=torch.long
+            )
+            if right_paddings is not None:
+                if not isinstance(right_paddings, Tensor):
+                    right_paddings = torch.tensor(right_paddings, device=self.device)
+                feature_buffer_lens = feature_buffer_lens - right_paddings
+            return feature_buffers.to(self.device), feature_buffer_lens
+
         feature_buffers = [f_buffer.unsqueeze_(0) for f_buffer in buffers]
         # Trim to expected feature buffer length (safeguard for external feature buffer inputs)
         feature_buffers = [
@@ -295,7 +311,8 @@ class CacheAwareRNNTPipeline(BasePipeline):
         ]
         feature_buffer_lens = torch.tensor([f_buffer.shape[2] for f_buffer in feature_buffers], device=self.device)
         if right_paddings is not None:
-            right_paddings = torch.tensor(right_paddings, device=feature_buffer_lens.device)
+            if not isinstance(right_paddings, Tensor):
+                right_paddings = torch.tensor(right_paddings, device=feature_buffer_lens.device)
             feature_buffer_lens = feature_buffer_lens - right_paddings
         feature_buffers = torch.cat(feature_buffers).to(self.device)
         return feature_buffers, feature_buffer_lens
@@ -434,8 +451,8 @@ class CacheAwareRNNTPipeline(BasePipeline):
     def cache_aware_transcribe_step(
         self,
         requests: list[Request],
-        features: list[Tensor],
-        right_paddings: list[int],
+        features: list[Tensor] | Tensor,
+        right_paddings: list[int] | Tensor,
         ready_state_ids: set,
         keep_all_outputs: bool | Tensor = False,
     ) -> None:
@@ -453,8 +470,8 @@ class CacheAwareRNNTPipeline(BasePipeline):
         8. Update the ready states to indicate that the state is ready for text post-processing
         Args:
             requests: (list[Request]) List of requests (frames or feature buffers) to transcribe.
-            features: (list[Tensor]) List of feature buffers.
-            right_paddings: (list[int] | None) List of right paddings.
+            features: (list[Tensor] | Tensor) Feature buffers, per stream or batched (B, F, T).
+            right_paddings: (list[int] | Tensor | None) Right paddings, per stream or batched.
             ready_state_ids: (set) Set of ready state IDs.
             keep_all_outputs: (bool | Tensor) Whether to keep all outputs; a bool vector of shape [B]
                 keeps them per stream, so one call can serve last and non-last chunks together.

--- a/nemo/collections/asr/inference/pipelines/cache_aware_rnnt_pipeline.py
+++ b/nemo/collections/asr/inference/pipelines/cache_aware_rnnt_pipeline.py
@@ -90,7 +90,20 @@ class CacheAwareRNNTPipeline(BasePipeline):
         self.init_text_processor(cfg, itn_model)
         self.init_nmt_model(nmt_model)
         self.init_decoding_computer()
+        self.init_compiled_encoder(cfg)
         super().__init__()
+
+    def init_compiled_encoder(self, cfg: DictConfig) -> None:
+        """
+        Compile the encoder layers unless the encoder is running its own CUDA-graph path.
+        Args:
+            cfg: (DictConfig) Configuration parameters.
+        """
+        if cfg.asr.get("use_cuda_graphs", False):
+            return
+        compiled = self.asr_model.compile_encoder_layers()
+        if compiled:
+            logging.info(f"Compiled {compiled} encoder layers with torch.compile")
 
     def init_decoding_computer(self) -> None:
         """Initialize ``decoding_computer``."""

--- a/nemo/collections/asr/inference/pipelines/cache_aware_rnnt_pipeline.py
+++ b/nemo/collections/asr/inference/pipelines/cache_aware_rnnt_pipeline.py
@@ -308,7 +308,7 @@ class CacheAwareRNNTPipeline(BasePipeline):
         context,
         previous_hypotheses: list[Hypothesis | None],
         drop_extra_pre_encoded: int,
-        keep_all_outputs: bool,
+        keep_all_outputs: bool | Tensor,
         prompt_vectors: Tensor | None,
     ) -> tuple[list[Hypothesis], object]:
         """
@@ -437,7 +437,7 @@ class CacheAwareRNNTPipeline(BasePipeline):
         features: list[Tensor],
         right_paddings: list[int],
         ready_state_ids: set,
-        keep_all_outputs: bool = False,
+        keep_all_outputs: bool | Tensor = False,
     ) -> None:
         """
         Cache Aware Transcribe Step
@@ -456,7 +456,8 @@ class CacheAwareRNNTPipeline(BasePipeline):
             features: (list[Tensor]) List of feature buffers.
             right_paddings: (list[int] | None) List of right paddings.
             ready_state_ids: (set) Set of ready state IDs.
-            keep_all_outputs: (bool) Whether to keep all outputs or not.
+            keep_all_outputs: (bool | Tensor) Whether to keep all outputs; a bool vector of shape [B]
+                keeps them per stream, so one call can serve last and non-last chunks together.
         """
 
         feature_buffers, feature_buffer_lens = self.preprocess(features, right_paddings)
@@ -524,6 +525,24 @@ class CacheAwareRNNTPipeline(BasePipeline):
                 if eos:
                     state.reset_beam_decoding_state_()
 
+    def _keep_mask(self, is_last: list[bool]) -> bool | Tensor:
+        """
+        The keep_all_outputs argument for a batch of streams.
+
+        A batch that is all last or all non-last keeps the cheaper scalar form, which lets the encoder
+        trim the right context itself; only a mixed batch needs the per-stream vector, which is what
+        lets one call serve it instead of two.
+        Args:
+            is_last: (list[bool]) whether each stream of the batch is on its last chunk
+        Returns:
+            (bool | Tensor) scalar when the batch is uniform, otherwise a bool vector of shape [B]
+        """
+        if all(is_last):
+            return True
+        if not any(is_last):
+            return False
+        return torch.tensor(is_last, device=self.device, dtype=torch.bool)
+
     def transcribe_step_for_feature_buffers(self, fbuffers: list[FeatureBuffer]) -> None:
         """
         Transcribes the feature buffers in a streaming manner.
@@ -534,30 +553,13 @@ class CacheAwareRNNTPipeline(BasePipeline):
         """
         ready_state_ids = set()
 
-        final_fbuffers, final_features = [], []
-        nonfinal_fbuffers, nonfinal_features = [], []
-        final_right_paddings = []
+        features = [fbuffer.features for fbuffer in fbuffers]
+        right_paddings = [max(0, self.expected_feature_buffer_len - fbuffer.valid_size) for fbuffer in fbuffers]
+        is_last = [fbuffer.is_last for fbuffer in fbuffers]
 
-        for fbuffer in fbuffers:
-            feature = fbuffer.features
-            right_padding = max(0, self.expected_feature_buffer_len - fbuffer.valid_size)
-
-            if fbuffer.is_last:
-                final_fbuffers.append(fbuffer)
-                final_features.append(feature)
-                final_right_paddings.append(right_padding)
-            else:
-                nonfinal_fbuffers.append(fbuffer)
-                nonfinal_features.append(feature)
-
-        if len(nonfinal_fbuffers) > 0:
+        if len(fbuffers) > 0:
             self.cache_aware_transcribe_step(
-                nonfinal_fbuffers, nonfinal_features, None, ready_state_ids, keep_all_outputs=False
-            )
-
-        if len(final_fbuffers) > 0:
-            self.cache_aware_transcribe_step(
-                final_fbuffers, final_features, final_right_paddings, ready_state_ids, keep_all_outputs=True
+                fbuffers, features, right_paddings, ready_state_ids, keep_all_outputs=self._keep_mask(is_last)
             )
 
         if len(ready_state_ids) > 0:
@@ -580,30 +582,10 @@ class CacheAwareRNNTPipeline(BasePipeline):
 
         # streams that contains multiple frames
         if len(all_fbuffers) > 0:
-            final_frames, final_fbuffers = [], []
-            nonfinal_frames, nonfinal_fbuffers = [], []
-            final_right_paddings = []
-
-            for jdx, bfeature in enumerate(all_fbuffers):
-                bframe = frames[jdx]
-
-                if bframe.is_last:
-                    final_frames.append(bframe)
-                    final_fbuffers.append(bfeature)
-                    final_right_paddings.append(right_paddings[jdx])
-                else:
-                    nonfinal_frames.append(bframe)
-                    nonfinal_fbuffers.append(bfeature)
-
-            if len(nonfinal_frames) > 0:
-                self.cache_aware_transcribe_step(
-                    nonfinal_frames, nonfinal_fbuffers, None, ready_state_ids, keep_all_outputs=False
-                )
-
-            if len(final_frames) > 0:
-                self.cache_aware_transcribe_step(
-                    final_frames, final_fbuffers, final_right_paddings, ready_state_ids, keep_all_outputs=True
-                )
+            is_last = [frame.is_last for frame in frames]
+            self.cache_aware_transcribe_step(
+                frames, all_fbuffers, right_paddings, ready_state_ids, keep_all_outputs=self._keep_mask(is_last)
+            )
 
         # post-process the ready states
         if len(ready_state_ids) > 0:

--- a/nemo/collections/asr/inference/pipelines/cache_aware_rnnt_pipeline.py
+++ b/nemo/collections/asr/inference/pipelines/cache_aware_rnnt_pipeline.py
@@ -101,9 +101,8 @@ class CacheAwareRNNTPipeline(BasePipeline):
         """
         if cfg.asr.get("use_cuda_graphs", False):
             return
-        compiled = self.asr_model.compile_encoder_layers()
-        if compiled:
-            logging.info(f"Compiled {compiled} encoder layers with torch.compile")
+        if self.asr_model.compile_encoder_layers():
+            logging.info("Compiled the encoder with torch.compile")
 
     def init_decoding_computer(self) -> None:
         """Initialize ``decoding_computer``."""

--- a/nemo/collections/asr/inference/streaming/buffering/cache_feature_bufferer.py
+++ b/nemo/collections/asr/inference/streaming/buffering/cache_feature_bufferer.py
@@ -148,21 +148,27 @@ class BatchedCacheFeatureBufferer:
         right_padding = (features.shape[2] - feature_lens).clamp(min=0).to(torch.long)
         return features, right_padding
 
-    def _update_feature_buffer(self, slot_ids: list[int], feat_chunk: Tensor) -> None:
+    def _update_feature_buffer(self, slot_ids: Tensor, feat_chunk: Tensor) -> Tensor:
         """
-        Add an extracted feature to `feature_buffer`
-        Args:
-            slot_ids (list[int]): list of slot ids
-            feat_chunk (Tensor): feature chunk of shape (B, F, T)
-        """
-        for i, slot_id in enumerate(slot_ids):
-            chunk_len = feat_chunk[i].shape[-1]
-            if chunk_len > self.feature_buffer_len:
-                raise ValueError(f"feat_chunk ({chunk_len}) longer than buffer ({self.feature_buffer_len})")
+        Shift the buffers of `slot_ids` left by the chunk length and append the new feature chunk.
 
-            shifted = self.feature_buffer[slot_id, :, chunk_len:].clone()
-            self.feature_buffer[slot_id, :, :-chunk_len].copy_(shifted)
-            self.feature_buffer[slot_id, :, -chunk_len:].copy_(feat_chunk[i])
+        The whole batch is shifted with one gather, one concatenation and one scatter instead of three
+        copies per slot; every slot of a batch holds one distinct stream and every chunk has the same
+        length, so this moves exactly the same data as the per-slot loop did.
+        Args:
+            slot_ids (Tensor): slot indices of the batch, shape (B,).
+            feat_chunk (Tensor): feature chunk of shape (B, F, T).
+        Returns:
+            (Tensor) the updated feature buffers of the batch, shape (B, F, feature_buffer_len).
+        """
+        chunk_len = feat_chunk.shape[-1]
+        if chunk_len > self.feature_buffer_len:
+            raise ValueError(f"feat_chunk ({chunk_len}) longer than buffer ({self.feature_buffer_len})")
+
+        buffers = self.feature_buffer.index_select(0, slot_ids)
+        buffers = torch.cat([buffers[:, :, chunk_len:], feat_chunk], dim=2)
+        self.feature_buffer.index_copy_(0, slot_ids, buffers)
+        return buffers
 
     def update(self, frames: list[Frame]) -> tuple[list[Tensor], list[int]]:
         """
@@ -217,8 +223,11 @@ class BatchedCacheFeatureBufferer:
             right_paddings=right_paddings,
             expected_feat_len=self.feature_chunk_len + self.plus_one,
         )
-        self._update_feature_buffer(slot_ids=slot_ids, feat_chunk=features[:, :, -self.feature_chunk_len :])
-        fbuffers = list(self.feature_buffer[slot_ids].unbind(0))
+        slot_ids_tensor = torch.tensor(slot_ids, device=self.device, dtype=torch.long)
+        buffers = self._update_feature_buffer(
+            slot_ids=slot_ids_tensor, feat_chunk=features[:, :, -self.feature_chunk_len :]
+        )
+        fbuffers = list(buffers.unbind(0))
 
         if len(slots_to_free) > 0:
             self.free_slots(slots_to_free)

--- a/nemo/collections/asr/inference/streaming/buffering/cache_feature_bufferer.py
+++ b/nemo/collections/asr/inference/streaming/buffering/cache_feature_bufferer.py
@@ -170,17 +170,21 @@ class BatchedCacheFeatureBufferer:
         self.feature_buffer.index_copy_(0, slot_ids, buffers)
         return buffers
 
-    def update(self, frames: list[Frame]) -> tuple[list[Tensor], list[int]]:
+    def update(self, frames: list[Frame]) -> tuple[Tensor, Tensor]:
         """
         Update the feature bufferers with the new frames.
+
+        The buffers and the right paddings stay batched: unbinding them here only to have the caller
+        stack them again costs a copy per stream, and reading the paddings back to Python costs a
+        device synchronization on every step.
         Args:
             frames (list[Frame]): list of frames with length equal to batch size
         Returns:
-            tuple[list[Tensor], list[int]]: feature buffers and right paddings
+            tuple[Tensor, Tensor]: feature buffers of shape (B, F, T) and right paddings of shape (B,)
         """
-        # if there are no frames, return empty lists
+        # if there are no frames, return empty batches
         if len(frames) == 0:
-            return [], []
+            return torch.empty(0, device=self.device), torch.empty(0, dtype=torch.long, device=self.device)
 
         # if the stream_id is new, we need to assign a slot to it
         slot_ids, slots_to_reset, slots_to_free = [], [], []
@@ -203,11 +207,13 @@ class BatchedCacheFeatureBufferer:
         if len(slots_to_reset) > 0:
             self.reset_slots(slots_to_reset)
 
-        right_paddings = torch.zeros(len(frames), dtype=torch.long, device=self.device)
+        # one transfer for the whole batch instead of a scalar copy per stream
+        right_paddings = torch.tensor(
+            [frame.size - frame.valid_size for frame in frames], dtype=torch.long, device=self.device
+        )
         audio_buffers = []
         for i, frame in enumerate(frames):
             slot_id = slot_ids[i]
-            right_paddings[i] = frame.size - frame.valid_size
             self.audio_bufferers[slot_id].update(frame)
 
             buffer = self.audio_bufferers[slot_id].sample_buffer
@@ -227,9 +233,7 @@ class BatchedCacheFeatureBufferer:
         buffers = self._update_feature_buffer(
             slot_ids=slot_ids_tensor, feat_chunk=features[:, :, -self.feature_chunk_len :]
         )
-        fbuffers = list(buffers.unbind(0))
-
         if len(slots_to_free) > 0:
             self.free_slots(slots_to_free)
 
-        return fbuffers, right_paddings.tolist()
+        return buffers, right_paddings

--- a/nemo/collections/asr/inference/streaming/framing/multi_stream.py
+++ b/nemo/collections/asr/inference/streaming/framing/multi_stream.py
@@ -124,18 +124,28 @@ class ContinuousBatchedFrameStreamer:
         self._progress_bar = None
         self.processed_streams = set()
 
-    def set_audio_filepaths(self, audio_filepaths: list[str], options: list[RequestOptions]) -> None:
+    def set_audio_filepaths(
+        self,
+        audio_filepaths: list[str],
+        options: list[RequestOptions],
+        audio_samples: list[torch.Tensor] | None = None,
+    ) -> None:
         """
         Set the audio filepaths
         Args:
             audio_filepaths (list[str]): The list of audio filepaths
             options (list[RequestOptions]): The list of options
+            audio_samples (list[torch.Tensor] | None): Preloaded audio samples, one tensor per filepath.
+                When given, streams are fed from these tensors and no audio file is read from disk.
         """
         if len(audio_filepaths) != len(options):
             raise ValueError("audio_filepaths and options must have the same length")
+        if audio_samples is not None and len(audio_samples) != len(audio_filepaths):
+            raise ValueError("audio_filepaths and audio_samples must have the same length")
 
         self.audio_filepaths = audio_filepaths
         self.options = options
+        self.audio_samples = audio_samples
         self.n_audio_files = len(audio_filepaths)
         self.total_progress_steps = self.n_audio_files * 2  # One step for adding, one for processing
         self.sid2filepath = {}
@@ -183,7 +193,10 @@ class ContinuousBatchedFrameStreamer:
         options = self.options[self.stream_id]
         self.sid2filepath[self.stream_id] = audio_filepath
         self.elapsed_durations[self.stream_id] = 0.0
-        stream.load_audio(audio_filepath, options)
+        if self.audio_samples is not None:
+            stream.load_audio(self.audio_samples[self.stream_id], options)
+        else:
+            stream.load_audio(audio_filepath, options)
 
         # Add the stream to the multi streamer
         self.multi_streamer.add_stream(stream, stream_id=self.stream_id)
@@ -284,14 +297,20 @@ class ContinuousBatchedRequestStreamer:
             )
             self.right_pad_features = right_pad_features
 
-    def set_audio_filepaths(self, audio_filepaths: list[str], options: list[RequestOptions]) -> None:
+    def set_audio_filepaths(
+        self,
+        audio_filepaths: list[str],
+        options: list[RequestOptions],
+        audio_samples: list[torch.Tensor] | None = None,
+    ) -> None:
         """
         Set the audio filepaths
         Args:
             audio_filepaths (list[str]): The list of audio filepaths
             options (list[RequestOptions]): The list of options
+            audio_samples (list[torch.Tensor] | None): Preloaded audio samples, one tensor per filepath.
         """
-        self.multi_streamer.set_audio_filepaths(audio_filepaths, options)
+        self.multi_streamer.set_audio_filepaths(audio_filepaths, options, audio_samples=audio_samples)
 
     def set_progress_bar(self, progress_bar: ProgressBar) -> None:
         """

--- a/nemo/collections/asr/inference/utils/context_manager.py
+++ b/nemo/collections/asr/inference/utils/context_manager.py
@@ -89,6 +89,27 @@ class CacheAwareContextManager:
             self.cache_last_channel_len,  # B
         ) = self.cache_aware_model.get_initial_cache_state(self.num_slots)
         self.device = self.cache_last_channel.device
+        # reusable buffers for the slot ids of the active batch, so no tensor is built per step
+        self._slot_ids_host = torch.empty(self.num_slots, dtype=torch.long, pin_memory=True)
+        self._slot_ids_dev = torch.empty(self.num_slots, dtype=torch.long, device=self.device)
+        self._slot_ids_list: list[int] = []
+        self._slot_ids_contiguous = False
+
+    def _set_active_slots(self, slot_ids: list[int]) -> Tensor:
+        """
+        Records the slots of the active batch in the reusable buffers and returns them as a tensor.
+        Args:
+            slot_ids: slot index per element of the active batch, in batch order
+        Returns:
+            (Tensor) the slot ids on the cache device
+        """
+        self._slot_ids_list = slot_ids
+        self._slot_ids_contiguous = slot_ids == list(range(len(slot_ids)))
+        host = self._slot_ids_host[: len(slot_ids)]
+        host.copy_(torch.tensor(slot_ids, dtype=torch.long))
+        dev = self._slot_ids_dev[: len(slot_ids)]
+        dev.copy_(host, non_blocking=True)
+        return dev
 
     def _reset_slots(self, slot_ids: list[int]) -> None:
         """
@@ -96,7 +117,7 @@ class CacheAwareContextManager:
         Args:
             slot_ids: list of slot indices to reset
         """
-        if self.cache_disabled:
+        if self.cache_disabled or len(slot_ids) == 0:
             return
 
         slot_ids_tensor = torch.tensor(slot_ids, device=self.device, dtype=torch.long)
@@ -124,19 +145,19 @@ class CacheAwareContextManager:
             return
 
         slot_ids_list = [self.streamidx2slotidx[sid] for sid in stream_ids]
-        slot_ids = torch.tensor(slot_ids_list, device=self.device, dtype=torch.long)
-        tgt_slot_ids = torch.tensor(
-            [mapping[sid] for sid in slot_ids_list],
-            device=self.device,
-            dtype=torch.long,
-        )
+        # `mapping` sends each slot to its position in the batch, so the gather it would drive is the
+        # identity and is skipped; new_context is already in batch order.
+        num = len(slot_ids_list)
+
+        if slot_ids_list == self._slot_ids_list:
+            slot_ids = self._slot_ids_dev[:num]
+        else:
+            slot_ids = torch.tensor(slot_ids_list, device=self.device, dtype=torch.long)
 
         # In-place copy along batch/slot dimension
-        self.cache_last_channel.index_copy_(1, slot_ids, new_context.cache_last_channel.index_select(1, tgt_slot_ids))
-        self.cache_last_time.index_copy_(1, slot_ids, new_context.cache_last_time.index_select(1, tgt_slot_ids))
-        self.cache_last_channel_len.index_copy_(
-            0, slot_ids, new_context.cache_last_channel_len.index_select(0, tgt_slot_ids)
-        )
+        self.cache_last_channel.index_copy_(1, slot_ids, new_context.cache_last_channel)
+        self.cache_last_time.index_copy_(1, slot_ids, new_context.cache_last_time)
+        self.cache_last_channel_len.index_copy_(0, slot_ids, new_context.cache_last_channel_len)
 
     def reset_slots(self, stream_ids: list[int], eos_flags: list[bool]) -> None:
         """
@@ -182,9 +203,12 @@ class CacheAwareContextManager:
 
         # get the cache for the particular stream_ids
         slot_ids = [self.streamidx2slotidx[stream_id] for stream_id in stream_ids]
-        cache_last_channel = self.cache_last_channel[:, slot_ids, :, :]
-        cache_last_time = self.cache_last_time[:, slot_ids, :, :]
-        cache_last_channel_len = self.cache_last_channel_len[slot_ids]
+        slot_ids_dev = self._set_active_slots(slot_ids)
+        # a gather, not a view of the slot prefix: the encoder is sensitive to the layout of the cache
+        # it reads, and a strided view changes which bf16 kernels it picks
+        cache_last_channel = self.cache_last_channel.index_select(1, slot_ids_dev)
+        cache_last_time = self.cache_last_time.index_select(1, slot_ids_dev)
+        cache_last_channel_len = self.cache_last_channel_len.index_select(0, slot_ids_dev)
 
         # create a context object
         context = CacheAwareContext(

--- a/nemo/collections/asr/inference/utils/manifest_io.py
+++ b/nemo/collections/asr/inference/utils/manifest_io.py
@@ -50,7 +50,8 @@ def prepare_audio_data(
     Args:
         audio_file: (str) Path to the audio file, folder or manifest file
         per_stream_biasing_defaults: default params for per-stream biasing
-        sort_by_duration: (bool) If True, sort the audio files by duration from shortest to longest
+        sort_by_duration: (bool) If True, sort the audio files by duration from longest to shortest, so the
+            continuous-batching tail (when no files are left to refill the batch) is made of short streams
     Returns:
         (list[str], list[dict] | None, list[ASRRequestOptions] | None, dict[str, int])
         List of audio filepaths, manifest, options and filepath order
@@ -98,7 +99,7 @@ def prepare_audio_data(
         indices = list(range(len(filepaths)))
         durations = [librosa.get_duration(path=filepaths[i]) for i in indices]
         indices_with_durations = list(zip(indices, durations))
-        indices_with_durations.sort(key=lambda x: x[1])
+        indices_with_durations.sort(key=lambda x: x[1], reverse=True)
         filepaths = [filepaths[i] for i, duration in indices_with_durations]
         if manifest is not None:
             # keep manifest in the same order as filepaths for consistency

--- a/nemo/collections/asr/parts/triton/subsampling.py
+++ b/nemo/collections/asr/parts/triton/subsampling.py
@@ -71,6 +71,18 @@ WINDOW_SIZE = tl.constexpr(KERNEL.value * WINDOW_COLS.value)
 TAPS = tl.constexpr(KERNEL.value * KERNEL.value)
 PAD = tl.constexpr(1 << (max(TAPS.value, WINDOW_SIZE.value) - 1).bit_length())  # a power of two
 
+# The same geometry as plain ints, for the host code below. A ``tl.constexpr`` implements
+# ``__index__``, so eager host code can reshape and slice with the wrappers directly, but Dynamo
+# does not honour it: under ``torch.compile`` a wrapper used as a slice bound raises TypeError.
+# The kernels keep the wrappers; everything outside them uses these.
+_KERNEL = KERNEL.value
+_STRIDE = STRIDE.value
+_NUM_BINS = NUM_BINS.value
+_WINDOW_COLS = WINDOW_COLS.value
+_WINDOW_SIZE = WINDOW_SIZE.value
+_TAPS = TAPS.value
+_PAD = PAD.value
+
 
 def _forward_configs():
     return [
@@ -373,18 +385,18 @@ def _backward_kernel(
 
 def _downsampled_length(length, pad_total):
     """Output extent of one strided convolution stage, floor mode. Takes ints or int tensors."""
-    return (length + pad_total - KERNEL.value) // STRIDE.value + 1
+    return (length + pad_total - _KERNEL) // _STRIDE + 1
 
 
 def _as_window(row):
     """Read a flat PAD-wide row back as the KERNEL x WINDOW_COLS window it holds."""
-    return row[:, :WINDOW_SIZE].reshape(-1, KERNEL, WINDOW_COLS)
+    return row[:, :_WINDOW_SIZE].reshape(-1, _KERNEL, _WINDOW_COLS)
 
 
 def _as_row(window):
     """Flatten a window into the PAD-wide row the kernel loads; PAD is the next power of two."""
-    row = window.new_zeros(window.shape[0], PAD)
-    row[:, :WINDOW_SIZE] = window.reshape(window.shape[0], WINDOW_SIZE)
+    row = window.new_zeros(window.shape[0], _PAD)
+    row[:, :_WINDOW_SIZE] = window.reshape(window.shape[0], _WINDOW_SIZE)
     return row
 
 
@@ -403,11 +415,11 @@ def _build_bin_taps(depth_weight):
     zeros stand in for a slice, which the flattened window tile cannot express.
     """
     channels = depth_weight.shape[0]
-    taps = depth_weight.reshape(channels, KERNEL, KERNEL)
-    bin0 = depth_weight.new_zeros(channels, KERNEL, WINDOW_COLS)
-    bin1 = depth_weight.new_zeros(channels, KERNEL, WINDOW_COLS)
-    bin0[..., :KERNEL] = taps
-    bin1[..., STRIDE:] = taps
+    taps = depth_weight.reshape(channels, _KERNEL, _KERNEL)
+    bin0 = depth_weight.new_zeros(channels, _KERNEL, _WINDOW_COLS)
+    bin1 = depth_weight.new_zeros(channels, _KERNEL, _WINDOW_COLS)
+    bin0[..., :_KERNEL] = taps
+    bin1[..., _STRIDE:] = taps
     return _as_row(bin0), _as_row(bin1)
 
 
@@ -438,7 +450,7 @@ class _FusedSubsampling(torch.autograd.Function):
 
         def grid(meta):
             return (
-                triton.cdiv(out_time, meta["TIME_ROWS"]) * triton.cdiv(out_freq, NUM_BINS),
+                triton.cdiv(out_time, meta["TIME_ROWS"]) * triton.cdiv(out_freq, _NUM_BINS),
                 triton.cdiv(channels, meta["CHANNEL_BLOCK"]),
                 batch_size,
             )
@@ -489,14 +501,14 @@ class _FusedSubsampling(torch.autograd.Function):
         (batch_size, channels, mel_freq, relu_out_freq, out_time, out_freq, pad_start) = ctx.shapes
         grad_output = grad_output.contiguous()
         device = grad_output.device
-        grad_conv_weight = torch.zeros((channels, PAD), device=device, dtype=torch.float32)
+        grad_conv_weight = torch.zeros((channels, _PAD), device=device, dtype=torch.float32)
         grad_conv_bias = torch.zeros((channels,), device=device, dtype=torch.float32)
-        acc_bin0 = torch.zeros((channels, PAD), device=device, dtype=torch.float32)
-        acc_bin1 = torch.zeros((channels, PAD), device=device, dtype=torch.float32)
+        acc_bin0 = torch.zeros((channels, _PAD), device=device, dtype=torch.float32)
+        acc_bin1 = torch.zeros((channels, _PAD), device=device, dtype=torch.float32)
         grad_depth_bias = torch.zeros((channels,), device=device, dtype=torch.float32)
 
         def grid(meta):
-            tiles = batch_size * triton.cdiv(out_time, meta["TIME_ROWS"]) * triton.cdiv(out_freq, NUM_BINS)
+            tiles = batch_size * triton.cdiv(out_time, meta["TIME_ROWS"]) * triton.cdiv(out_freq, _NUM_BINS)
             return triton.cdiv(channels, meta["CHANNEL_BLOCK"]), min(meta["TILE_SPLITS"], tiles)
 
         _backward_kernel[grid](
@@ -528,15 +540,15 @@ class _FusedSubsampling(torch.autograd.Function):
             grad_output.stride(2),
         )
         # Undo `_build_bin_taps`: each bin accumulated into the columns it read.
-        grad_depth_weight = (_as_window(acc_bin0)[..., :KERNEL] + _as_window(acc_bin1)[..., STRIDE:]).reshape(
-            channels, TAPS
+        grad_depth_weight = (_as_window(acc_bin0)[..., :_KERNEL] + _as_window(acc_bin1)[..., _STRIDE:]).reshape(
+            channels, _TAPS
         )
         conv_w_dtype, conv_b_dtype, depth_w_dtype, depth_b_dtype = ctx.param_dtypes
         return (
             None,  # mel
-            grad_conv_weight[:, :TAPS].view(channels, 1, KERNEL, KERNEL).to(conv_w_dtype),
+            grad_conv_weight[:, :_TAPS].view(channels, 1, _KERNEL, _KERNEL).to(conv_w_dtype),
             grad_conv_bias.to(conv_b_dtype),
-            grad_depth_weight.view(channels, 1, KERNEL, KERNEL).to(depth_w_dtype),
+            grad_depth_weight.view(channels, 1, _KERNEL, _KERNEL).to(depth_w_dtype),
             grad_depth_bias.to(depth_b_dtype),
             None,  # mel_lengths
             None,  # relu_out_lengths

--- a/nemo/collections/common/parts/rnn.py
+++ b/nemo/collections/common/parts/rnn.py
@@ -245,10 +245,11 @@ class LSTMDropout(torch.nn.Module):
         One timestep of the stacked LSTM, layer by layer, with `torch.lstm_cell`.
 
         Autoregressive transducer decoding calls this module once per symbol with a sequence length of
-        one. cuDNN spends about 0.4 ms of host time per such call setting up descriptors for 0.03 ms of
-        device work; `torch.lstm_cell` is the same recurrence without that setup. Accumulation order
-        inside the gate GEMM differs from cuDNN, so results agree to within low-precision rounding
-        rather than bit for bit.
+        one. Each such call pays cuDNN's fixed per-call setup — descriptors and workspace — for a single
+        timestep of work, and on a small batch that setup, not the arithmetic, is what the step costs;
+        `torch.lstm_cell` runs the same recurrence without it. How much this saves depends on the GPU,
+        the driver and the size of the prediction network. Accumulation order inside the gate GEMM
+        differs from cuDNN, so results agree to within low-precision rounding rather than bit for bit.
         Args:
             x: (torch.Tensor) input of shape (1, B, input_size).
             h: (tuple) `(h_0, c_0)`, each of shape (num_layers, B, hidden_size).

--- a/nemo/collections/common/parts/rnn.py
+++ b/nemo/collections/common/parts/rnn.py
@@ -276,6 +276,15 @@ class LSTMDropout(torch.nn.Module):
     def forward(
         self, x: torch.Tensor, h: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
     ) -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        """
+        Run the stacked LSTM over `x`, taking the unrolled path for a single inference timestep.
+
+        Args:
+            x: (torch.Tensor) input of shape (T, B, input_size).
+            h: (tuple | None) optional initial `(h_0, c_0)`, each of shape (num_layers, B, hidden_size).
+        Returns:
+            (tuple) output of shape (T, B, hidden_size) and the final `(h_n, c_n)`.
+        """
         if not self.training and h is not None and x.shape[0] == 1 and self._single_step_supported():
             return self._single_step(x, h)
 

--- a/nemo/collections/common/parts/rnn.py
+++ b/nemo/collections/common/parts/rnn.py
@@ -228,9 +228,56 @@ class LSTMDropout(torch.nn.Module):
             if 'weight' in name or 'bias' in name:
                 v.data *= float(weights_init_scale)
 
+    def _single_step_supported(self) -> bool:
+        """
+        Whether the unrolled single-timestep path may stand in for the cuDNN call.
+
+        Only the plain unidirectional, non-projected, sequence-first case is covered, and only in eval
+        mode, where the inter-layer dropout of `torch.nn.LSTM` and `self.dropout` are both identities.
+        """
+        lstm = self.lstm
+        return not lstm.bidirectional and lstm.proj_size == 0 and not lstm.batch_first
+
+    def _single_step(
+        self, x: torch.Tensor, h: Tuple[torch.Tensor, torch.Tensor]
+    ) -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        """
+        One timestep of the stacked LSTM, layer by layer, with `torch.lstm_cell`.
+
+        Autoregressive transducer decoding calls this module once per symbol with a sequence length of
+        one. cuDNN spends about 0.4 ms of host time per such call setting up descriptors for 0.03 ms of
+        device work; `torch.lstm_cell` is the same recurrence without that setup. Accumulation order
+        inside the gate GEMM differs from cuDNN, so results agree to within low-precision rounding
+        rather than bit for bit.
+        Args:
+            x: (torch.Tensor) input of shape (1, B, input_size).
+            h: (tuple) `(h_0, c_0)`, each of shape (num_layers, B, hidden_size).
+        Returns:
+            (tuple) output of shape (1, B, hidden_size) and the new `(h_n, c_n)`.
+        """
+        h_0, c_0 = h
+        inp = x[0]
+        h_n, c_n = [], []
+        for layer in range(self.lstm.num_layers):
+            h_l, c_l = torch.lstm_cell(
+                inp,
+                (h_0[layer], c_0[layer]),
+                getattr(self.lstm, f"weight_ih_l{layer}"),
+                getattr(self.lstm, f"weight_hh_l{layer}"),
+                getattr(self.lstm, f"bias_ih_l{layer}"),
+                getattr(self.lstm, f"bias_hh_l{layer}"),
+            )
+            h_n.append(h_l)
+            c_n.append(c_l)
+            inp = h_l
+        return inp.unsqueeze(0), (torch.stack(h_n), torch.stack(c_n))
+
     def forward(
         self, x: torch.Tensor, h: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
     ) -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        if not self.training and h is not None and x.shape[0] == 1 and self._single_step_supported():
+            return self._single_step(x, h)
+
         x, h = self.lstm(x, h)
 
         if self.dropout:

--- a/nemo/collections/common/parts/rnn.py
+++ b/nemo/collections/common/parts/rnn.py
@@ -237,8 +237,13 @@ class LSTMDropout(torch.nn.Module):
         Tracing keeps the cuDNN path whatever the shapes: `torch.lstm_cell` lowers to
         `aten::_thnn_fused_lstm_cell`, which the ONNX exporter has no symbolic for, and a traced graph
         should hold the general recurrence rather than one unrolled timestep of it.
+        Autocast keeps it too: `torch.nn.LSTM` casts to float16 under autocast whatever the autocast
+        dtype is, while `torch.lstm_cell` follows that dtype, so the two paths would return states of
+        different dtypes and a later `batch_copy_states` into a cached state would fail.
         """
         if torch.jit.is_tracing():
+            return False
+        if torch.is_autocast_enabled(self.lstm.weight_ih_l0.device.type):
             return False
         lstm = self.lstm
         return not lstm.bidirectional and lstm.proj_size == 0 and not lstm.batch_first

--- a/nemo/collections/common/parts/rnn.py
+++ b/nemo/collections/common/parts/rnn.py
@@ -234,7 +234,12 @@ class LSTMDropout(torch.nn.Module):
 
         Only the plain unidirectional, non-projected, sequence-first case is covered, and only in eval
         mode, where the inter-layer dropout of `torch.nn.LSTM` and `self.dropout` are both identities.
+        Tracing keeps the cuDNN path whatever the shapes: `torch.lstm_cell` lowers to
+        `aten::_thnn_fused_lstm_cell`, which the ONNX exporter has no symbolic for, and a traced graph
+        should hold the general recurrence rather than one unrolled timestep of it.
         """
+        if torch.jit.is_tracing():
+            return False
         lstm = self.lstm
         return not lstm.bidirectional and lstm.proj_size == 0 and not lstm.batch_first
 

--- a/tests/collections/asr/test_fast_subsampling.py
+++ b/tests/collections/asr/test_fast_subsampling.py
@@ -382,3 +382,23 @@ def test_state_dict_is_identical_with_and_without_triton():
 
     without_triton.load_state_dict(with_triton.state_dict())
     with_triton.load_state_dict(without_triton.state_dict())
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(not CUDA_TRITON_AVAILABLE, reason="CUDA and Triton are required")
+def test_bin_taps_survive_dynamo():
+    """The geometry constants must reach Dynamo as ints; a ``tl.constexpr`` is not one to it.
+
+    Eager code may index with the wrappers, since ``tl.constexpr`` implements ``__index__``, but
+    ``torch.compile`` traces rather than runs, and a wrapper used as a slice bound raises
+    ``TypeError: slice indices must be integers``. A caller that compiles the encoder puts this
+    function under Dynamo, so the host code holds the plain ints.
+    """
+    from nemo.collections.asr.parts.triton.subsampling import _build_bin_taps
+
+    depth_weight = torch.arange(CONV_CHANNELS * 9, dtype=torch.float32, device="cuda").reshape(CONV_CHANNELS, 9)
+
+    eager = _build_bin_taps(depth_weight)
+    compiled = torch.compile(_build_bin_taps, backend="eager")(depth_weight)
+
+    assert all(torch.equal(before, after) for before, after in zip(eager, compiled))


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Speed up the cache-aware streaming RNNT inference.

**Collection**: [ASR]

# Changelog

Nine ideas, one commit each, in the order they stack. Four came from one autoresearch campaign and
five from two later ones; each was accepted on its own A/B benchmark before it was picked here.

- `asr_streaming_infer.py`, `base_pipeline.py`, `multi_stream.py`, the five inference YAMLs
  (**A1 fix-rtfx**): read every audio file once before the timed loop and pass the tensors into
  `pipeline.run()`, so no file is read from disk inside the measured region. This changes what RTFx
  reports, not how fast the pipeline is. Preloaded audio stays in host memory for the whole run, so
  the script logs how much that is before loading, and `preload_audio: false` streams from disk as
  before for a manifest that does not fit, with the reported RTFx then including disk I/O.
- `manifest_io.py` (**A2 longest-first**): sort the input manifest longest-first, so the tail of a
  continuous-batching run — where no streams are left to refill the batch — is made of short streams.
- `cache_feature_bufferer.py` (**A3 batched-feat-shift**): shift the whole batch of feature buffers
  with one gather, one shift and one scatter instead of a Python loop over slots (about 190 kernel
  launches per step on a batch of 64).
- `rnn.py`, `LSTMDropout` (**A4 lstm-cell**): unroll the single-timestep eval step with
  `torch.lstm_cell` instead of the cuDNN call, for unidirectional, non-projected, sequence-first
  LSTMs with identity dropout. Transducer decoding calls the prediction network once per symbol with
  sequence length one, where cuDNN's fixed per-call setup dominates a single timestep of work on a
  small batch; how much this saves depends on the GPU, the driver and the size of the prediction
  network. Training, tracing and autocast are unchanged: the unrolled path is skipped in all three.
- `cache_aware_asr_inference_wrapper.py`, `cache_aware_ctc_pipeline.py` (**B1 compile-layers**):
  compile the cache-aware encoder layers with `torch.compile`.
- `cache_aware_asr_inference_wrapper.py`, `cache_aware_rnnt_pipeline.py`
  (**B2 compile-encoder-static-len**): compile the encoder as one graph with the chunk length pinned,
  so the shape solver sees a static length.
- `context_manager.py` (**B3 ctx-manager**): drop the identity gather and stop rebuilding the
  no-slot tensors on every step.
- `cache_aware_rnnt_pipeline.py`, `cache_aware_rnnt_inference_wrapper.py` (**B4 merged-step**): run
  one step for a batch that mixes last and non-last chunks, instead of splitting the batch in two.
- `cache_feature_bufferer.py`, `cache_aware_rnnt_pipeline.py`, `cache_aware_asr_inference_wrapper.py`
  (**B5 batch-plumbing**): keep the batch batched across the feature-bufferer step boundary.

# Usage

No API change: the same entry point, the same YAML, the same flags.

## Before / After

Full LibriSpeech test-other (2939 utterances, 5.34 h), `nvidia/nemotron-speech-streaming-en-0.6b`,
cache-aware RNNT, greedy without LM, no CUDA graphs, no end-of-utterance, bfloat16, `num_slots=256`,
one RTX 5000 Ada (unshared), 1 warmup and 3 measured repeats per point, RTFx reported as the median
over repeats. WER is scored outside the pipeline with `--norm-mode lowercase_punctuation`.

### The branch as a whole

Both sides measured in one session, the baseline re-run on upstream `de26b36` at the same time as the
candidate.

| batch size | RTFx before | RTFx after | change | exec s before | exec s after | WER before | WER after | peak GPU MiB |
|---|---|---|---|---|---|---|---|---|
| 64 | 532.81 | 920.58 | +72.8% | 36.09 | 20.89 | 0.0756 | 0.0754 | 6864 → 6818 |
| 128 | 747.27 | 1238.46 | +65.7% | 25.73 | 15.53 | 0.0758 | 0.0750 | 8056 → 7562 |
| 256 | 922.19 | 1379.25 | +49.6% | 20.85 | 13.94 | 0.0754 | 0.0753 | 9936 → 9052 |

### What each idea contributes

Two ladders, measured against different bases, so read them separately rather than as one chain.

**A1–A4**, each rung against the one below, measured in an earlier session against upstream `de26b36`:

RTFx before → after at that rung, with the change over the rung below.

| | idea | bs=64 | bs=128 | bs=256 |
|---|---|---|---|---|
| | upstream `de26b36` | 514.81 | 731.18 | 936.34 |
| A1 | fix-rtfx | 514.81 → 572.91 (+11.3%) | 731.18 → 799.07 (+9.3%) | 936.34 → 1011.03 (+8.0%) |
| A2 | longest-first | 572.91 → 545.82 (−4.7%) | 799.07 → 834.55 (+4.4%) | 1011.03 → 1089.48 (+7.8%) |
| A3 | batched-feat-shift | 545.82 → 565.77 (+3.7%)◇ | 834.55 → 862.62 (+3.4%) | 1089.48 → 1121.24 (+2.9%) |
| A4 | lstm-cell | 565.77 → 606.51 (+7.2%) | 862.62 → 903.16 (+4.7%) | 1121.24 → 1165.00 (+3.9%) |

**B1–B5**, each rung against the one below, measured in this session on top of A1–A4:

| | idea | bs=64 | bs=128 | bs=256 |
|---|---|---|---|---|
| | A1–A4 plus review commits | 597.72 | 916.83 | 1158.39 |
| B1 | compile-layers | 597.72 → 656.56 (+9.8%) | 916.83 → 959.80 (+4.7%) | 1158.39 → 1184.80 (+2.3%) |
| B2 | compile-encoder-static-len | 656.56 → 703.28 (+7.1%) | 959.80 → 998.02 (+4.0%) | 1184.80 → 1184.27 (−0.04%)◇ |
| B3 | ctx-manager | 703.28 → 711.99 (+1.2%) | 998.02 → 1007.83 (+1.0%)◇ | 1184.27 → 1244.81 (+5.1%) |
| B4 | merged-step | 711.99 → 898.19 (+26.2%) | 1007.83 → 1208.81 (+19.9%) | 1244.81 → 1349.48 (+8.4%) |
| B5 | batch-plumbing | 898.19 → 920.58 (+2.5%) | 1208.81 → 1238.46 (+2.5%) | 1349.48 → 1379.25 (+2.2%) |

◇ marks a rung whose measured ranges overlap: the sign is what was measured, but the effect is not
separated from run-to-run variation at that batch size.

Three things these rows say that the totals do not:

- **A1 is a measurement correction, not a speedup.** It moves audio reading out of the timed region;
  the pipeline does the same work at the same speed. Its rung is the size of the disk I/O that used
  to be counted.
- **A2 costs 4.7% at batch size 64 and pays 7.8% at 256.** Longest-first ordering shortens the tail
  of a continuous-batching run, which matters more as the batch grows. It is kept because the stack
  is faster with it at the batch sizes this model is served at, not because it helps everywhere.
- **B4 carries the PR.** It is worth more than the other eight rungs put together at every batch
  size, and B1 and B2 fade as the batch grows — B2 is within noise at 256.


### Peak GPU memory

Peak device memory in use during the run, MiB, at each rung of the B ladder. The A1–A4 rungs are
omitted: they were measured in the earlier session and none of them moved memory by more than the
8 MiB seen between the two baselines below.

| | rung | bs=64 | bs=128 | bs=256 |
|---|---|---|---|---|
| | upstream `de26b36` | 6864 | 8056 | 9936 |
| | A1–A4 plus review commits | 6864 | 8056 | 9928 |
| B1 | compile-layers | 6860 | 8056 | 9888 |
| B2 | compile-encoder-static-len | 7040 | 8022 | 9920 |
| B3 | ctx-manager | **6830** | **7602** | **9080** |
| B4 | merged-step | 6820 | 7562 | 9052 |
| B5 | batch-plumbing (tip) | 6818 | 7562 | 9052 |
| | **total change** | **−46** | **−494** | **−884** |

### A second benchmark: Earnings-22

The stack was developed and tuned entirely on LibriSpeech test-other, so it was also run end to end
on Earnings-22, which it was never tuned against.

| batch size | WER before | WER after | change | RTFx before | RTFx after | change |
|---|---|---|---|---|---|---|
| 64 | 0.1924 | 0.1921 | −0.0003 | 463.04 | 891.04 | +92.4% |
| 128 | 0.1918 | 0.1915 | −0.0003 | 705.45 | 1199.85 | +70.1% |
| 256 | 0.1920 | 0.1919 | −0.0001 | 895.07 | 1373.87 | +53.5% |

### The cache-aware CTC path

Two of the commits touch code the CTC pipeline shares — B1 edits `cache_aware_ctc_pipeline.py` and
`cache_aware_asr_inference_wrapper.py`, B5 edits the feature bufferer and the same wrapper — and no
benchmark above exercises that path. It was therefore run end to end as well, at the
`cache_aware_ctc.yaml` defaults: the default model `stt_en_fastconformer_hybrid_large_streaming_multi`,
CTC decoding, `num_slots=1024` and end-of-utterance enabled at 800 ms, none of which the RNNT
measurements above use. Full tier, batch size 256, upstream `de26b36` against the tip of this branch.

| benchmark | WER before | WER after | change | RTFx before | RTFx after | change |
|---|---|---|---|---|---|---|
| LibriSpeech test-other | 0.0997 | 0.0995 | −0.0002 | 1574.44 | 2464.01 | +56.5% |
| Earnings-22 | 0.2680 | 0.2680 | 0.0000 | 1525.16 | 2289.29 | +50.1% |


# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

Trusted PRs run automatically through copy-pr-bot. For an untrusted PR, a maintainer can trigger CI by commenting
`/ok to test <head-sha>`; repeat this after a new push if the PR remains untrusted.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
