### PR TITLE
[audio codec] Apply MMD loss to pre-dropout embeddings

### DIFF
--- a/nemo/collections/tts/models/audio_codec.py
+++ b/nemo/collections/tts/models/audio_codec.py
@@ -605,15 +605,18 @@ class AudioCodecModel(ModelPT):
         else:
             commit_loss = 0.0
 
+        # Preserve the complete quantized representation in `encoded` for
+        # representation losses such as MMD.
+        decoder_inputs = encoded
         if self.training and self.codebook_dropout_rate:
-            encoded = self._dropout_random_codebooks(encoded)
+            decoder_inputs = self._dropout_random_codebooks(encoded)
 
         # [B, T]
-        audio_gen, _ = self.audio_decoder(inputs=encoded, input_len=encoded_len)
+        audio_gen, _ = self.audio_decoder(inputs=decoder_inputs, input_len=encoded_len)
 
         if self.training and self.use_slm_loss:
             slm_emb = self.slm_encoder(audio=audio)
-            slm_emb_pred = self.slm_predictor(inputs=encoded)
+            slm_emb_pred = self.slm_predictor(inputs=decoder_inputs)
         else:
             slm_emb = None
             slm_emb_pred = None
@@ -675,7 +678,7 @@ class AudioCodecModel(ModelPT):
         else:
             optim_gen, optim_disc = self.optimizers()
 
-        audio, audio_len, audio_gen, commit_loss, codes, slm_emb, slm_emb_pred = self._process_batch(batch)
+        audio, audio_len, audio_gen, commit_loss, encoded, slm_emb, slm_emb_pred = self._process_batch(batch)
 
         metrics = {
             "global_step": self.global_step,
@@ -744,13 +747,13 @@ class AudioCodecModel(ModelPT):
             generator_losses.append(self.commit_loss_scale * commit_loss)
 
         if self.mmd_loss_scale:
-            loss_mmd = self.mmd_loss_fn(inputs=codes)
+            loss_mmd = self.mmd_loss_fn(inputs=encoded)
             metrics["g_loss_mmd"] = loss_mmd
             if self.current_epoch >= self.mmd_loss_start_epoch:
                 generator_losses.append(self.mmd_loss_scale * loss_mmd)
 
         if self.mmd_time_loss_scale:
-            loss_mmd_time = self.mmd_time_loss_fn(inputs=codes)
+            loss_mmd_time = self.mmd_time_loss_fn(inputs=encoded)
             metrics["g_loss_mmd_time"] = loss_mmd_time
             if self.current_epoch >= self.mmd_loss_start_epoch:
                 generator_losses.append(self.mmd_time_loss_scale * loss_mmd_time)

--- a/nemo/collections/tts/models/audio_codec.py
+++ b/nemo/collections/tts/models/audio_codec.py
@@ -605,11 +605,16 @@ class AudioCodecModel(ModelPT):
         else:
             commit_loss = 0.0
 
-        # Preserve the complete quantized representation in `encoded` for
-        # representation losses such as MMD.
+        mmd_inputs = encoded
         decoder_inputs = encoded
         if self.training and self.codebook_dropout_rate:
             decoder_inputs = self._dropout_random_codebooks(encoded)
+            # For MMD, the forward pass includes all pre-codebook-dropout codes, while
+            # the backward pass excludes the dropped codes. This avoids putting MMD
+            # pressure on dropped codes which would not be balanced by reconstruction
+            # losses and could therefore push the dropped dimensions in a degenerate
+            # direction, e.g. constants.
+            mmd_inputs = encoded.detach() + decoder_inputs - decoder_inputs.detach()
 
         # [B, T]
         audio_gen, _ = self.audio_decoder(inputs=decoder_inputs, input_len=encoded_len)
@@ -621,7 +626,7 @@ class AudioCodecModel(ModelPT):
             slm_emb = None
             slm_emb_pred = None
 
-        return audio, audio_len, audio_gen, commit_loss, encoded, slm_emb, slm_emb_pred
+        return audio, audio_len, audio_gen, commit_loss, mmd_inputs, slm_emb, slm_emb_pred
 
     @property
     def disc_update_prob(self) -> float:
@@ -678,7 +683,7 @@ class AudioCodecModel(ModelPT):
         else:
             optim_gen, optim_disc = self.optimizers()
 
-        audio, audio_len, audio_gen, commit_loss, encoded, slm_emb, slm_emb_pred = self._process_batch(batch)
+        audio, audio_len, audio_gen, commit_loss, mmd_inputs, slm_emb, slm_emb_pred = self._process_batch(batch)
 
         metrics = {
             "global_step": self.global_step,
@@ -747,13 +752,13 @@ class AudioCodecModel(ModelPT):
             generator_losses.append(self.commit_loss_scale * commit_loss)
 
         if self.mmd_loss_scale:
-            loss_mmd = self.mmd_loss_fn(inputs=encoded)
+            loss_mmd = self.mmd_loss_fn(inputs=mmd_inputs)
             metrics["g_loss_mmd"] = loss_mmd
             if self.current_epoch >= self.mmd_loss_start_epoch:
                 generator_losses.append(self.mmd_loss_scale * loss_mmd)
 
         if self.mmd_time_loss_scale:
-            loss_mmd_time = self.mmd_time_loss_fn(inputs=encoded)
+            loss_mmd_time = self.mmd_time_loss_fn(inputs=mmd_inputs)
             metrics["g_loss_mmd_time"] = loss_mmd_time
             if self.current_epoch >= self.mmd_loss_start_epoch:
                 generator_losses.append(self.mmd_time_loss_scale * loss_mmd_time)

--- a/tests/collections/tts/losses/test_audio_codec_loss.py
+++ b/tests/collections/tts/losses/test_audio_codec_loss.py
@@ -18,10 +18,55 @@ import torch
 from torchmetrics import ScaleInvariantSignalDistortionRatio
 
 from nemo.collections.common.parts.utils import mask_sequence_tensor
-from nemo.collections.tts.losses.audio_codec_loss import MaskedMAELoss, MaskedMSELoss, SISDRLoss
+from nemo.collections.tts.losses.audio_codec_loss import (
+    MMDCodebookLoss,
+    MMDEmbeddingLoss,
+    MMDLoss,
+    MMDTimeLoss,
+    MaskedMAELoss,
+    MaskedMSELoss,
+    SISDRLoss,
+)
 
 
 class TestAudioCodecLoss:
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "loss_fn",
+        [
+            MMDEmbeddingLoss(loss_fn=MMDLoss()),
+            MMDCodebookLoss(num_codebooks=2, codebook_dim=3, loss_fn=MMDLoss()),
+            MMDTimeLoss(loss_fn=MMDLoss()),
+        ],
+        ids=["embedding", "codebook", "time"],
+    )
+    def test_mmd_flavors_respect_gradient_gated_inputs(self, loss_fn):
+        batch_size, embedding_dim, num_frames = 16, 6, 4
+        shared_values = torch.linspace(-1, 1, batch_size).reshape(batch_size, 1, 1)
+        encoded = shared_values.expand(batch_size, embedding_dim, num_frames).clone().requires_grad_()
+        keep_mask = torch.ones_like(encoded)
+        keep_mask[::2, embedding_dim // 2 :] = 0
+
+        # Forward values remain complete while the mask controls which representation gradients pass through.
+        mmd_inputs = encoded.detach() + keep_mask * (encoded - encoded.detach())
+        torch.testing.assert_close(mmd_inputs, encoded)
+
+        reference_inputs = encoded.detach().clone().requires_grad_()
+        torch.manual_seed(1234)
+        reference_loss = loss_fn(inputs=reference_inputs)
+        assert reference_loss > 0
+        reference_loss.backward()
+
+        torch.manual_seed(1234)
+        gated_loss = loss_fn(inputs=mmd_inputs)
+        gated_loss.backward()
+
+        # Every MMD flavor keeps the full-code objective while suppressing gradients for dropped entries.
+        torch.testing.assert_close(gated_loss, reference_loss)
+        torch.testing.assert_close(encoded.grad, reference_inputs.grad * keep_mask)
+        assert torch.count_nonzero(encoded.grad[keep_mask == 1]) > 0
+
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
     def test_masked_loss_l1(self):

--- a/tests/collections/tts/losses/test_audio_codec_loss.py
+++ b/tests/collections/tts/losses/test_audio_codec_loss.py
@@ -19,12 +19,12 @@ from torchmetrics import ScaleInvariantSignalDistortionRatio
 
 from nemo.collections.common.parts.utils import mask_sequence_tensor
 from nemo.collections.tts.losses.audio_codec_loss import (
+    MaskedMAELoss,
+    MaskedMSELoss,
     MMDCodebookLoss,
     MMDEmbeddingLoss,
     MMDLoss,
     MMDTimeLoss,
-    MaskedMAELoss,
-    MaskedMSELoss,
     SISDRLoss,
 )
 

--- a/tests/collections/tts/models/test_audio_codec.py
+++ b/tests/collections/tts/models/test_audio_codec.py
@@ -204,17 +204,19 @@ class TestAudioCodecModel:
             torch.testing.assert_close(actual=dropped_codes, expected=torch.zeros_like(dropped_codes))
 
     @pytest.mark.unit
-    def test_process_batch_returns_codes_before_codebook_dropout(self, codec_model, monkeypatch):
+    def test_process_batch_gates_mmd_gradients_with_codebook_dropout(self, codec_model, monkeypatch):
         batch_size = 2
         num_frames = 2
         audio = torch.zeros(batch_size, 960)
         audio_len = torch.full((batch_size,), 960, dtype=torch.long)
         encoded_len = torch.full((batch_size,), num_frames, dtype=torch.long)
         encoder_output = torch.zeros(batch_size, 40, num_frames)
-        full_codes = torch.ones_like(encoder_output)
-        dropped_codes = torch.zeros_like(full_codes)
+        full_codes = torch.ones_like(encoder_output, requires_grad=True)
+        keep_mask = torch.ones_like(full_codes)
+        keep_mask[:, full_codes.shape[1] // 2 :] = 0
+        dropped_codes = full_codes * keep_mask
 
-        # Stub each codec stage so full quantized codes can be distinguished from dropped decoder inputs.
+        # Stub each codec stage so full MMD values can be distinguished from dropped decoder inputs.
         monkeypatch.setattr(codec_model, 'encode_audio', Mock(return_value=(encoder_output, encoded_len)))
         monkeypatch.setattr(
             codec_model.vector_quantizer,
@@ -226,25 +228,29 @@ class TestAudioCodecModel:
         decoder_forward = Mock(return_value=(torch.zeros_like(audio), audio_len))
         monkeypatch.setattr(codec_model.audio_decoder, 'forward', decoder_forward)
 
-        # During training, reconstruction uses dropped codes while representation losses receive the full codes.
         codec_model.codebook_dropout_rate = 1.0
         codec_model.train()
         batch = {'audio': audio, 'audio_lens': audio_len}
 
-        _, _, _, _, returned_codes, _, _ = codec_model._process_batch(batch)
+        _, _, _, _, mmd_inputs, _, _ = codec_model._process_batch(batch)
 
-        torch.testing.assert_close(returned_codes, full_codes)
+        # MMD observes the complete representation, but its gradients follow the codebook dropout mask.
+        torch.testing.assert_close(mmd_inputs, full_codes)
         torch.testing.assert_close(decoder_forward.call_args.kwargs['inputs'], dropped_codes)
         dropout_codebooks.assert_called_once()
+        mmd_inputs.sum().backward()
+        torch.testing.assert_close(full_codes.grad, keep_mask)
 
         decoder_forward.reset_mock()
         dropout_codebooks.reset_mock()
-
-        # Evaluation bypasses codebook dropout, so both consumers receive the full quantized representation.
+        full_codes.grad = None
         codec_model.eval()
 
-        _, _, _, _, returned_codes, _, _ = codec_model._process_batch(batch)
+        _, _, _, _, mmd_inputs, _, _ = codec_model._process_batch(batch)
 
-        torch.testing.assert_close(returned_codes, full_codes)
+        # Without training-time dropout, MMD retains the ordinary identity gradient.
+        torch.testing.assert_close(mmd_inputs, full_codes)
         torch.testing.assert_close(decoder_forward.call_args.kwargs['inputs'], full_codes)
         dropout_codebooks.assert_not_called()
+        mmd_inputs.sum().backward()
+        torch.testing.assert_close(full_codes.grad, torch.ones_like(full_codes))

--- a/tests/collections/tts/models/test_audio_codec.py
+++ b/tests/collections/tts/models/test_audio_codec.py
@@ -202,3 +202,45 @@ class TestAudioCodecModel:
             dropout_start_i = i * codec_model.vector_quantizer.codebook_dim
             dropped_codes = encoded[:, dropout_start_i:, :]
             torch.testing.assert_close(actual=dropped_codes, expected=torch.zeros_like(dropped_codes))
+
+    @pytest.mark.unit
+    def test_process_batch_returns_codes_before_codebook_dropout(self, codec_model, monkeypatch):
+        batch_size = 2
+        num_frames = 2
+        audio = torch.zeros(batch_size, 960)
+        audio_len = torch.full((batch_size,), 960, dtype=torch.long)
+        encoded_len = torch.full((batch_size,), num_frames, dtype=torch.long)
+        encoder_output = torch.zeros(batch_size, 40, num_frames)
+        full_codes = torch.ones_like(encoder_output)
+        dropped_codes = torch.zeros_like(full_codes)
+
+        monkeypatch.setattr(codec_model, 'encode_audio', Mock(return_value=(encoder_output, encoded_len)))
+        monkeypatch.setattr(
+            codec_model.vector_quantizer,
+            'forward',
+            Mock(return_value=(full_codes, torch.zeros(codec_model.num_codebooks, batch_size, num_frames))),
+        )
+        dropout_codebooks = Mock(return_value=dropped_codes)
+        monkeypatch.setattr(codec_model, '_dropout_random_codebooks', dropout_codebooks)
+        decoder_forward = Mock(return_value=(torch.zeros_like(audio), audio_len))
+        monkeypatch.setattr(codec_model.audio_decoder, 'forward', decoder_forward)
+
+        codec_model.codebook_dropout_rate = 1.0
+        codec_model.train()
+        batch = {'audio': audio, 'audio_lens': audio_len}
+
+        _, _, _, _, returned_codes, _, _ = codec_model._process_batch(batch)
+
+        torch.testing.assert_close(returned_codes, full_codes)
+        torch.testing.assert_close(decoder_forward.call_args.kwargs['inputs'], dropped_codes)
+        dropout_codebooks.assert_called_once()
+
+        decoder_forward.reset_mock()
+        dropout_codebooks.reset_mock()
+        codec_model.eval()
+
+        _, _, _, _, returned_codes, _, _ = codec_model._process_batch(batch)
+
+        torch.testing.assert_close(returned_codes, full_codes)
+        torch.testing.assert_close(decoder_forward.call_args.kwargs['inputs'], full_codes)
+        dropout_codebooks.assert_not_called()

--- a/tests/collections/tts/models/test_audio_codec.py
+++ b/tests/collections/tts/models/test_audio_codec.py
@@ -214,6 +214,7 @@ class TestAudioCodecModel:
         full_codes = torch.ones_like(encoder_output)
         dropped_codes = torch.zeros_like(full_codes)
 
+        # Stub each codec stage so full quantized codes can be distinguished from dropped decoder inputs.
         monkeypatch.setattr(codec_model, 'encode_audio', Mock(return_value=(encoder_output, encoded_len)))
         monkeypatch.setattr(
             codec_model.vector_quantizer,
@@ -225,6 +226,7 @@ class TestAudioCodecModel:
         decoder_forward = Mock(return_value=(torch.zeros_like(audio), audio_len))
         monkeypatch.setattr(codec_model.audio_decoder, 'forward', decoder_forward)
 
+        # During training, reconstruction uses dropped codes while representation losses receive the full codes.
         codec_model.codebook_dropout_rate = 1.0
         codec_model.train()
         batch = {'audio': audio, 'audio_lens': audio_len}
@@ -237,6 +239,8 @@ class TestAudioCodecModel:
 
         decoder_forward.reset_mock()
         dropout_codebooks.reset_mock()
+
+        # Evaluation bypasses codebook dropout, so both consumers receive the full quantized representation.
         codec_model.eval()
 
         _, _, _, _, returned_codes, _, _ = codec_model._process_batch(batch)


### PR DESCRIPTION
During codec training, MMD loss was being applied on quantized encoder embeddings *after* random codebook dropout. That carried the risk of pushing the non-dropped out entries towards a distribution similar to the dropped out entries (zeros), which we do not want.

This change:
1. Calculates MMD on pre-dropout codes.
2. Blocks MMD gradients on dropped-out codes.
The latter change was added to avoid a situation where dropped-out codes continue to get MMD loss pressure while not having reconstruction losses to balance it out. This carried the risk of pushing them towards a degenerate direction, e.g. to be constants.


