### PR TITLE
Fix negative offsets in GPUBiasingMultiModel.remove_model

### DIFF
--- a/nemo/collections/asr/parts/context_biasing/biasing_multi_model.py
+++ b/nemo/collections/asr/parts/context_biasing/biasing_multi_model.py
@@ -562,22 +562,19 @@ class GPUBiasingMultiModel(GPUBiasingMultiModelBase):
         self.model2num_states[model_id] = 0
         self.model2num_arcs[model_id] = 0
         self.model2num_arcs_extended[model_id] = 0
-        # shift model offsets
+        # Shift the offsets of the models that lived after the removed one.
+        # Only ACTIVE models take part in the shift. An unused slot holds offset 0, and 0 is also a
+        # legitimate arena address, so a shift applied to every slot underflows every unused slot to a
+        # negative offset whenever the removed model started at 0. `model2active[model_id]` is already
+        # False here, so the removed model is excluded from the mask and its own offsets are cleared last.
+        states_shift_mask = self.model2active & (self.model2states_offset >= start_state)
+        arcs_shift_mask = self.model2active & (self.model2arcs_offset >= start_arc)
+        self.model2states_offset[states_shift_mask] -= num_states
+        self.model2arcs_offset[arcs_shift_mask] -= num_arcs
+
+        # clear the removed model's own offsets last
         self.model2states_offset[model_id] = 0
         self.model2arcs_offset[model_id] = 0
-        # shift states and arcs offsets
-        torch.where(
-            self.model2states_offset < start_state,
-            self.model2states_offset,
-            self.model2states_offset - num_states,
-            out=self.model2states_offset,
-        )
-        torch.where(
-            self.model2arcs_offset < start_arc,
-            self.model2arcs_offset,
-            self.model2arcs_offset - num_arcs,
-            out=self.model2arcs_offset,
-        )
 
     def get_init_states(self, batch_size: int, bos=True) -> torch.Tensor:
         """

--- a/tests/collections/asr/decoding/test_biasing_multi_model.py
+++ b/tests/collections/asr/decoding/test_biasing_multi_model.py
@@ -143,6 +143,67 @@ class TestGPUBiasingMultiModel:
         assert multi_model.model2states_offset[model_id2].item() == 0
         assert multi_model.model2arcs_offset[model_id2].item() == 0
 
+        # Every offset must stay a valid, non-negative arena index, including the reserved slots that
+        # have never held a model. Before the ordering fix in remove_model, removing the model that
+        # started at offset 0 underflowed every zero-valued slot to -num_states / -num_arcs.
+        assert torch.all(multi_model.model2states_offset >= 0)
+        assert torch.all(multi_model.model2arcs_offset >= 0)
+
+        # Inactive slots carry a canonical, empty descriptor.
+        inactive = ~multi_model.model2active
+        assert torch.all(multi_model.model2states_offset[inactive] == 0)
+        assert torch.all(multi_model.model2arcs_offset[inactive] == 0)
+        assert torch.all(multi_model.model2num_states[inactive] == 0)
+        assert torch.all(multi_model.model2num_arcs_extended[inactive] == 0)
+
+    @pytest.mark.unit
+    @pytest.mark.with_downloads
+    @pytest.mark.parametrize("device", DEVICES)
+    @pytest.mark.parametrize("remove_index", [0, 1, 2])
+    def test_offsets_stay_non_negative_for_any_removal_position(
+        self, stt_en_conformer_transducer_small, device: torch.device, remove_index: int
+    ):
+        """Removing a model from any position leaves every offset a valid arena index.
+
+        Removing the model at the front of the arena is the interesting case: its start offset is 0,
+        which every unused reserved slot also holds, so a shift that does not exclude inactive slots
+        drives all of them negative.
+        """
+        tokenizer = stt_en_conformer_transducer_small.tokenizer
+        vocab_size = tokenizer.vocab_size
+
+        multi_model = GPUBiasingMultiModel(vocab_size=vocab_size).to(device)
+        phrase_lists = [["alpha", "beta"], ["gamma"], ["delta", "epsilon", "zeta"]]
+        model_ids = [
+            multi_model.add_model(create_boosting_model(phrases, tokenizer, device), alpha=1.0)
+            for phrases in phrase_lists
+        ]
+
+        # A surviving model's scores must be unchanged by an unrelated removal.
+        survivor = model_ids[(remove_index + 1) % len(model_ids)]
+        states = multi_model.get_init_states(batch_size=2, bos=True)
+        survivor_ids = torch.full((2,), survivor, dtype=torch.long, device=device)
+        scores_before, _ = multi_model.advance(states=states, model_ids=survivor_ids)
+        scores_before = scores_before.clone()
+
+        multi_model.remove_model(model_ids[remove_index])
+
+        assert torch.all(multi_model.model2states_offset >= 0)
+        assert torch.all(multi_model.model2arcs_offset >= 0)
+
+        inactive = ~multi_model.model2active
+        assert torch.all(multi_model.model2states_offset[inactive] == 0)
+        assert torch.all(multi_model.model2arcs_offset[inactive] == 0)
+
+        active = multi_model.model2active
+        assert torch.all(
+            multi_model.model2states_offset[active] + multi_model.model2num_states[active]
+            <= multi_model.num_states_total
+        )
+
+        scores_after, _ = multi_model.advance(states=states, model_ids=survivor_ids)
+        assert torch.equal(scores_before, scores_after)
+
     @pytest.mark.unit
     @pytest.mark.with_downloads
     @pytest.mark.parametrize("device", DEVICES)


### PR DESCRIPTION
### What

`GPUBiasingMultiModel.remove_model` leaves almost every unused reserved slot holding a **negative** offset whenever the removed model started at arena offset 0.

`remove_model` clears the departing model's own offsets to `0`, then applies the shift across the whole table with the predicate `offset < start_state`. Unused slots also hold `0`. When the removed model started at `0`, that predicate is false for them, so each one is decremented to `-num_states` / `-num_arcs`.

With the default reserve of 128 slots, registering three boosting models and removing the first gives:

```text
offsets before removal : [0, 6, 11, 0, 0, ...]
offsets after  removal : [-6, 0, 5, -6, -6, ...]
reserved slots holding a negative offset: 126 of 128
```

The underlying cause is that `0` carries two meanings in this table: a valid arena start address, and a slot that has never held a model. The shift cannot tell them apart, so it transforms slots that should not take part in it.

### Impact, stated honestly

**This is latent, not an active miscompute.** I tried to make it produce a wrong answer and could not:

- the Triton kernel returns early for `model_id < 0`, so the `-1` sentinel never dereferences its slot;
- rows carrying the sentinel come back all-zero on both the Triton and the non-Triton path, and the two agree bit for bit;
- a surviving model's scores are bit-identical before and after a removal;
- registering a new model after a removal reuses the freed id and scores correctly.

What is broken is the invariant that an offset is a non-negative index into the arena. Neither the Triton kernel nor `_advance_pytorch` re-checks `model2active` before turning an offset into a base pointer, so a stale or out-of-range positive id would find a negative base rather than failing closed. It is a hazard for the next consumer that does not gate, and it costs one masked subtraction to remove.

### The change

Restrict the shift to **active** models, and clear the removed model's own offsets **last**. `model2active[model_id]` is already `False` at that point, so the removed model is excluded from the mask.

Using an explicit active mask rather than only reordering the two statements makes the intent readable: inactive slots are not participants in the relocation transform.

### Test

Extends `test_add_then_remove_model` to assert that every offset stays non-negative and that inactive slots carry a canonical empty descriptor.

Adds `test_offsets_stay_non_negative_for_any_removal_position`, parametrized over removal from the front, middle and back of the arena, asserting:

- every offset is non-negative;
- inactive slots hold a canonical empty descriptor;
- active extents stay inside the arena;
- a surviving model's `advance()` scores are unchanged by an unrelated removal.

The existing test checked only the survivor's shifted offset, which is why this was not caught.

### Verification

Reproduced and verified on an NVIDIA RTX A6000 with Triton, using a standalone script that builds boosting trees from raw token id lists so it needs no checkpoint, tokenizer or audio. After the change: negative offsets go from 126 to 0, surviving models remain bit-identical, slot reuse after removal still works, and the Triton and non-Triton paths continue to agree.

### Two related things, deliberately not in this PR

Raising them here only so they are on the record; each deserves its own thread.

1. `add_model` fires `reallocation_callbacks` when the arena grows, and `remove_model` fires nothing, although both move data that a captured CUDA graph addresses. I could not demonstrate a wrong result from this, and the kernel loads the offsets through a pointer at run time, which suggests a replay sees the committed values. I would rather ask whether that is the intended contract than assert a bug.
2. There is no way to pre-size the arena. `INIT_NUM_MODELS`, `INIT_NUM_ARCS` and `INIT_NUM_STATES` are fixed and growth doubles, with no configurable maximum and no `reserve()`. A server that registers a phrase list per session cannot guarantee that no reallocation, and therefore no CUDA-graph reset, happens mid-stream for the other sessions in the batch. A capacity knob would let deployments trade memory for predictability.