### PR TITLE
optional tail silence to flush the decoder

### DIFF
--- a/examples/asr/conf/asr_streaming_inference/buffered_rnnt.yaml
+++ b/examples/asr/conf/asr_streaming_inference/buffered_rnnt.yaml
@@ -108,6 +108,7 @@ streaming:
   chunk_size: 4.8                             # Audio chunk size in seconds
   word_boundary_tolerance: 4                  # Tolerance for word boundaries
   request_type: feature_buffer                # Type of request: frame or feature_buffer
+  flush_size_in_secs: 0.0                     # Silence appended per stream so the decoder can flush its tail; 0.0 appends none
   stateful: true                              # Whether to use stateful processing
   padding_mode: right                         # Padding mode: left or right. How to pad frames to match the required buffer length
 

--- a/examples/asr/conf/asr_streaming_inference/cache_aware_rnnt.yaml
+++ b/examples/asr/conf/asr_streaming_inference/cache_aware_rnnt.yaml
@@ -129,6 +129,7 @@ streaming:
   use_feat_cache: true                        # Whether to cache mel-spec features, set false to re-calculate all mel-spec features in audio buffer
   chunk_size_in_secs: null                    # Amount of audio to load for each streaming step, e.g., 0.08s for FastConformer. Set to `null` for using default size equal to 1+lookahead frames.
   request_type: frame                         # Type of request: frame or feature_buffer
+  flush_size_in_secs: 0.0                     # Silence appended per stream so the decoder can flush its tail; 0.0 appends none
   num_slots: 256                             # Number of slots in the context manager: must be >= batch_size
 
 

--- a/nemo/collections/asr/inference/pipelines/buffered_rnnt_pipeline.py
+++ b/nemo/collections/asr/inference/pipelines/buffered_rnnt_pipeline.py
@@ -125,6 +125,7 @@ class BufferedRNNTPipeline(BasePipeline):
             self.buffer_size_in_secs = self.chunk_size + self.left_padding_size + self.right_padding_size
 
         self.request_type = RequestType.from_str(cfg.streaming.request_type)
+        self.flush_size_in_secs = cfg.streaming.get("flush_size_in_secs", 0.0)  # 0.0 disables
         self.padding_mode = FeatureBufferPaddingMode.from_str(cfg.streaming.padding_mode)
         self.right_padding = self.padding_mode is FeatureBufferPaddingMode.RIGHT
         self.stop_history_eou_in_milliseconds = cfg.endpointing.stop_history_eou
@@ -814,6 +815,7 @@ class BufferedRNNTPipeline(BasePipeline):
             buffer_size_in_secs=self.buffer_size_in_secs,
             device=self.device,
             pad_last_frame=True,
+            flush_size_in_secs=self.flush_size_in_secs,
             right_pad_features=self.right_padding,
         )
         return request_generator

--- a/nemo/collections/asr/inference/pipelines/cache_aware_rnnt_pipeline.py
+++ b/nemo/collections/asr/inference/pipelines/cache_aware_rnnt_pipeline.py
@@ -188,6 +188,7 @@ class CacheAwareRNNTPipeline(BasePipeline):
         self.return_tail_result = cfg.return_tail_result
 
         self.request_type = RequestType.from_str(cfg.streaming.request_type)
+        self.flush_size_in_secs = cfg.streaming.get("flush_size_in_secs", 0.0)  # 0.0 disables
 
     def init_greedy_rnnt_decoder(self) -> None:
         """Initialize the RNNT decoder."""
@@ -617,6 +618,7 @@ class CacheAwareRNNTPipeline(BasePipeline):
             buffer_size_in_secs=self.buffer_size_in_secs,
             device=self.device,
             pad_last_frame=True,
+            flush_size_in_secs=self.flush_size_in_secs,
         )
         return request_generator
 

--- a/nemo/collections/asr/inference/streaming/framing/mono_stream.py
+++ b/nemo/collections/asr/inference/streaming/framing/mono_stream.py
@@ -38,7 +38,7 @@ class MonoStream(Stream):
         Initialize the MonoStream
         Args:
             rate (int): sampling rate
-            frame_size_in_secs (int): frame length in seconds
+            frame_size_in_secs (float): frame length in seconds
             stream_id (int): stream id
             pad_last_frame (bool): whether to pad the last frame up to frame_size
             flush_size_in_secs (float): seconds of silence appended to the audio, 0.0 to append none

--- a/nemo/collections/asr/inference/streaming/framing/mono_stream.py
+++ b/nemo/collections/asr/inference/streaming/framing/mono_stream.py
@@ -26,18 +26,28 @@ class MonoStream(Stream):
     Iterates over the frames of the audio file
     """
 
-    def __init__(self, rate: int, frame_size_in_secs: float, stream_id: int, pad_last_frame: bool = False):
+    def __init__(
+        self,
+        rate: int,
+        frame_size_in_secs: float,
+        stream_id: int,
+        pad_last_frame: bool = False,
+        flush_size_in_secs: float = 0.0,
+    ):
         """
         Initialize the MonoStream
         Args:
             rate (int): sampling rate
             frame_size_in_secs (int): frame length in seconds
             stream_id (int): stream id
+            pad_last_frame (bool): whether to pad the last frame up to frame_size
+            flush_size_in_secs (float): seconds of silence appended to the audio, 0.0 to append none
         """
 
         self.rate = rate
         self.frame_size = int(frame_size_in_secs * rate)
         self.pad_last_frame = pad_last_frame
+        self.flush_size = int(flush_size_in_secs * rate)
 
         self.samples = None
         self.n_samples = None
@@ -56,6 +66,8 @@ class MonoStream(Stream):
             self.samples = read_audio(audio, target_sr=self.rate, mono=True)
         else:
             self.samples = audio
+        if self.flush_size > 0:  # appended as signal, not padding, so it is not trimmed downstream
+            self.samples = torch.cat([self.samples, torch.zeros(self.flush_size, dtype=self.samples.dtype)])
         self.n_samples = len(self.samples)
         self.frame_count = 0  # Reset frame count
         self.options = options

--- a/nemo/collections/asr/inference/streaming/framing/multi_stream.py
+++ b/nemo/collections/asr/inference/streaming/framing/multi_stream.py
@@ -103,6 +103,7 @@ class ContinuousBatchedFrameStreamer:
         batch_size: int,
         n_frames_per_stream: int,
         pad_last_frame: bool = False,
+        flush_size_in_secs: float = 0.0,
     ):
         """
         Args:
@@ -111,12 +112,14 @@ class ContinuousBatchedFrameStreamer:
             batch_size (int): The batch size
             n_frames_per_stream (int): The number of frames per stream
             pad_last_frame (bool): Whether to pad the last frame
+            flush_size_in_secs (float): Seconds of silence appended to every stream, 0.0 for none
         """
 
         self.sample_rate = sample_rate
         self.frame_size_in_secs = frame_size_in_secs
         self.batch_size = batch_size
         self.pad_last_frame = pad_last_frame
+        self.flush_size_in_secs = flush_size_in_secs
 
         self.multi_streamer = MultiStream(n_frames_per_stream=n_frames_per_stream)
         self.stream_id = 0
@@ -176,7 +179,11 @@ class ContinuousBatchedFrameStreamer:
 
         # Create a new stream
         stream = MonoStream(
-            self.sample_rate, self.frame_size_in_secs, stream_id=self.stream_id, pad_last_frame=self.pad_last_frame
+            self.sample_rate,
+            self.frame_size_in_secs,
+            stream_id=self.stream_id,
+            pad_last_frame=self.pad_last_frame,
+            flush_size_in_secs=self.flush_size_in_secs,
         )
         # Load the next audio file
         audio_filepath = self.audio_filepaths[self.stream_id]
@@ -244,6 +251,7 @@ class ContinuousBatchedRequestStreamer:
         device: torch.device = None,
         pad_last_frame: bool = False,
         right_pad_features: bool = False,
+        flush_size_in_secs: float = 0.0,
     ):
         """
         Args:
@@ -274,6 +282,7 @@ class ContinuousBatchedRequestStreamer:
             batch_size=batch_size,
             n_frames_per_stream=n_frames_per_stream,
             pad_last_frame=pad_last_frame,
+            flush_size_in_secs=flush_size_in_secs,
         )
 
         if self.request_type is RequestType.FEATURE_BUFFER:


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Adds `streaming.flush_size_in_secs`, an opt-in amount of silence appended to the end of every stream
so a streaming decoder can emit the tokens it is still holding when the audio stops. The default is
`0.0`, which appends nothing and leaves current behaviour unchanged.

**Collection**: [ASR]

# Changelog

- `streaming/framing/mono_stream.py`: `MonoStream` takes `flush_size_in_secs` and appends that many
  seconds of zeros to the samples in `load_audio`, before framing. They are appended as **signal, not
  padding**: `n_samples` covers them, so the frames carrying them report their full length as valid
  and nothing downstream trims them away.
- `streaming/framing/multi_stream.py`: threads the value through `ContinuousBatchedFrameStreamer` and
  `ContinuousBatchedRequestStreamer` to the `MonoStream` it builds, so one path serves both pipelines.
- `pipelines/cache_aware_rnnt_pipeline.py`, `pipelines/buffered_rnnt_pipeline.py`: read
  `cfg.streaming.get("flush_size_in_secs", 0.0)` and pass it to the request generator. `.get` keeps
  existing YAMLs working unchanged.
- `conf/asr_streaming_inference/cache_aware_rnnt.yaml`, `buffered_rnnt.yaml`: the new key, default `0.0`.

# Usage

```bash
python examples/asr/asr_streaming_inference/asr_streaming_infer.py \
    --config-path=../conf/asr_streaming_inference/ \
    --config-name=cache_aware_rnnt.yaml \
    audio_file=<manifest.json> \
    output_filename=<preds.jsonl> \
    streaming.flush_size_in_secs=0.48
```

### What the parameter buys when it is turned on

`nemotron-speech-streaming-en-0.6b`, cache-aware RNNT, WER against `flush=0.0`:

## Results, WER

Best value per row and benchmark in bold.

### att_context_size [70,13] — 1.12 s lookahead

| flush s | LibriSpeech test-other | earnings22 | AMI |
|---|---|---|---|
| 0.00 | 0.0756 | 0.1924 | 0.1438 |
| 0.08 | 0.0756 | 0.1924 | 0.1439 |
| 0.16 | 0.0758 | 0.1917 | 0.1451 |
| 0.32 | 0.0757 | 0.1906 | 0.1420 |
| 0.48 | **0.0753** | 0.1878 | **0.1381** |
| 0.64 | 0.0756 | 0.1880 | 0.1402 |
| 0.80 | 0.0756 | **0.1862** | 0.1416 |
| 1.04 | 0.0756 | 0.1866 | 0.1382 |

### att_context_size [70,6] — 0.56 s lookahead

| flush s | LibriSpeech test-other | earnings22 | AMI |
|---|---|---|---|
| 0.00 | 0.0779 | 0.1932 | 0.1456 |
| 0.08 | **0.0776** | 0.1938 | 0.1442 |
| 0.16 | 0.0779 | 0.1934 | 0.1443 |
| 0.32 | 0.0778 | 0.1918 | 0.1398 |
| 0.48 | 0.0779 | 0.1898 | **0.1386** |
| 0.64 | **0.0776** | 0.1904 | 0.1397 |
| 0.80 | 0.0780 | 0.1898 | 0.1418 |
| 1.04 | 0.0779 | **0.1887** | 0.1387 |

### att_context_size [70,1] — 0.16 s lookahead

| flush s | LibriSpeech test-other | earnings22 | AMI |
|---|---|---|---|
| 0.00 | 0.0820 | 0.1980 | 0.1659 |
| 0.08 | 0.0818 | 0.1969 | 0.1598 |
| 0.16 | 0.0814 | 0.1958 | 0.1577 |
| 0.32 | 0.0813 | 0.1946 | 0.1540 |
| 0.48 | 0.0812 | 0.1936 | 0.1525 |
| 0.64 | **0.0811** | 0.1921 | 0.1510 |
| 0.80 | 0.0813 | 0.1916 | 0.1497 |
| 1.04 | 0.0813 | **0.1909** | **0.1496** |

### att_context_size [70,0] — 0.08 s lookahead

| flush s | LibriSpeech test-other | earnings22 | AMI |
|---|---|---|---|
| 0.00 | 0.0904 | 0.2042 | 0.1972 |
| 0.08 | 0.0898 | 0.1993 | 0.1908 |
| 0.16 | 0.0889 | 0.1969 | 0.1851 |
| 0.32 | 0.0881 | 0.1943 | 0.1770 |
| 0.48 | 0.0880 | 0.1932 | 0.1745 |
| 0.64 | **0.0878** | **0.1931** | 0.1724 |
| 0.80 | 0.0879 | **0.1931** | 0.1714 |
| 1.04 | 0.0879 | **0.1931** | **0.1702** |

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

Trusted PRs run automatically through copy-pr-bot. For an untrusted PR, a maintainer can trigger CI by commenting
`/ok to test <head-sha>`; repeat this after a new push if the PR remains untrusted.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
