### PR TITLE
2608 tts training pneekhara

### DIFF
--- a/examples/tts/magpietts_inference.py
+++ b/examples/tts/magpietts_inference.py
@@ -115,6 +115,7 @@ def run_inference_and_evaluation(
     violin_plot_metrics: Optional[List[str]] = None,
     clean_up_disk: bool = False,
     skip_evaluation: bool = False,
+    ignore_manifest_language: bool = False,
 ) -> Tuple[Optional[float], Optional[float]]:
     """Run inference and optional evaluation on specified datasets.
 
@@ -136,6 +137,7 @@ def run_inference_and_evaluation(
         violin_plot_metrics: Metrics to include in violin plots.
         clean_up_disk: Whether to clean up output directory after completion.
         skip_evaluation: Whether to skip evaluation (inference only mode).
+        ignore_manifest_language: Whether dataset-level language should override manifest records.
 
     Returns:
         Tuple of (mean CER across datasets, mean SSIM across datasets).
@@ -204,7 +206,7 @@ def run_inference_and_evaluation(
             "audio_dir": meta["audio_dir"],
             "language": language,
             "tokenizer_names": tokenizer_names,
-            "ignore_manifest_language": args.ignore_manifest_language,
+            "ignore_manifest_language": ignore_manifest_language,
         }
 
         # Setup output directories
@@ -522,6 +524,7 @@ def main(argv=None):
                 violin_plot_metrics=args.violin_plot_metrics,
                 clean_up_disk=args.clean_up_disk,
                 skip_evaluation=not args.run_evaluation,
+                ignore_manifest_language=args.ignore_manifest_language,
             )
 
     else:  # nemo mode
@@ -560,6 +563,7 @@ def main(argv=None):
                 violin_plot_metrics=args.violin_plot_metrics,
                 clean_up_disk=args.clean_up_disk,
                 skip_evaluation=not args.run_evaluation,
+                ignore_manifest_language=args.ignore_manifest_language,
             )
 
     # Check quality targets

--- a/examples/tts/magpietts_inference.py
+++ b/examples/tts/magpietts_inference.py
@@ -204,6 +204,7 @@ def run_inference_and_evaluation(
             "audio_dir": meta["audio_dir"],
             "language": language,
             "tokenizer_names": tokenizer_names,
+            "ignore_manifest_language": args.ignore_manifest_language,
         }
 
         # Setup output directories

--- a/nemo/collections/tts/data/text_to_speech_dataset.py
+++ b/nemo/collections/tts/data/text_to_speech_dataset.py
@@ -50,6 +50,7 @@ class DatasetMeta:
     sample_weight: float = 1.0
     language: Optional[str] = None
     tokenizer_names: List[str] = None
+    ignore_manifest_language: bool = False
 
 
 @dataclass
@@ -195,7 +196,7 @@ class TextToSpeechDataset(Dataset):
                 speaker = None
                 speaker_index = 0
 
-            if "language" in entry:
+            if "language" in entry and not dataset.ignore_manifest_language:
                 language = entry.get("language")
             elif dataset.language:
                 language = dataset.language

--- a/nemo/collections/tts/data/text_to_speech_dataset.py
+++ b/nemo/collections/tts/data/text_to_speech_dataset.py
@@ -448,8 +448,6 @@ class MagpieTTSDataset(TextToSpeechDataset):
         data = self.data_samples[index]
 
         def _sample_context_duration_with_available_limit(available_duration_sec: float) -> float:
-            if self.dataset_type == 'test':
-                return min(available_duration_sec, self.context_duration_max)
             effective_duration_max = min(self.context_duration_max, available_duration_sec)
             effective_duration_max = max(self.context_duration_min, effective_duration_max)
             return random.uniform(self.context_duration_min, effective_duration_max)

--- a/nemo/collections/tts/data/text_to_speech_dataset.py
+++ b/nemo/collections/tts/data/text_to_speech_dataset.py
@@ -448,6 +448,8 @@ class MagpieTTSDataset(TextToSpeechDataset):
         data = self.data_samples[index]
 
         def _sample_context_duration_with_available_limit(available_duration_sec: float) -> float:
+            if self.dataset_type == 'test':
+                return min(available_duration_sec, self.context_duration_max)
             effective_duration_max = min(self.context_duration_max, available_duration_sec)
             effective_duration_max = max(self.context_duration_min, effective_duration_max)
             return random.uniform(self.context_duration_min, effective_duration_max)

--- a/nemo/collections/tts/modules/magpietts_inference/utils.py
+++ b/nemo/collections/tts/modules/magpietts_inference/utils.py
@@ -1216,6 +1216,11 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
         help='Comma-separated list of dataset names to process',
     )
     data_group.add_argument(
+        '--ignore_manifest_language',
+        action='store_true',
+        help='Ignore per-record manifest language and use the dataset or CLI language instead.',
+    )
+    data_group.add_argument(
         '--tokenizer_name',
         type=str,
         default="english_phoneme",


### PR DESCRIPTION
Our inhouse evaluation manifests contains two versions of language tags:
  - eval_manifest.json
  - lang.json

Setting this parameter uses lang.json which is correct for the latest model, but incorrect for older models which should not use this tag and defer to eval_manifest.json